### PR TITLE
fix: update versions on standardise-publish-import workflow TDE-784

### DIFF
--- a/workflows/imagery/standardising-publish-import.yaml
+++ b/workflows/imagery/standardising-publish-import.yaml
@@ -37,11 +37,11 @@ spec:
       - name: retile
         value: "false"
       - name: version-argo-tasks
-        value: "v2.9"
+        value: "v2"
       - name: version-basemaps-cli
         value: "v6"
       - name: version-topo-imagery
-        value: "v2"
+        value: "v3"
   templateDefaults:
     container:
       imagePullPolicy: Always


### PR DESCRIPTION
Adding two version updates that were missed in https://github.com/linz/topo-workflows/pull/142/files