### PR TITLE
feat: update argo-task version and add new copy parameter

### DIFF
--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -39,8 +39,8 @@ spec:
         parameters:
           - name: layer
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/workflows/imagery/extent.yaml
+++ b/workflows/imagery/extent.yaml
@@ -35,8 +35,8 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -40,8 +40,8 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -31,6 +31,11 @@ spec:
         value: "YYYY-MM-DD"
       - name: end_datetime
         value: "YYYY-MM-DD"
+      - name: copy-option
+        value: "--no-clobber"
+        enum:
+          - "--no-clobber"
+          - "--force"
   templates:
     - name: main
       dag:
@@ -95,8 +100,8 @@ spec:
             depends: "get-location && flatten-copy"
     - name: aws-list
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json
@@ -174,8 +179,8 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json
@@ -203,15 +208,18 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
         resources:
           requests:
             memory: 7.8Gi
             cpu: 2000m
-        command: [node, /app/index.cjs]
+        command: [node, /app/index.js]
         args:
-          - "copy"
-          - "{{inputs.parameters.file}}"
+          [
+            "copy",
+            "{{workflow.parameters.copy-option}}",
+            "{{inputs.parameters.file}}",
+          ]
     - name: create-collection
       retryStrategy:
         limit: "2"
@@ -245,7 +253,7 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: stac-validate-v1.0.0-26
+  name: stac-validate-v1.0.0-29
   namespace: argo
 spec:
   nodeSelector:
@@ -31,8 +31,8 @@ spec:
         parameters:
           - name: stac-file-path
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-flatten-v1.0.0-26
+  name: test-flatten-v1.0.0-29
   namespace: argo
 spec:
   nodeSelector:
@@ -14,6 +14,11 @@ spec:
         value: ""
       - name: filter
         value: ".tiff?$|.json$"
+      - name: copy-option
+        value: "--no-clobber"
+        enum:
+          - "--no-clobber"
+          - "--force"
   templates:
     - name: main
       dag:
@@ -40,8 +45,8 @@ spec:
           - name: uri
           - name: filter
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json
@@ -69,12 +74,15 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
         resources:
           requests:
             memory: 7.8Gi
             cpu: 2000m
-        command: [node, /app/index.cjs]
+        command: [node, /app/index.js]
         args:
-          - "copy"
-          - "{{inputs.parameters.file}}"
+          [
+            "copy",
+            "{{workflow.parameters.copy-option}}",
+            "{{inputs.parameters.file}}",
+          ]

--- a/workflows/test/list.yaml
+++ b/workflows/test/list.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: test-aws-list-v1.0.0-26
+  generateName: test-aws-list-v1.0.0-29
 spec:
   serviceAccountName: workflow-runner-sa
   entrypoint: main
@@ -27,8 +27,8 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-v2.json


### PR DESCRIPTION
## Description
`argo-task` `copy` command has two new parameters `--no-clobber` and `--force`. The way the container is build has changed as well, so needed to update the command entry point.