### PR TITLE
fix: change default flatten group size

### DIFF
--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -52,7 +52,7 @@ spec:
             "--include",
             "{{inputs.parameters.filter}}",
             "--group",
-            "500",
+            "30",
             "--output",
             "/tmp/file_list.json",
             "{{inputs.parameters.uri}}",


### PR DESCRIPTION
`500` is too big, `30` seems reliable for a temporary fix.