### PR TITLE
fix: stac-validate fails on input parameter parsing

### DIFF
--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -45,5 +45,5 @@ spec:
           [
             "stac-validate",
             "--recursive",
-            "{{=sprig.trim(inputs.parameters.stac-file-path)}}",
+            "{{=sprig.trim(inputs.parameters['stac-file-path'])}}",
           ]


### PR DESCRIPTION
When using sprig function, needs to address the parameter differently: https://argoproj.github.io/argo-workflows/variables/#expression