### PR TITLE
feat: workflow that sleeps for a hour for testing

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -66,6 +66,8 @@ spec:
     - name: standardise
       retryStrategy:
         limit: "2"
+      nodeSelector:
+        karpenter.sh/capacity-type: "spot"
       inputs:
         parameters:
           - name: file
@@ -73,9 +75,9 @@ spec:
         image: ghcr.io/linz/topo-imagery:v0.2.0-20-ged4d623
         resources:
           requests:
-            memory: 2Gi
-            cpu: 4000m
-            ephemeral-storage: 9Gi
+            memory: 3.9Gi
+            cpu: 2000m
+            ephemeral-storage: 3Gi
         volumeMounts:
           - name: ephemeral
             mountPath: "/tmp"

--- a/workflows/test/sleep.yml
+++ b/workflows/test/sleep.yml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: sleep-
+spec:
+  entrypoint: sleep
+  templates:
+    - name: sleep
+      nodeSelector:
+        karpenter.sh/capacity-type: "spot"
+      container:
+        resources:
+          requests:
+            memory: 3.9Gi
+            cpu: 2000m
+        image: ubuntu:22.04
+        command: ["sleep", "3600"]


### PR DESCRIPTION
developers can submit the workflow then use kubectl to connect to the machine.

```
argo submit workflows/test/sleep.yml
k exec -it sleep-:podName /bin/bash
```