### PR TITLE
feat: make flatten optional in publish copy

### DIFF
--- a/workflows/imagery/README.md
+++ b/workflows/imagery/README.md
@@ -175,12 +175,13 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Input Parameters
 
-| Parameter   | Type  | Default                                       | Description                                                                                                                     |
-| ----------- | ----- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| source      | str   | s3://linz-imagery-staging/test/sample/        | The URIs (paths) to the s3 source location                                                                                      |
-| target      | str   | s3://linz-imagery-staging/test/sample_target/ | The URIs (paths) to the s3 target location                                                                                      |
-| include     | regex | .tiff?\$\|.json\$\|.tfw\$                     | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                     |
-| copy-option | enum  | --no-clobber                                  | `--no-clobber` will not overwrite files if the name and the file size in bytes are the same. `--force` will overwrite all files |
+| Parameter   | Type  | Default                                       | Description                                                                                                                                        |
+| ----------- | ----- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| source      | str   | s3://linz-imagery-staging/test/sample/        | The URIs (paths) to the s3 source location                                                                                                         |
+| target      | str   | s3://linz-imagery-staging/test/sample_target/ | The URIs (paths) to the s3 target location                                                                                                         |
+| include     | regex | .tiff?\$\|.json\$\|.tfw\$                     | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                        |
+| copy-option | enum  | --no-clobber                                  | `--no-clobber` will not overwrite files if the name and the file size in bytes are the same. `--force` will overwrite all files                    |
+| flatten     | enum  | --flatten                                     | `--flatten` will write all files to the specified directory, it will not copy subfolder structure. ` ` will copy files and the subfolder structure |
 
 ## Examples
 
@@ -194,6 +195,8 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 **copy-option:** `--no-clobber`
 
+**flatten:** `--flatten`
+
 **Target path naming convention:** `s3://linz-imagery/<region>/<city-or-sub-region>_<year>_<resolution>/<product>/<crs>/`
 
 ### Backup RGBI:
@@ -205,6 +208,8 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 **include:** Although only `.tif(f)` and `.tfw` files are required, there should not be any `.json` files in with the uploaded imagery, so this option can be left at the default.
 
 **copy-option:** `--no-clobber`
+
+**flatten:** `--flatten`
 
 # Tileset-validate
 

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: publish-copy-v1.0.0-46
+  name: publish-copy-v1.0.0-50
   namespace: argo
 spec:
   parallelism: 50
@@ -59,7 +59,7 @@ spec:
           - name: include
           - name: flatten
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-46-gf39162d
+        image: ghcr.io/linz/argo-tasks:v1.0.0-50-g007ed49
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -93,7 +93,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-46-gf39162d
+        image: ghcr.io/linz/argo-tasks:v1.0.0-50-g007ed49
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: publish-copy-v1.0.0-42
+  name: publish-copy-v1.0.0-46
   namespace: argo
 spec:
   parallelism: 50
@@ -22,6 +22,11 @@ spec:
         enum:
           - "--no-clobber"
           - "--force"
+      - name: flatten
+        value: "--flatten"
+        enum:
+          - "--flatten"
+          - ""
   templates:
     - name: main
       dag:
@@ -36,6 +41,8 @@ spec:
                   value: "{{workflow.parameters.target}}"
                 - name: include
                   value: "{{workflow.parameters.include}}"
+                - name: flatten
+                  value: "{{workflow.parameters.flatten}}"
           - name: copy
             template: copy
             arguments:
@@ -50,8 +57,9 @@ spec:
           - name: source
           - name: target
           - name: include
+          - name: flatten
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+        image: ghcr.io/linz/argo-tasks:v1.0.0-46-gf39162d
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -60,6 +68,7 @@ spec:
           [
             "create-manifest",
             "--verbose",
+            "{{inputs.parameters.flatten}}",
             "--include",
             "{{inputs.parameters.include}}",
             "--group",
@@ -84,7 +93,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+        image: ghcr.io/linz/argo-tasks:v1.0.0-46-gf39162d
         resources:
           requests:
             memory: 7.8Gi


### PR DESCRIPTION
In order to move the data from `linz-imagery-upload` to `linz-topographic-upload`

Tested successfully by copying all the existing data from linz-imagery-upload to linz-topographic-upload

This change will affect TDP so they should be warned of the changes and what it means for their workflows (run with --flatten option)