### PR TITLE
feat: add optional scale TDE-674

### DIFF
--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -35,6 +35,7 @@ spec:
           - "5000"
           - "10000"
           - "50000"
+          - "None"
       - name: group
         value: "50"
       - name: compression


### PR DESCRIPTION
Since scale is optional for standardising imagery (https://github.com/linz/topo-imagery/pull/372)