### PR TITLE
feat(imagery): Non Visual QA workflow-template TDE-309

### DIFF
--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: imagery-non-visual-qa-v0.2.0-20
+  annotations:
+    fluentbit.io/parser: json
 spec:
   serviceAccountName: workflow-runner-sa
   podGC:

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -54,6 +54,8 @@ spec:
             "list",
             "--filter",
             "{{inputs.parameters.filter}}",
+            "--group",
+            "10",
             "--output",
             "/tmp/file_list.json",
             "--config",

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  generateName: imagery-non-visual-qa-
+  name: imagery-non-visual-qa-v0.2.0-20
 spec:
   serviceAccountName: workflow-runner-sa
   podGC:
@@ -55,7 +55,7 @@ spec:
             "--filter",
             "{{inputs.parameters.filter}}",
             "--group",
-            "10",
+            "100",
             "--output",
             "/tmp/file_list.json",
             "--config",

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -3,10 +3,11 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: imagery-non-visual-qa-v0.2.0-20
-  annotations:
-    fluentbit.io/parser: json
 spec:
   serviceAccountName: workflow-runner-sa
+  workflowMetadata:
+    annotations:
+      fluentbit.io/parser: json
   podGC:
     strategy: OnPodCompletion # Delete pod once its finished
   nodeSelector:

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  generateName: imagery-non-visual-qa-
+spec:
+  serviceAccountName: workflow-runner-sa
+  podGC:
+    strategy: OnPodCompletion # Delete pod once its finished
+  nodeSelector:
+    karpenter.sh/capacity-type: "spot"
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: uri
+        value: ""
+      - name: filter
+        value: ".tiff?$"
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: aws-list
+            template: aws-list
+            arguments:
+              parameters:
+                - name: uri
+                  value: "{{workflow.parameters.uri}}"
+                - name: filter
+                  value: "{{workflow.parameters.filter}}"
+          - name: non-visual-qa
+            template: non-visual-qa
+            arguments:
+              parameters:
+                - name: file
+                  value: "{{item}}"
+            depends: "aws-list"
+            withParam: "{{tasks.aws-list.outputs.parameters.files}}"
+    - name: aws-list
+      inputs:
+        parameters:
+          - name: uri
+          - name: filter
+      container:
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2000m
+        image: ghcr.io/linz/basemaps/cli:v6.29.0-3-gb4dec98c
+        command: [node, index.cjs]
+        args:
+          [
+            "-V",
+            "list",
+            "--filter",
+            "{{inputs.parameters.filter}}",
+            "--output",
+            "/tmp/file_list.json",
+            "--config",
+            "linz-bucket-config",
+            "{{inputs.parameters.uri}}",
+          ]
+      outputs:
+        parameters:
+          - name: files
+            valueFrom:
+              path: /tmp/file_list.json
+    - name: non-visual-qa
+      retryStrategy:
+        limit: "2"
+      inputs:
+        parameters:
+          - name: file
+      container:
+        image: ghcr.io/linz/topo-imagery:v0.2.0-20-ged4d623
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2000m
+        command:
+          - python
+          - "/app/non_visual_qa.py"
+        args:
+          - "--source"
+          - "{{inputs.parameters.file}}"

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -4,12 +4,6 @@ kind: WorkflowTemplate
 metadata:
   name: imagery-non-visual-qa-v0.2.0-20
 spec:
-  serviceAccountName: workflow-runner-sa
-  workflowMetadata:
-    annotations:
-      fluentbit.io/parser: json
-  podGC:
-    strategy: OnPodCompletion # Delete pod once its finished
   nodeSelector:
     karpenter.sh/capacity-type: "spot"
   entrypoint: main
@@ -45,10 +39,6 @@ spec:
           - name: uri
           - name: filter
       container:
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 2000m
         image: ghcr.io/linz/basemaps/cli:v6.29.0-3-gb4dec98c
         command: [node, index.cjs]
         args:
@@ -78,10 +68,6 @@ spec:
           - name: file
       container:
         image: ghcr.io/linz/topo-imagery:v0.2.0-20-ged4d623
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 2000m
         command:
           - python
           - "/app/non_visual_qa.py"


### PR DESCRIPTION
## Description
In order to use the `non_visual_qa.py` script from `Topo-Imagery`, we need a workflow template that allows us to submit a workflow from Argo.

## Change
Add the workflow template `non-visual-qa.yaml`

## Tests
The workflow template has been created in Argo `imagery-non-visual-qa-l9z66` under the namespace `argo`.