### PR TITLE
feat: add cutline option and container version bump TDE-487 TDE-602

### DIFF
--- a/workflows/imagery/README.md
+++ b/workflows/imagery/README.md
@@ -14,35 +14,37 @@ In addition, a Basemaps link is produced enabling visual QA.
 
 ## Workflow Input Parameters
 
-| Parameter      | Type  | Default                                                                                             | Description                                                                                                                      |
-| -------------- | ----- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| source         | str   | s3://linz-imagery-staging/test/sample                                                               | the uri (path) to the input tiffs                                                                                                |
-| include        | regex | .tiff?$                                                                                             | A regular expression to match object path(s) or name(s) from within the source path to include in standardising\*.               |
-| scale          | enum  | 500                                                                                                 | The scale of the TIFFs                                                                                                           |
-| group          | int   | 50                                                                                                  | The number of files to grouped into the pods (testing has recommended using 50 for large datasets).                              |
-| compression    | enum  | webp                                                                                                | Standardised file format                                                                                                         |
-| title          | str   | \*Region/District/City\* \*GSD\* \*Urban/Rural\* Aerial Photos (\*Year-Year\*)                      | Collection title                                                                                                                 |
-| description    | str   | Orthophotography within the \*Region Name\* region captured in the \*Year\*-\*Year\* flying season. | Collection description                                                                                                           |
-| start-datetime | str   | YYYY-MM-DD                                                                                          | Imagery start date (flown from), must be in default formatting                                                                   |
-| end-datetime   | str   | YYYY-MM-DD                                                                                          | Imagery end date (flown to), must be in default formatting                                                                       |
-| copy-option    | enum  | --no-clobber                                                                                        | `--no-clobber` will not overwrite files if the name and the file size in bytes are the same. `--force` will overwrite all files. |
+| Parameter                | Type  | Default                                                                                             | Description                                                                                                                      |
+| ------------------------ | ----- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| source                   | str   | s3://linz-imagery-staging/test/sample                                                               | the uri (path) to the input tiffs                                                                                                |
+| include                  | regex | .tiff?$                                                                                             | A regular expression to match object path(s) or name(s) from within the source path to include in standardising\*.               |
+| scale                    | enum  | 500                                                                                                 | The scale of the TIFFs                                                                                                           |
+| group                    | int   | 50                                                                                                  | The number of files to grouped into the pods (testing has recommended using 50 for large datasets).                              |
+| compression              | enum  | webp                                                                                                | Standardised file format                                                                                                         |
+| optional-cutline-s3-path | str   |                                                                                                     | S3 path to a FlatGeoBuf (`.fgb`) cutline file (optional, leave blank if no cutline)                                              |
+| title                    | str   | \*Region/District/City\* \*GSD\* \*Urban/Rural\* Aerial Photos (\*Year-Year\*)                      | Collection title                                                                                                                 |
+| description              | str   | Orthophotography within the \*Region Name\* region captured in the \*Year\*-\*Year\* flying season. | Collection description                                                                                                           |
+| start-datetime           | str   | YYYY-MM-DD                                                                                          | Imagery start date (flown from), must be in default formatting                                                                   |
+| end-datetime             | str   | YYYY-MM-DD                                                                                          | Imagery end date (flown to), must be in default formatting                                                                       |
+| copy-option              | enum  | --no-clobber                                                                                        | `--no-clobber` will not overwrite files if the name and the file size in bytes are the same. `--force` will overwrite all files. |
 
 \* This regex can be used to exclude paths as well, e.g. if there are RBG and RGBI directories, the following regex will only include TIFF files in the RGB directory: `RGB(?!I).*.tiff?$`. For more complicated exclusions, there is an `--exclude` parameter, which would need to be added to the Argo WorkflowTemplate.
 
 ### Example Input Parameters
 
-| Parameter      | Value                                                                                     |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| source         | s3://linz-imagery-upload/PRJ39741_BOPLASS_Imagery_2021-22/PRJ39741_03/01_GeoTiff/         |
-| include        | .tiff?$                                                                                   |
-| scale          | 2000                                                                                      |
-| group          | 50                                                                                        |
-| compression    | webp                                                                                      |
-| title          | Bay of Plenty 0.2m Rural Aerial Photos (2021-2022)                                        |
-| description    | Orthophotography within the Bay of Plenty region captured in the 2021-2022 flying season. |
-| start-datetime | 2021-12-02                                                                                |
-| end-datetime   | 2022-05-06                                                                                |
-| copy-option    | --no-clobber                                                                              |
+| Parameter                | Value                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| source                   | s3://linz-imagery-upload/PRJ39741_BOPLASS_Imagery_2021-22/PRJ39741_03/01_GeoTiff/         |
+| include                  | .tiff?$                                                                                   |
+| scale                    | 2000                                                                                      |
+| group                    | 50                                                                                        |
+| compression              | webp                                                                                      |
+| optional-cutline-s3-path | s3://linz-imagery-staging/cutline/bay-of-plenty_2021-2022.fgb                             |
+| title                    | Bay of Plenty 0.2m Rural Aerial Photos (2021-2022)                                        |
+| description              | Orthophotography within the Bay of Plenty region captured in the 2021-2022 flying season. |
+| start-datetime           | 2021-12-02                                                                                |
+| end-datetime             | 2022-05-06                                                                                |
+| copy-option              | --no-clobber                                                                              |
 
 ## Workflow Outputs
 
