### PR TITLE
chore: rename test script to avoid alert on Slack main channel

### DIFF
--- a/workflows/imagery/tests.yaml
+++ b/workflows/imagery/tests.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: topo-imagery-test-script-
+  generateName: test-topo-imagery-
 spec:
   serviceAccountName: workflow-runner-sa
   podGC:


### PR DESCRIPTION
`test-` are not alerted on `#alert-argo-workflows`