### PR TITLE
feat: use major version for basemaps

### DIFF
--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -9,7 +9,7 @@ spec:
   arguments:
     parameters:
       - name: version-basemaps-cli
-        value: "v6.36.0-3-g59a3e7fa"
+        value: "v6"
       - name: location
         value: "s3://bucket/path/to"
   templates:

--- a/workflows/basemaps/create-overview-all.yaml
+++ b/workflows/basemaps/create-overview-all.yaml
@@ -12,7 +12,7 @@ spec:
   arguments:
     parameters:
       - name: version-basemaps-cli
-        value: "v6.38.0-19-gc9865784"
+        value: "v6"
   templates:
     - name: main
       dag:

--- a/workflows/basemaps/create-overview.yaml
+++ b/workflows/basemaps/create-overview.yaml
@@ -9,7 +9,7 @@ spec:
   arguments:
     parameters:
       - name: version-basemaps-cli
-        value: "v6.38.0-19-gc9865784"
+        value: "v6"
       - name: source
         value: ""
       - name: output

--- a/workflows/basemaps/imagery-import.yaml
+++ b/workflows/basemaps/imagery-import.yaml
@@ -11,7 +11,7 @@ spec:
   arguments:
     parameters:
       - name: version-basemaps-cli
-        value: "v6.38.0-19-gc9865784"
+        value: "v6"
       - name: source
         value: ""
       - name: category

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -10,7 +10,7 @@ spec:
       - name: version-argo-tasks
         value: "v2"
       - name: version-basemaps-cli
-        value: "v6.38.0-23-gd4715ac0"
+        value: "v6"
       - name: layer
         value: "104687"
       - name: include

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -19,7 +19,7 @@ spec:
       - name: version-argo-tasks
         value: "v2"
       - name: version-basemaps-cli
-        value: "v6.38.0-23-gd4715ac0"
+        value: "v6"
       - name: version-topo-imagery
         value: "v0"
       - name: source


### PR DESCRIPTION
Now `basemaps` uses major version tags!
https://github.com/linz/basemaps/pkgs/container/basemaps%2Fcli