### PR TITLE
feat: use ecr topo imagery containers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -73,7 +73,7 @@ Environment variables can be set in the containers as below, which is setting th
 
 ```yaml
 container:
-  image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+  image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-latest
   command: [node, /app/index.js]
   env:
     - name: AWS_ROLE_CONFIG_PATH
@@ -149,7 +149,7 @@ Two example workflow tasks requesting specific resources (memory and CPU) from t
     parameters:
       - name: file
   container:
-    image: ghcr.io/linz/argo-tasks:v1.0.0-42-gdbb002b
+    image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-latest
     resources:
       requests:
         memory: 7.8Gi

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -130,7 +130,7 @@ Two example workflow tasks requesting specific resources (memory and CPU) from t
       - name: file
       - name: collection-id
   container:
-    image: ghcr.io/linz/topo-imagery:v0.2.0-60-g58d4cd2
+    image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-latest
     resources:
       requests:
         memory: 7.8Gi

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -52,7 +52,7 @@ spec:
         parameters:
           - name: layer
       container:
-        image: ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
         command: [node, index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -80,7 +80,7 @@ spec:
           - name: group
           - name: group-size
       container:
-        image: "ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -115,7 +115,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: "ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -264,7 +264,7 @@ spec:
               parameter: "{{tasks.get-location.outputs.parameters.location}}"
     - name: aws-list
       container:
-        image: "ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -351,7 +351,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: "ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -385,7 +385,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: "ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         resources:
           requests:
             memory: 7.8Gi
@@ -437,7 +437,7 @@ spec:
         parameters:
           - name: location
       container:
-        image: "ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -288,7 +288,7 @@ spec:
               path: /tmp/file_list.json
     - name: generate-ulid
       script:
-        image: "ghcr.io/linz/topo-imagery:{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
         command: [python]
         source: |
           import ulid
@@ -309,7 +309,7 @@ spec:
           - name: file
           - name: collection-id
       container:
-        image: "ghcr.io/linz/topo-imagery:{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
         resources:
           requests:
             memory: 7.8Gi
@@ -407,7 +407,7 @@ spec:
           - name: collection-id
           - name: location
       container:
-        image: "ghcr.io/linz/topo-imagery:{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/imagery/tests.yaml
+++ b/workflows/imagery/tests.yaml
@@ -17,7 +17,7 @@ spec:
   templates:
     - name: test-script
       script:
-        image: ghcr.io/linz/topo-imagery:{{workflow.parameters.version-topo-imagery}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-{{workflow.parameters.version-topo-imagery}}
         command: [python]
         source: |
           import sys

--- a/workflows/imagery/tileset-validate.yaml
+++ b/workflows/imagery/tileset-validate.yaml
@@ -36,7 +36,7 @@ spec:
         parameters:
           - name: processed-imagery-path
       container:
-        image: ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -36,7 +36,7 @@ spec:
         parameters:
           - name: stac-file-path
       container:
-        image: ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/test/env.yaml
+++ b/workflows/test/env.yaml
@@ -7,5 +7,5 @@ spec:
   templates:
     - name: env
       container:
-        image: ghcr.io/linz/topo-imagery:latest
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-latest
         command: [env]

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -51,7 +51,7 @@ spec:
           - name: uri
           - name: filter
       container:
-        image: ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -82,7 +82,7 @@ spec:
         parameters:
           - name: file
       container:
-        image: ghcr.io/linz/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
         resources:
           requests:
             memory: 7.8Gi

--- a/workflows/test/list.yaml
+++ b/workflows/test/list.yaml
@@ -32,7 +32,7 @@ spec:
           - name: uri
           - name: include
       container:
-        image: ghcr.io/linz/argo-tasks:{{workflow.parameters.version-argo-tasks}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{workflow.parameters.version-argo-tasks}}
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH


### PR DESCRIPTION
update workflows to use ECR container versions of topo-imagery and argo-tasks

**Test run results:**
```
18m         Normal    Pulled                  pod/test-mdavidson-ecr-aws-list-2h2px-nf97p-aws-list-4146989921   Successfully pulled image "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-latest" in 15.565196347s

91s         Normal    Pulled                  pod/test-mdavidson-ecr-imagery-standardising-7tgtf-standardise-validate-678835351   Successfully pulled image "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-latest" in 12.104966455s
91s         Normal    Pulled                  pod/test-mdavidson-ecr-imagery-standardising-7tgtf-standardise-validate-678835351   Successfully pulled image "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-latest" in 12.104966455s
```
