### PR TITLE
feat: add non visual qa in imagery-standardising workflow TDE-450

### DIFF
--- a/workflows/imagery/standardise-only.yaml
+++ b/workflows/imagery/standardise-only.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: imagery-standardising-v0.2.0-34
+  name: imagery-standardise-only-v0.2.0-34
 spec:
   parallelism: 20
   nodeSelector:
@@ -28,23 +28,14 @@ spec:
                   value: "{{workflow.parameters.source}}"
                 - name: filter
                   value: "{{workflow.parameters.filter}}"
-          - name: standardise-validate
-            template: standardise-validate
+          - name: standardise
+            template: standardise
             arguments:
               parameters:
                 - name: file
                   value: "{{item}}"
             depends: "aws-list"
             withParam: "{{tasks.aws-list.outputs.parameters.files}}"
-          - name: get-location
-            template: get-location
-          - name: create-config
-            arguments:
-              parameters:
-                - name: location
-                  value: "{{tasks.get-location.outputs.parameters.location}}"
-            template: create-config
-            depends: "get-location && standardise-validate"
     - name: aws-list
       inputs:
         parameters:
@@ -73,7 +64,7 @@ spec:
           - name: files
             valueFrom:
               path: /tmp/file_list.json
-    - name: standardise-validate
+    - name: standardise
       retryStrategy:
         limit: "2"
       nodeSelector:
@@ -93,7 +84,7 @@ spec:
             mountPath: "/tmp"
         command:
           - python
-          - "/app/scripts/standardise_validate.py"
+          - "/app/scripts/standardising.py"
         args:
           - "--source"
           - "{{inputs.parameters.file}}"
@@ -103,45 +94,6 @@ spec:
             path: /tmp/
             archive:
               none: {}
-    - name: get-location
-      script:
-        image: node:alpine
-        command: [node]
-        source: |
-          const fs = require('fs');
-          const loc = JSON.parse(process.env['ARGO_TEMPLATE']).archiveLocation.s3;
-          const key = loc.key.replace('{{pod.name}}','');
-          fs.writeFileSync('/tmp/location', `s3://${loc.bucket}/${key}`);
-      outputs:
-        parameters:
-          - name: location
-            valueFrom:
-              path: "/tmp/location"
-    - name: create-config
-      inputs:
-        parameters:
-          - name: location
-      container:
-        image: ghcr.io/linz/basemaps/cli:v6.34.0-27-gd3c9adb8
-        command: [node, index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-        args:
-          [
-            "-V",
-            "create-config",
-            "--path",
-            "{{inputs.parameters.location}}",
-            "--output",
-            "/tmp/url",
-            "--commit",
-          ]
-      outputs:
-        parameters:
-          - name: url
-            valueFrom:
-              path: "/tmp/url"
   volumes:
     - name: ephemeral
       emptyDir: {}


### PR DESCRIPTION
## Description
The `imagery-standardising` workflow should include the non visual qa process. The non visual qa process has been added as a second step running after the standardising script in `topo-imagery` via `standardise_validate.py` script.

## Changes

- Rename workflow templace to `imagery-standardising-`
- Call the `standardise_validate.py` instead of the `standardising.py` script
- Create a workflow template `imagery-standardise-only-` that calls only `standardising.py` script

> **_NOTE:_**  Both workflow templates have been deployed in Argo.