@@ -107,7 +109,7 @@ This was done to reduce the number of times gdalinfo is run and files are looped
 
 #### [Standardise](https://github.com/linz/topo-imagery/blob/master/scripts/standardising.py)
 
-Runs `gdal_translate` on the TIFF files.
+Runs `gdal_translate` on the TIFF files, applying a cutline (if supplied) to remove unwanted pixels.
 See [topo-imagery/scripts/gdal/gdal_preset.py](https://github.com/linz/topo-imagery/blob/master/scripts/gdal/gdal_preset.py) for gdal_translate options and arguments.
 
 #### [Non-Visual QA](https://github.com/linz/topo-imagery/blob/master/scripts/files/file_check.py)

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -40,6 +40,11 @@ spec:
         value: "YYYY-MM-DD"
       - name: end-datetime
         value: "YYYY-MM-DD"
+      - name: copy-option
+        value: "--no-clobber"
+        enum:
+          - "--no-clobber"
+          - "--force"
   templates:
     - name: main
       dag:
@@ -233,7 +238,12 @@ spec:
             memory: 7.8Gi
             cpu: 2000m
         command: [node, /app/index.js]
-        args: ["copy", "--no-clobber", "{{inputs.parameters.file}}"]
+        args:
+          [
+            "copy",
+            "{{workflow.parameters.copy-option}}",
+            "{{inputs.parameters.file}}",
+          ]
     - name: create-collection
       retryStrategy:
         limit: "2"
@@ -298,7 +308,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/basemaps/cli:v6.36.0-33-gc50b85cc
+        image: ghcr.io/linz/basemaps/cli:v6.38.0-5-g5d8e0bea
         resources:
           requests:
             cpu: 3000m
@@ -320,7 +330,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/basemaps/cli:v6.36.0-33-gc50b85cc
+        image: ghcr.io/linz/basemaps/cli:v6.38.0-5-g5d8e0bea
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: imagery-standardising-v0.2.0-60
+  name: imagery-standardising-v0.2.0.75
   namespace: argo
 spec:
   parallelism: 50
@@ -30,7 +30,8 @@ spec:
         enum:
           - "webp"
           - "lzw"
-          - "gray_webp"
+      - name: optional-cutline-s3-path
+        value: ""
       - name: title
         value: "*Region/District/City* *GSD* *Urban/Rural* Aerial Photos (*Year-Year*)"
       - name: description
@@ -39,11 +40,6 @@ spec:
         value: "YYYY-MM-DD"
       - name: end-datetime
         value: "YYYY-MM-DD"
-      - name: copy-option
-        value: "--no-clobber"
-        enum:
-          - "--no-clobber"
-          - "--force"
   templates:
     - name: main
       dag:
@@ -115,7 +111,7 @@ spec:
             depends: "get-location && create-overview"
     - name: aws-list
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+        image: ghcr.io/linz/argo-tasks:v1.0.0-50-g007ed49
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -139,7 +135,7 @@ spec:
               path: /tmp/file_list.json
     - name: generate-ulid
       script:
-        image: ghcr.io/linz/topo-imagery:v0.2.0-60-g58d4cd2
+        image: ghcr.io/linz/topo-imagery:v0.2.0-75-gcfa20cf
         command: [python]
         source: |
           import ulid
@@ -160,7 +156,7 @@ spec:
           - name: file
           - name: collection-id
       container:
-        image: ghcr.io/linz/topo-imagery:v0.2.0-60-g58d4cd2
+        image: ghcr.io/linz/topo-imagery:v0.2.0-75-gcfa20cf
         resources:
           requests:
             memory: 7.8Gi
@@ -185,6 +181,8 @@ spec:
           - "{{workflow.parameters.end-datetime}}"
           - "--collection-id"
           - "{{inputs.parameters.collection-id}}"
+          - "--cutline"
+          - "{{workflow.parameters.optional-cutline-s3-path}}"
       outputs:
         artifacts:
           - name: standardised_tiffs
@@ -196,7 +194,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+        image: ghcr.io/linz/argo-tasks:v1.0.0-50-g007ed49
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -229,18 +227,13 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+        image: ghcr.io/linz/argo-tasks:v1.0.0-50-g007ed49
         resources:
           requests:
             memory: 7.8Gi
             cpu: 2000m
         command: [node, /app/index.js]
-        args:
-          [
-            "copy",
-            "{{workflow.parameters.copy-option}}",
-            "{{inputs.parameters.file}}",
-          ]
+        args: ["copy", "--no-clobber", "{{inputs.parameters.file}}"]
     - name: create-collection
       retryStrategy:
         limit: "2"
@@ -251,7 +244,7 @@ spec:
           - name: collection-id
           - name: location
       container:
-        image: ghcr.io/linz/topo-imagery:v0.2.0-60-g58d4cd2
+        image: ghcr.io/linz/topo-imagery:v0.2.0-75-gcfa20cf
         resources:
           requests:
             memory: 7.8Gi
@@ -275,7 +268,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+        image: ghcr.io/linz/argo-tasks:v1.0.0-50-g007ed49
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH


### PR DESCRIPTION
Adds an optional `cutline` parameter and updates all containers to the latest version.
Also removes obsolete `gray_webp` compression option.