### PR TITLE
feat: Publish Workflow TDE-494

### DIFF
--- a/workflows/imagery/extent.yaml
+++ b/workflows/imagery/extent.yaml
@@ -35,11 +35,11 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "list",

--- a/workflows/imagery/non-visual-qa.yaml
+++ b/workflows/imagery/non-visual-qa.yaml
@@ -40,11 +40,11 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "list",

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -17,6 +17,11 @@ spec:
         value: "s3://linz-imagery-staging/test/sample_target/"
       - name: include
         value: ".tiff?$|.json$|.tfw$"
+      - name: copy-option
+        value: "--no-clobber"
+        enum:
+          - "--no-clobber"
+          - "--force"
   templates:
     - name: main
       dag:
@@ -89,5 +94,8 @@ spec:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config.json
         args:
-          - "copy"
-          - "{{inputs.parameters.file}}"
+          [
+            "copy",
+            "{{workflow.parameters.copy-option}}",
+            "{{inputs.parameters.file}}",
+          ]

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -12,9 +12,9 @@ spec:
   arguments:
     parameters:
       - name: source
-        value: ""
+        value: "s3://linz-imagery-staging/test/sample/"
       - name: target
-        value: ""
+        value: "s3://linz-imagery-staging/test/sample_target/"
       - name: include
         value: ".tiff?$|.json$|.tfw$"
   templates:

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: publish-imagery-v1.0.0-26
+  name: publish-copy-v1.0.0-40
   namespace: argo
 spec:
   parallelism: 50
@@ -16,7 +16,7 @@ spec:
       - name: target
         value: ""
       - name: include
-        value: ".tiff?$|.json$"
+        value: ".tiff?$|.json$|.tfw$"
   templates:
     - name: main
       dag:
@@ -46,8 +46,8 @@ spec:
           - name: target
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
-        command: [node, /app/index.cjs]
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
@@ -79,12 +79,12 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         resources:
           requests:
             memory: 7.8Gi
             cpu: 2000m
-        command: [node, /app/index.cjs]
+        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config.json

--- a/workflows/imagery/publish-imagery.yaml
+++ b/workflows/imagery/publish-imagery.yaml
@@ -5,6 +5,7 @@ metadata:
   name: publish-imagery-v1.0.0-26
   namespace: argo
 spec:
+  parallelism: 50
   nodeSelector:
     karpenter.sh/capacity-type: "spot"
   entrypoint: main
@@ -57,7 +58,9 @@ spec:
             "--include",
             "{{inputs.parameters.include}}",
             "--group",
-            "30",
+            "1000",
+            "--group-size",
+            "100Gi",
             "--output",
             "/tmp/file_list.json",
             "--target",

--- a/workflows/imagery/publish-imagery.yaml
+++ b/workflows/imagery/publish-imagery.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: publish-imagery-v1.0.0-26
+  namespace: argo
+spec:
+  nodeSelector:
+    karpenter.sh/capacity-type: "spot"
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: source
+        value: ""
+      - name: target
+        value: ""
+      - name: include
+        value: ".tiff?$|.json$"
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: create-manifest
+            template: create-manifest
+            arguments:
+              parameters:
+                - name: source
+                  value: "{{workflow.parameters.source}}"
+                - name: target
+                  value: "{{workflow.parameters.target}}"
+                - name: include
+                  value: "{{workflow.parameters.include}}"
+          - name: copy
+            template: copy
+            arguments:
+              parameters:
+                - name: file
+                  value: "{{item}}"
+            depends: "create-manifest"
+            withParam: "{{tasks.create-manifest.outputs.parameters.files}}"
+    - name: create-manifest
+      inputs:
+        parameters:
+          - name: source
+          - name: target
+          - name: include
+      container:
+        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
+        command: [node, /app/index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          [
+            "create-manifest",
+            "--verbose",
+            "--include",
+            "{{inputs.parameters.include}}",
+            "--group",
+            "30",
+            "--output",
+            "/tmp/file_list.json",
+            "--target",
+            "{{inputs.parameters.target}}",
+            "{{inputs.parameters.source}}",
+          ]
+      outputs:
+        parameters:
+          - name: files
+            valueFrom:
+              path: /tmp/file_list.json
+    - name: copy
+      retryStrategy:
+        limit: "2"
+      inputs:
+        parameters:
+          - name: file
+      container:
+        image: ghcr.io/linz/argo-tasks:v1.0.0-26-gc81459e
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 2000m
+        command: [node, /app/index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config.json
+        args:
+          - "copy"
+          - "{{inputs.parameters.file}}"

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -102,7 +102,7 @@ spec:
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "list",
@@ -181,7 +181,7 @@ spec:
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "flatten",
@@ -194,6 +194,8 @@ spec:
             "100Gi",
             "--output",
             "/tmp/file_list.json",
+            "--target",
+            "{{inputs.parameters.location}}flat/",
             "{{inputs.parameters.location}}",
           ]
       outputs:
@@ -256,7 +258,7 @@ spec:
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "stac-validate",

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -98,7 +98,7 @@ spec:
             depends: "get-location && flatten-copy"
     - name: aws-list
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -177,7 +177,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -210,7 +210,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         resources:
           requests:
             memory: 7.8Gi
@@ -254,7 +254,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: stac-validate-v1.0.0-29
+  name: stac-validate-v1.0.0-40
   namespace: argo
 spec:
   nodeSelector:
@@ -31,11 +31,11 @@ spec:
         parameters:
           - name: stac-file-path
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "stac-validate",

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-flatten-v1.0.0-29
+  name: test-flatten-v1.0.0-40
   namespace: argo
 spec:
   nodeSelector:
@@ -45,11 +45,11 @@ spec:
           - name: uri
           - name: filter
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "flatten",
@@ -76,7 +76,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/test/list.yaml
+++ b/workflows/test/list.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: test-aws-list-v1.0.0-29
+  generateName: test-aws-list-v1.0.0-40
 spec:
   serviceAccountName: workflow-runner-sa
   entrypoint: main
@@ -27,11 +27,11 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-29-gcaa00e2
+        image: ghcr.io/linz/argo-tasks:v1.0.0-40-g10e90df
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-v2.json
+            value: s3://linz-bucket-config/config.json
         args:
           [
             "list",


### PR DESCRIPTION
- Changes to the `flatten` argo-task to allow it to copy to and from other locations.
- `standardising` has been updated for this change.
- New `publish-copy` workflow for publishing from Argo Tasks `flat` directory to `linz-imagery` and RGBI from `linz-imagery-upload` to `linz-imagery-staging`.
- `argo-tasks` container version bumped up to the latest version.
- `imagery` workflows changed to use latest `config.json`