### PR TITLE
fix: lower storage limits, move the standardise to spot and align cpu/memory requests

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -66,6 +66,8 @@ spec:
     - name: standardise
       retryStrategy:
         limit: "2"
+      nodeSelector:
+        karpenter.sh/capacity-type: "spot"
       inputs:
         parameters:
           - name: file
@@ -73,9 +75,9 @@ spec:
         image: ghcr.io/linz/topo-imagery:v0.2.0-20-ged4d623
         resources:
           requests:
-            memory: 2Gi
-            cpu: 4000m
-            ephemeral-storage: 9Gi
+            memory: 3.9Gi
+            cpu: 2000m
+            ephemeral-storage: 3Gi
         volumeMounts:
           - name: ephemeral
             mountPath: "/tmp"


### PR DESCRIPTION
the machines are only spawning with ~12GB of usable storage, so it will limit to 1 pod per machine.