### PR TITLE
fix: use ecr/ghcr and not docker.io to bypass rate limit

### DIFF
--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -75,7 +75,7 @@ spec:
           - name: geopackage
             path: /tmp/
       container:
-        image: osgeo/gdal:alpine-small-3.6.1
+        image: ghcr.io/osgeo/gdal:alpine-small-3.7.0
         imagePullPolicy: IfNotPresent
         command: [sh]
         args: ["-c", "ogr2ogr -f FlatGeobuf tmp/flatGeobuf.fgb tmp/*.gpkg"]

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -391,7 +391,7 @@ spec:
           ]
     - name: get-location
       script:
-        image: node:alpine
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         command: [node]
         source: |
           const fs = require('fs');


### PR DESCRIPTION
Starting to see 


> ImagePull: rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/debian:latest": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/debian/manifests/sha256:63d62ae233b588d6b426b7b072d79d1306bfd02a72bff1fc045b8511cc89ee09: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit