### PR TITLE
feat: add standardising output TDE-615

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -60,6 +60,7 @@ spec:
           - "--force-no-clobber"
   templates:
     - name: main
+
       dag:
         tasks:
           - name: aws-list

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -60,7 +60,6 @@ spec:
           - "--force-no-clobber"
   templates:
     - name: main
-
       dag:
         tasks:
           - name: aws-list
@@ -128,9 +127,14 @@ spec:
                   value: "{{tasks.get-location.outputs.parameters.location}}"
             template: create-config
             depends: "get-location && create-overview"
+      outputs:
+        parameters:
+          - name: target
+            valueFrom:
+              parameter: "{{tasks.get-location.outputs.parameters.location}}"
     - name: aws-list
       container:
-        image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
+        image: "ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}"
         imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
@@ -155,7 +159,7 @@ spec:
               path: /tmp/file_list.json
     - name: generate-ulid
       script:
-        image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
+        image: "ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}"
         imagePullPolicy: Always
         command: [python]
         source: |
@@ -177,7 +181,7 @@ spec:
           - name: file
           - name: collection-id
       container:
-        image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
+        image: "ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}"
         imagePullPolicy: Always
         resources:
           requests:
@@ -216,7 +220,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
+        image: "ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}"
         imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
@@ -251,7 +255,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
+        image: "ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}"
         imagePullPolicy: Always
         resources:
           requests:
@@ -274,7 +278,7 @@ spec:
           - name: collection-id
           - name: location
       container:
-        image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
+        image: "ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}"
         imagePullPolicy: Always
         resources:
           requests:
@@ -299,7 +303,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
+        image: "ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}"
         imagePullPolicy: Always
         command: [node, /app/index.js]
         env:
@@ -330,7 +334,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
+        image: "ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}"
         imagePullPolicy: Always
         resources:
           requests:
@@ -353,7 +357,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}
+        image: "ghcr.io/linz/basemaps/cli:{{workflow.parameters.version-basemaps-cli}}"
         imagePullPolicy: Always
         command: [node, index.cjs]
         env:


### PR DESCRIPTION
- Add standardising outputs in preparation for using the output for the new standardising-publish workflow.
- Wrap the container variables in quotes as otherwise they don't resolve when sent through from a workflow.