### PR TITLE
chore: default imagePullPolicy to Always for all tasks TDE-527

### DIFF
--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -12,6 +12,9 @@ spec:
         value: "v6"
       - name: location
         value: "s3://bucket/path/to"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -28,7 +31,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/basemaps/create-overview-all.yaml
+++ b/workflows/basemaps/create-overview-all.yaml
@@ -13,6 +13,9 @@ spec:
     parameters:
       - name: version-basemaps-cli
         value: "v6"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -48,7 +51,6 @@ spec:
           - name: source
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         resources:
           requests:
             cpu: 3000m

--- a/workflows/basemaps/create-overview.yaml
+++ b/workflows/basemaps/create-overview.yaml
@@ -14,6 +14,9 @@ spec:
         value: ""
       - name: output
         value: ""
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -33,7 +36,6 @@ spec:
           - name: output
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         resources:
           requests:
             cpu: 3000m

--- a/workflows/basemaps/imagery-import.yaml
+++ b/workflows/basemaps/imagery-import.yaml
@@ -51,6 +51,9 @@ spec:
       secret:
         secretName: github
 
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -114,7 +117,6 @@ spec:
           - name: aligned-level
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -164,7 +166,6 @@ spec:
           - name: names
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -196,7 +197,6 @@ spec:
           - name: path
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         resources:
           requests:
             cpu: 3000m
@@ -221,7 +221,6 @@ spec:
           - name: category
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         command: [node, index.cjs]
         env:
           - name: GITHUB_API_TOKEN

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -17,6 +17,9 @@ spec:
         value: ""
       - name: exclude
         value: "nz_satellite"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -48,7 +51,6 @@ spec:
           - name: layer
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -73,6 +75,7 @@ spec:
             path: /tmp/geopackage.gpkg
       container:
         image: osgeo/gdal:alpine-small-3.6.1
+        imagePullPolicy: IfNotPresent
         command: [ogr2ogr]
         args:
           ["-f", "FlatGeobuf", "/tmp/flatGeobuf.fgb", "/tmp/geopackage.gpkg"]
@@ -88,7 +91,6 @@ spec:
             path: /tmp/flatGeobuf.fgb
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -25,6 +25,9 @@ spec:
           - "--no-clobber"
           - "--force"
           - "--force-no-clobber"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -55,7 +58,6 @@ spec:
           - name: include
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -89,7 +91,6 @@ spec:
           - name: file
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/imagery/standardising-publish.yaml
+++ b/workflows/imagery/standardising-publish.yaml
@@ -61,6 +61,9 @@ spec:
           - "--no-clobber"
           - "--force"
           - "--force-no-clobber"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -152,7 +155,6 @@ spec:
     - name: aws-list
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -177,7 +179,6 @@ spec:
     - name: generate-ulid
       script:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         command: [python]
         source: |
           import ulid
@@ -199,7 +200,6 @@ spec:
           - name: collection-id
       container:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -238,7 +238,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -273,7 +272,6 @@ spec:
           - name: file
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -296,7 +294,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -321,7 +318,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -340,7 +336,6 @@ spec:
           - name: include
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -374,7 +369,6 @@ spec:
           - name: file
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -404,7 +398,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         resources:
           requests:
             cpu: 3000m
@@ -427,7 +420,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -58,6 +58,9 @@ spec:
           - "--no-clobber"
           - "--force"
           - "--force-no-clobber"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -130,7 +133,6 @@ spec:
     - name: aws-list
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -155,7 +157,6 @@ spec:
     - name: generate-ulid
       script:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         command: [python]
         source: |
           import ulid
@@ -177,7 +178,6 @@ spec:
           - name: collection-id
       container:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -216,7 +216,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -251,7 +250,6 @@ spec:
           - name: file
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -274,7 +272,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi
@@ -299,7 +296,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -330,7 +326,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         resources:
           requests:
             cpu: 3000m
@@ -353,7 +348,6 @@ spec:
           - name: location
       container:
         image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
-        imagePullPolicy: Always
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/imagery/tests.yaml
+++ b/workflows/imagery/tests.yaml
@@ -11,11 +11,13 @@ spec:
     parameters:
       - name: version-topo-imagery
         value: "latest"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: test-script
       script:
         image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
-        imagePullPolicy: Always
         command: [python]
         source: |
           import sys

--- a/workflows/imagery/tileset-validate.yaml
+++ b/workflows/imagery/tileset-validate.yaml
@@ -14,6 +14,9 @@ spec:
         value: "v2"
       - name: processed-imagery-path
         value: "s3://linz-imagery-staging/test/tileset-validate/flat"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -34,7 +37,6 @@ spec:
           - name: processed-imagery-path
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -14,6 +14,9 @@ spec:
         value: "v2"
       - name: stac-file-path
         value: "s3://linz-imagery-staging/test/stac-validate/collection.json"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -34,7 +37,6 @@ spec:
           - name: stac-file-path
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/test/env.yaml
+++ b/workflows/test/env.yaml
@@ -8,5 +8,4 @@ spec:
     - name: env
       container:
         image: ghcr.io/linz/topo-imagery:latest
-        imagePullPolicy: Always
         command: [env]

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -22,6 +22,9 @@ spec:
           - "--no-clobber"
           - "--force"
           - "--force-no-clobber"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -49,7 +52,6 @@ spec:
           - name: filter
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -81,7 +83,6 @@ spec:
           - name: file
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/test/list.yaml
+++ b/workflows/test/list.yaml
@@ -11,6 +11,9 @@ spec:
         value: "latest"
       - name: uri
         value: "s3://linz-imagery-staging/test/sample/"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   templates:
     - name: main
       dag:
@@ -30,7 +33,6 @@ spec:
           - name: include
       container:
         image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
-        imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH


### PR DESCRIPTION
Currently a solution that works to default `ImagePullPolicy` to `Always`.
Had a try specifying in the `configmaps` created while deploying Argo with CDK in the `WorkflowDefaults` but without success.