### PR TITLE
feat: use artifacts bucket instead of output

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -16,8 +16,6 @@ spec:
         value: "s3://linz-imagery-staging/RGB/nelson/2022/06/nelson-urban/"
       - name: filter
         value: ".tiff?$"
-      - name: output
-        value: "s3://linz-imagery-staging/test/output/2022/06/nelson-urban/"
   templates:
     - name: main
       dag:
@@ -36,8 +34,6 @@ spec:
               parameters:
                 - name: file
                   value: "{{item}}"
-                - name: output
-                  value: "{{workflow.parameters.output}}"
             depends: "aws-list"
             withParam: "{{tasks.aws-list.outputs.parameters.files}}"
     - name: aws-list
@@ -88,5 +84,9 @@ spec:
         args:
           - "--source"
           - "{{inputs.parameters.file}}"
-          - "--destination"
-          - "{{inputs.parameters.output}}"
+      outputs:
+        artifacts:
+          - name: standardised_tiffs
+            path: /tmp/
+            archive:
+              none: {}

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -71,7 +71,6 @@ spec:
       inputs:
         parameters:
           - name: file
-          - name: output
       container:
         image: ghcr.io/linz/topo-imagery:v0.2.0-6-gc3932e4
         resources:


### PR DESCRIPTION
remove output as parameter and upload tmp output to artifacts bucket.

relates to: https://github.com/linz/topo-imagery/pull/61