### PR TITLE
fix: retry create overviews and fix basemaps-cli version

### DIFF
--- a/workflows/basemaps/create-overview-all.yaml
+++ b/workflows/basemaps/create-overview-all.yaml
@@ -46,6 +46,8 @@ spec:
               path: "/tmp/imagery.json"
 
     - name: create-overview
+      retryStrategy:
+        limit: "2"
       inputs:
         parameters:
           - name: source

--- a/workflows/basemaps/create-overview.yaml
+++ b/workflows/basemaps/create-overview.yaml
@@ -30,6 +30,8 @@ spec:
                 - name: output
                   value: "{{workflow.parameters.output}}"
     - name: create-overview
+      retryStrategy:
+        limit: "2"
       inputs:
         parameters:
           - name: source

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -19,7 +19,7 @@ spec:
       - name: version-argo-tasks
         value: "v2"
       - name: version-basemaps-cli
-        value: "v6"
+        value: "v6.39.0-15-g3e982390"
       - name: version-topo-imagery
         value: "v1"
       - name: source

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -450,6 +450,8 @@ spec:
             valueFrom:
               path: "/tmp/location"
     - name: create-overview
+      retryStrategy:
+        limit: "2"
       inputs:
         parameters:
           - name: location


### PR DESCRIPTION
Retry on create-overviews failure.
Basemaps CLI version needs to be set for the create-overview fix.
Can set it back to generic version after next `basemaps-cli` release.