### PR TITLE
feat: update standardising workflow to create stac items TDE-492

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: imagery-standardising-v0.2.0-44
+  name: imagery-standardising-v0.2.0-46
   namespace: argo
 spec:
   parallelism: 20
@@ -23,19 +23,27 @@ spec:
           - "webp"
           - "lzw"
           - "gray_webp"
+      - name: start_datetime
+        value: "YYYY-MM-DD"
+      - name: end_datetime
+        value: "YYYY-MM-DD"
   templates:
     - name: main
       dag:
         tasks:
           - name: aws-list
             template: aws-list
+          - name: generate-ulid
+            template: generate-ulid
           - name: standardise-validate
             template: standardise-validate
             arguments:
               parameters:
                 - name: file
                   value: "{{item}}"
-            depends: "aws-list"
+                - name: collection_id
+                  value: "{{tasks.generate-ulid.outputs.parameters.ulid}}"
+            depends: "aws-list && generate-ulid"
             withParam: "{{tasks.aws-list.outputs.parameters.files}}"
           - name: get-location
             template: get-location
@@ -70,6 +78,19 @@ spec:
           - name: files
             valueFrom:
               path: /tmp/file_list.json
+    - name: generate-ulid
+      script:
+        image: ghcr.io/linz/topo-imagery:v0.2.0-46-g5d8ee79
+        command: [python]
+        source: |
+          import ulid
+          with open("/tmp/ulid", "w") as f:
+            f.write(str(ulid.ULID()))
+      outputs:
+        parameters:
+          - name: ulid
+            valueFrom:
+              path: "/tmp/ulid"
     - name: standardise-validate
       retryStrategy:
         limit: "2"
@@ -78,8 +99,9 @@ spec:
       inputs:
         parameters:
           - name: file
+          - name: collection_id
       container:
-        image: ghcr.io/linz/topo-imagery:v0.2.0-44-g8b9503b
+        image: ghcr.io/linz/topo-imagery:v0.2.0-46-g5d8ee79
         resources:
           requests:
             memory: 3.9Gi
@@ -96,6 +118,12 @@ spec:
           - "{{inputs.parameters.file}}"
           - "--preset"
           - "{{workflow.parameters.compression}}"
+          - "--start_datetime"
+          - "{{workflow.parameters.start_datetime}}"
+          - "--end_datetime"
+          - "{{workflow.parameters.end_datetime}}"
+          - "--collection_id"
+          - "{{inputs.parameters.collection_id}}"
       outputs:
         artifacts:
           - name: standardised_tiffs


### PR DESCRIPTION
example output: `s3://linz-workflow-artifacts/2022-10/09-mdavidson-test-imagery-standardising-nk44q/mdavidson-test-imagery-standardising-nk44q-82035514/tmp/`

example stac item file (converted to txt as github wouldn't allow json): [BX24_5000_0407.txt](https://github.com/linz/topo-workflows/files/9742594/BX24_5000_0407.txt)

![image](https://user-images.githubusercontent.com/33814653/194780216-27efd2fe-55b0-47b6-b2d8-20470f3b779f.png)

![image](https://user-images.githubusercontent.com/33814653/194781481-0683d447-14cb-44e2-9dac-8c2bf1db5839.png)
