### PR TITLE
refactor: simplify parameters passing in standardising workflow

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -1,145 +1,145 @@
 ---
-    apiVersion: argoproj.io/v1alpha1
-    kind: WorkflowTemplate
-    metadata:
-      name: imagery-standardising-v0.2.0-43
-      namespace: argo
-    spec:
-      parallelism: 20
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: imagery-standardising-v0.2.0-43
+  namespace: argo
+spec:
+  parallelism: 20
+  nodeSelector:
+    karpenter.sh/capacity-type: "spot"
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: source
+        value: "s3://linz-imagery-staging/test/sample/"
+      - name: filter
+        value: ".tiff?$"
+      - name: group
+        value: 10
+      - name: compression
+        value: "webp"
+        enum:
+          - "webp"
+          - "lzw"
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: aws-list
+            template: aws-list
+          - name: standardise-validate
+            template: standardise-validate
+            arguments:
+              parameters:
+                - name: file
+                  value: "{{item}}"
+            depends: "aws-list"
+            withParam: "{{tasks.aws-list.outputs.parameters.files}}"
+          - name: get-location
+            template: get-location
+          - name: create-config
+            arguments:
+              parameters:
+                - name: location
+                  value: "{{tasks.get-location.outputs.parameters.location}}"
+            template: create-config
+            depends: "get-location && standardise-validate"
+    - name: aws-list
+      container:
+        image: ghcr.io/linz/argo-tasks:v1.0.0-8-g53a2c88
+        command: [node, /app/index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config-v2.json
+        args:
+          [
+            "list",
+            "--verbose",
+            "--filter",
+            "{{workflow.parameters.filter}}",
+            "--group",
+            "{{workflow.parameters.group}}",
+            "--output",
+            "/tmp/file_list.json",
+            "{{workflow.parameters.source}}",
+          ]
+      outputs:
+        parameters:
+          - name: files
+            valueFrom:
+              path: /tmp/file_list.json
+    - name: standardise-validate
+      retryStrategy:
+        limit: "2"
       nodeSelector:
         karpenter.sh/capacity-type: "spot"
-      entrypoint: main
-      arguments:
+      inputs:
         parameters:
-          - name: source
-            value: "s3://linz-imagery-staging/test/sample/"
-          - name: filter
-            value: ".tiff?$"
-          - name: group
-            value: 10
-          - name: compression
-            value: "webp"
-            enum:
-              - "webp"
-              - "lzw"
-      templates:
-        - name: main
-          dag:
-            tasks:
-              - name: aws-list
-                template: aws-list
-              - name: standardise-validate
-                template: standardise-validate
-                arguments:
-                  parameters:
-                    - name: file
-                      value: "{{item}}"
-                depends: "aws-list"
-                withParam: "{{tasks.aws-list.outputs.parameters.files}}"
-              - name: get-location
-                template: get-location
-              - name: create-config
-                arguments:
-                  parameters:
-                    - name: location
-                      value: "{{tasks.get-location.outputs.parameters.location}}"
-                template: create-config
-                depends: "get-location && standardise-validate"
-        - name: aws-list
-          container:
-            image: ghcr.io/linz/argo-tasks:v1.0.0-8-g53a2c88
-            command: [node, /app/index.cjs]
-            env:
-              - name: AWS_ROLE_CONFIG_PATH
-                value: s3://linz-bucket-config/config-v2.json
-            args:
-              [
-                "list",
-                "--verbose",
-                "--filter",
-                "{{workflow.parameters.filter}}",
-                "--group",
-                "{{workflow.parameters.group}}",
-                "--output",
-                "/tmp/file_list.json",
-                "{{workflow.parameters.source}}",
-              ]
-          outputs:
-            parameters:
-              - name: files
-                valueFrom:
-                  path: /tmp/file_list.json
-        - name: standardise-validate
-          retryStrategy:
-            limit: "2"
-          nodeSelector:
-            karpenter.sh/capacity-type: "spot"
-          inputs:
-            parameters:
-              - name: file
-          container:
-            image: ghcr.io/linz/topo-imagery:v0.2.0-43-g9127002
-            resources:
-              requests:
-                memory: 3.9Gi
-                cpu: 2000m
-                ephemeral-storage: 3Gi
-            volumeMounts:
-              - name: ephemeral
-                mountPath: "/tmp"
-            command:
-              - python
-              - "/app/scripts/standardise_validate.py"
-            args:
-              - "--source"
-              - "{{inputs.parameters.file}}"
-              - "--preset"
-              - "{{workflow.parameters.compression}}"
-          outputs:
-            artifacts:
-              - name: standardised_tiffs
-                path: /tmp/
-                archive:
-                  none: {}
-        - name: get-location
-          script:
-            image: node:alpine
-            command: [node]
-            source: |
-              const fs = require('fs');
-              const loc = JSON.parse(process.env['ARGO_TEMPLATE']).archiveLocation.s3;
-              const key = loc.key.replace('{{pod.name}}','');
-              fs.writeFileSync('/tmp/location', `s3://${loc.bucket}/${key}`);
-          outputs:
-            parameters:
-              - name: location
-                valueFrom:
-                  path: "/tmp/location"
-        - name: create-config
-          inputs:
-            parameters:
-              - name: location
-          container:
-            image: ghcr.io/linz/basemaps/cli:v6.34.0-27-gd3c9adb8
-            command: [node, index.cjs]
-            env:
-              - name: AWS_ROLE_CONFIG_PATH
-                value: s3://linz-bucket-config/config.json
-            args:
-              [
-                "-V",
-                "create-config",
-                "--path",
-                "{{inputs.parameters.location}}",
-                "--output",
-                "/tmp/url",
-                "--commit",
-              ]
-          outputs:
-            parameters:
-              - name: url
-                valueFrom:
-                  path: "/tmp/url"
-      volumes:
-        - name: ephemeral
-          emptyDir: {}
+          - name: file
+      container:
+        image: ghcr.io/linz/topo-imagery:v0.2.0-43-g9127002
+        resources:
+          requests:
+            memory: 3.9Gi
+            cpu: 2000m
+            ephemeral-storage: 3Gi
+        volumeMounts:
+          - name: ephemeral
+            mountPath: "/tmp"
+        command:
+          - python
+          - "/app/scripts/standardise_validate.py"
+        args:
+          - "--source"
+          - "{{inputs.parameters.file}}"
+          - "--preset"
+          - "{{workflow.parameters.compression}}"
+      outputs:
+        artifacts:
+          - name: standardised_tiffs
+            path: /tmp/
+            archive:
+              none: {}
+    - name: get-location
+      script:
+        image: node:alpine
+        command: [node]
+        source: |
+          const fs = require('fs');
+          const loc = JSON.parse(process.env['ARGO_TEMPLATE']).archiveLocation.s3;
+          const key = loc.key.replace('{{pod.name}}','');
+          fs.writeFileSync('/tmp/location', `s3://${loc.bucket}/${key}`);
+      outputs:
+        parameters:
+          - name: location
+            valueFrom:
+              path: "/tmp/location"
+    - name: create-config
+      inputs:
+        parameters:
+          - name: location
+      container:
+        image: ghcr.io/linz/basemaps/cli:v6.34.0-27-gd3c9adb8
+        command: [node, index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          [
+            "-V",
+            "create-config",
+            "--path",
+            "{{inputs.parameters.location}}",
+            "--output",
+            "/tmp/url",
+            "--commit",
+          ]
+      outputs:
+        parameters:
+          - name: url
+            valueFrom:
+              path: "/tmp/url"
+  volumes:
+    - name: ephemeral
+      emptyDir: {}

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -1,158 +1,145 @@
 ---
-apiVersion: argoproj.io/v1alpha1
-kind: WorkflowTemplate
-metadata:
-  name: imagery-standardising-v0.2.0-43
-  namespace: argo
-spec:
-  parallelism: 20
-  nodeSelector:
-    karpenter.sh/capacity-type: "spot"
-  entrypoint: main
-  arguments:
-    parameters:
-      - name: source
-        value: "s3://linz-imagery-staging/test/sample/"
-      - name: filter
-        value: ".tiff?$"
-      - name: group
-        value: 10
-      - name: compression
-        value: "webp"
-        enum:
-          - "webp"
-          - "lzw"
-  templates:
-    - name: main
-      dag:
-        tasks:
-          - name: aws-list
-            template: aws-list
-            arguments:
-              parameters:
-                - name: source
-                  value: "{{workflow.parameters.source}}"
-                - name: filter
-                  value: "{{workflow.parameters.filter}}"
-          - name: standardise-validate
-            template: standardise-validate
-            arguments:
-              parameters:
-                - name: file
-                  value: "{{item}}"
-                - name: preset
-                  value: "{{workflow.parameters.compression}}"
-            depends: "aws-list"
-            withParam: "{{tasks.aws-list.outputs.parameters.files}}"
-          - name: get-location
-            template: get-location
-          - name: create-config
-            arguments:
-              parameters:
-                - name: location
-                  value: "{{tasks.get-location.outputs.parameters.location}}"
-            template: create-config
-            depends: "get-location && standardise-validate"
-    - name: aws-list
-      inputs:
-        parameters:
-          - name: source
-          - name: filter
-      container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-8-g53a2c88
-        command: [node, /app/index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
-        args:
-          [
-            "list",
-            "--verbose",
-            "--filter",
-            "{{inputs.parameters.filter}}",
-            "--group",
-            "{{workflow.parameters.group}}",
-            "--output",
-            "/tmp/file_list.json",
-            "{{inputs.parameters.source}}",
-          ]
-      outputs:
-        parameters:
-          - name: files
-            valueFrom:
-              path: /tmp/file_list.json
-    - name: standardise-validate
-      retryStrategy:
-        limit: "2"
+    apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTemplate
+    metadata:
+      name: imagery-standardising-v0.2.0-43
+      namespace: argo
+    spec:
+      parallelism: 20
       nodeSelector:
         karpenter.sh/capacity-type: "spot"
-      inputs:
+      entrypoint: main
+      arguments:
         parameters:
-          - name: file
-          - name: preset
-      container:
-        image: ghcr.io/linz/topo-imagery:v0.2.0-43-g9127002
-        resources:
-          requests:
-            memory: 3.9Gi
-            cpu: 2000m
-            ephemeral-storage: 3Gi
-        volumeMounts:
-          - name: ephemeral
-            mountPath: "/tmp"
-        command:
-          - python
-          - "/app/scripts/standardise_validate.py"
-        args:
-          - "--source"
-          - "{{inputs.parameters.file}}"
-          - "--preset"
-          - "{{inputs.parameters.preset}}"
-      outputs:
-        artifacts:
-          - name: standardised_tiffs
-            path: /tmp/
-            archive:
-              none: {}
-    - name: get-location
-      script:
-        image: node:alpine
-        command: [node]
-        source: |
-          const fs = require('fs');
-          const loc = JSON.parse(process.env['ARGO_TEMPLATE']).archiveLocation.s3;
-          const key = loc.key.replace('{{pod.name}}','');
-          fs.writeFileSync('/tmp/location', `s3://${loc.bucket}/${key}`);
-      outputs:
-        parameters:
-          - name: location
-            valueFrom:
-              path: "/tmp/location"
-    - name: create-config
-      inputs:
-        parameters:
-          - name: location
-      container:
-        image: ghcr.io/linz/basemaps/cli:v6.34.0-27-gd3c9adb8
-        command: [node, index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-        args:
-          [
-            "-V",
-            "create-config",
-            "--path",
-            "{{inputs.parameters.location}}",
-            "--output",
-            "/tmp/url",
-            "--commit",
-          ]
-      outputs:
-        parameters:
-          - name: url
-            valueFrom:
-              path: "/tmp/url"
-  volumes:
-    - name: ephemeral
-      emptyDir: {}
+          - name: source
+            value: "s3://linz-imagery-staging/test/sample/"
+          - name: filter
+            value: ".tiff?$"
+          - name: group
+            value: 10
+          - name: compression
+            value: "webp"
+            enum:
+              - "webp"
+              - "lzw"
+      templates:
+        - name: main
+          dag:
+            tasks:
+              - name: aws-list
+                template: aws-list
+              - name: standardise-validate
+                template: standardise-validate
+                arguments:
+                  parameters:
+                    - name: file
+                      value: "{{item}}"
+                depends: "aws-list"
+                withParam: "{{tasks.aws-list.outputs.parameters.files}}"
+              - name: get-location
+                template: get-location
+              - name: create-config
+                arguments:
+                  parameters:
+                    - name: location
+                      value: "{{tasks.get-location.outputs.parameters.location}}"
+                template: create-config
+                depends: "get-location && standardise-validate"
+        - name: aws-list
+          container:
+            image: ghcr.io/linz/argo-tasks:v1.0.0-8-g53a2c88
+            command: [node, /app/index.cjs]
+            env:
+              - name: AWS_ROLE_CONFIG_PATH
+                value: s3://linz-bucket-config/config-v2.json
+            args:
+              [
+                "list",
+                "--verbose",
+                "--filter",
+                "{{workflow.parameters.filter}}",
+                "--group",
+                "{{workflow.parameters.group}}",
+                "--output",
+                "/tmp/file_list.json",
+                "{{workflow.parameters.source}}",
+              ]
+          outputs:
+            parameters:
+              - name: files
+                valueFrom:
+                  path: /tmp/file_list.json
+        - name: standardise-validate
+          retryStrategy:
+            limit: "2"
+          nodeSelector:
+            karpenter.sh/capacity-type: "spot"
+          inputs:
+            parameters:
+              - name: file
+          container:
+            image: ghcr.io/linz/topo-imagery:v0.2.0-43-g9127002
+            resources:
+              requests:
+                memory: 3.9Gi
+                cpu: 2000m
+                ephemeral-storage: 3Gi
+            volumeMounts:
+              - name: ephemeral
+                mountPath: "/tmp"
+            command:
+              - python
+              - "/app/scripts/standardise_validate.py"
+            args:
+              - "--source"
+              - "{{inputs.parameters.file}}"
+              - "--preset"
+              - "{{workflow.parameters.compression}}"
+          outputs:
+            artifacts:
+              - name: standardised_tiffs
+                path: /tmp/
+                archive:
+                  none: {}
+        - name: get-location
+          script:
+            image: node:alpine
+            command: [node]
+            source: |
+              const fs = require('fs');
+              const loc = JSON.parse(process.env['ARGO_TEMPLATE']).archiveLocation.s3;
+              const key = loc.key.replace('{{pod.name}}','');
+              fs.writeFileSync('/tmp/location', `s3://${loc.bucket}/${key}`);
+          outputs:
+            parameters:
+              - name: location
+                valueFrom:
+                  path: "/tmp/location"
+        - name: create-config
+          inputs:
+            parameters:
+              - name: location
+          container:
+            image: ghcr.io/linz/basemaps/cli:v6.34.0-27-gd3c9adb8
+            command: [node, index.cjs]
+            env:
+              - name: AWS_ROLE_CONFIG_PATH
+                value: s3://linz-bucket-config/config.json
+            args:
+              [
+                "-V",
+                "create-config",
+                "--path",
+                "{{inputs.parameters.location}}",
+                "--output",
+                "/tmp/url",
+                "--commit",
+              ]
+          outputs:
+            parameters:
+              - name: url
+                valueFrom:
+                  path: "/tmp/url"
+      volumes:
+        - name: ephemeral
+          emptyDir: {}


### PR DESCRIPTION
## Description
Unless we want to see the parameters for each pods in the Argo UI - we can still see them in the main pod, I feel it's not necessary to pass the parameters from the user input to the task to the template and that adds some complexity in the `yaml` file.