### PR TITLE
fix: remove title and description values

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -24,9 +24,7 @@ spec:
           - "lzw"
           - "gray_webp"
       - name: title
-        value: ""
       - name: description
-        value: ""
       - name: start_datetime
         value: "YYYY-MM-DD"
       - name: end_datetime


### PR DESCRIPTION
stac validation failed as the description was empty. 
(https://argo.linzaccess.com/workflows/argo/imagery-standardising-v0.2.0-52-t49z9?tab=workflow) 

Removing `value: ""` from these parameters means the user has to input a value when submitting the workflow.
Otherwise argo will give an error that lets the user know it is required. 