### PR TITLE
feat(workflows/imagery): run standardise step on multiple files in parallel (TDE-303)

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -45,8 +45,8 @@ spec:
           - name: filter
       container:
         image: ghcr.io/linz/basemaps/cli:v6.29.0-3-gb4dec98c
-        command: [node, index.js]
-        args: ["-V", "list", "--filter", "{{inputs.parameters.filter}}","--group", "10", "--output", "/tmp/file_list.json", "{{inputs.parameters.uri}}"]
+        command: [node, index.cjs]
+        args: ["-V", "list", "--filter", "{{inputs.parameters.filter}}","--group", "10", "--output", "/tmp/file_list.json", "--config", "linz-bucket-config", "{{inputs.parameters.uri}}"]
       outputs:
         parameters:
           - name: files

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -11,11 +11,11 @@ spec:
   arguments:
     parameters:
       - name: uri
-        value: "s3://linz-imagery-staging/test/sample/"
+        value: ""
       - name: filter
-        value: "BX24_5000_0405.tif"
+        value: ".tif?$"
       - name: output
-        value: "s3://linz-imagery-staging/test/sample-output/"
+        value: ""
   templates:
     - name: main
       dag:
@@ -46,7 +46,7 @@ spec:
       container:
         image: ghcr.io/linz/basemaps/cli:v6.29.0-3-gb4dec98c
         command: [node, index.cjs]
-        args: ["-V", "list", "--filter", "{{inputs.parameters.filter}}","--group", "10", "--output", "/tmp/file_list.json", "--config", "linz-bucket-config", "{{inputs.parameters.uri}}"]
+        args: ["-V", "list", "--filter", "{{inputs.parameters.filter}}", "--output", "/tmp/file_list.json", "--config", "linz-bucket-config", "{{inputs.parameters.uri}}"]
       outputs:
         parameters:
           - name: files
@@ -58,7 +58,7 @@ spec:
           - name: file
           - name: output
       container:
-        image: ghcr.io/linz/topo-imagery:v0.2.0-4-gfd60e53
+        image: ghcr.io/linz/topo-imagery:v0.2.0-6-gc3932e4
         command:
           - python
           - "/app/standardising.py"

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -11,21 +11,52 @@ spec:
   arguments:
     parameters:
       - name: uri
-        value: s3://linz-imagery-staging/test/sample/BX24_5000_0405.tif
+        value: "s3://linz-imagery-staging/test/sample/"
+      - name: filter
+        value: "BX24_5000_0405.tif"
+      - name: output
+        value: "s3://linz-imagery-staging/test/sample-output/"
   templates:
     - name: main
       dag:
         tasks:
+          - name: aws-list
+            template: aws-list
+            arguments:
+              parameters:
+                - name: uri
+                  value: "{{workflow.parameters.uri}}"
+                - name: filter
+                  value: "{{workflow.parameters.filter}}"
           - name: standardise
             template: standardise
             arguments:
               parameters:
                 - name: file
-                  value: "{{workflow.parameters.uri}}"
+                  value: "{{item}}"
+                - name: output
+                  value: "{{workflow.parameters.output}}"
+            depends: "aws-list"
+            withParam: "{{tasks.aws-list.outputs.parameters.files}}"
+    - name: aws-list
+      inputs:
+        parameters:
+          - name: uri
+          - name: filter
+      container:
+        image: ghcr.io/linz/basemaps/cli:v6.29.0-3-gb4dec98c
+        command: [node, index.js]
+        args: ["-V", "list", "--filter", "{{inputs.parameters.filter}}","--group", "10", "--output", "/tmp/file_list.json", "{{inputs.parameters.uri}}"]
+      outputs:
+        parameters:
+          - name: files
+            valueFrom:
+              path: /tmp/file_list.json
     - name: standardise
       inputs:
         parameters:
           - name: file
+          - name: output
       container:
         image: ghcr.io/linz/topo-imagery:v0.2.0-4-gfd60e53
         command:
@@ -35,4 +66,4 @@ spec:
           - "--source"
           - "{{inputs.parameters.file}}"
           - "--destination"
-          - "s3://linz-imagery-staging/test/sample-output/"
+          - "{{inputs.parameters.output}}"


### PR DESCRIPTION
## Description
This change in the `standardising` workflow enable running the standardise step on a specified S3 path containing image files so each image can be processed in parallel.

## Changes
- A new task `aws-list` calling the `basemaps CLI` `list` command is executed prior to deploy one job per file returned - in parallel
- A new parameter `filter` has been added which allows to filter the files in the `uri` path using `RegExp`
- A new parameter `output` has been added which is used to determine where the processed files will be uploaded.

> **_NOTE:_**  The current `standardising.py` script called by the task `standardise` allows only one file per execution. A functionality allowing to pass a list of files will be implemented in the future.
