### PR TITLE
fix: use sh to allow path globbing to find the geopackage

### DIFF
--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -65,19 +65,19 @@ spec:
       outputs:
         artifacts:
           - name: geopackage
-            path: /tmp/lds-layer
+            path: /tmp/lds-layer/
 
     - name: transform
       inputs:
         artifacts:
           - name: geopackage
-            path: /tmp/lds-layer
+            path: /tmp/
       container:
         image: osgeo/gdal:alpine-small-3.6.1
         imagePullPolicy: IfNotPresent
-        command: [ogr2ogr]
+        command: [sh]
         args:
-          ["-f", "FlatGeobuf", "/tmp/flatGeobuf.fgb", "/tmp/lds-layer/*.gpkg"]
+          ["-c", "ogr2ogr -f FlatGeobuf tmp/flatGeobuf.fgb tmp/*.gpkg"]
       outputs:
         artifacts:
           - name: flatGeobuf

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -76,8 +76,7 @@ spec:
         image: osgeo/gdal:alpine-small-3.6.1
         imagePullPolicy: IfNotPresent
         command: [sh]
-        args:
-          ["-c", "ogr2ogr -f FlatGeobuf tmp/flatGeobuf.fgb tmp/*.gpkg"]
+        args: ["-c", "ogr2ogr -f FlatGeobuf tmp/flatGeobuf.fgb tmp/*.gpkg"]
       outputs:
         artifacts:
           - name: flatGeobuf


### PR DESCRIPTION
since the geopackage does not have a fixed name, a glob "*.gpkg" is a good way of allowing ogr to find it.

however globbing is done by the shell, so switching to "sh" as the command allows the glob to expand then pass it into ogr2ogr
