### PR TITLE
fix: standardising workflowtemplate requested resources

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -42,10 +42,6 @@ spec:
           - name: source
           - name: filter
       container:
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 4000m
         image: ghcr.io/linz/basemaps/cli:v6.33.0
         command: [node, index.cjs]
         args:
@@ -78,7 +74,7 @@ spec:
         resources:
           requests:
             memory: 2Gi
-            cpu: 2000m
+            cpu: 4000m
             ephemeral-storage: 9Gi
         volumeMounts:
           - name: ephemeral


### PR DESCRIPTION
Fixing up the requested resources to use the default for the file listing and bumping up the CPU to 4000m for the `gdal_translate`.