### PR TITLE
chore: update basemaps/cli container version and revert version number

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: imagery-standardising-v0.2.0.76
+  name: imagery-standardising-v0.2.0-75
   namespace: argo
 spec:
   parallelism: 50
@@ -314,7 +314,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/basemaps/cli:v6.36.0-33-gc50b85cc
+        image: ghcr.io/linz/basemaps/cli:v6.38.0-23-gd4715ac0
         resources:
           requests:
             cpu: 3000m
@@ -336,7 +336,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/basemaps/cli:v6.36.0-33-gc50b85cc
+        image: ghcr.io/linz/basemaps/cli:v6.38.0-23-gd4715ac0
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH


### PR DESCRIPTION
- Updates the basemaps/cli container version.
- Reverts the workflow version number back to `v0.2.0-75` to keep it in sync with the topo-imagery container. Version number was previously incremented to `v0.2.0-76` in #80 as I was unaware of the convention of keeping the standardising workflow and topo-imagery container version numbers in sync.