### PR TITLE
fix: force containers in templates to be pulled

### DIFF
--- a/templates/argo-tasks/group.yml
+++ b/templates/argo-tasks/group.yml
@@ -5,6 +5,9 @@ metadata:
   # see https://github.com/linz/argo-tasks#group
   name: tpl-at-group
 spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   entrypoint: main
   templates:
     - name: main

--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -5,6 +5,9 @@ metadata:
   # see https://github.com/linz/argo-tasks#tileindex-validate
   name: tpl-at-tile-index-validate
 spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
   entrypoint: main
   templates:
     - name: main


### PR DESCRIPTION
#### Why

Argo will not automatically re-pull docker container with tags of `:argo-tasks-latest` or `:v2` which means sometimes containers will be older versions, the expected `:argo-tasks-latest` or `:v2`

This can cause stale containers to live for a long time on long running machines such as the controller nodes which are up for months at a time, sometimes causing very old containers to run.

#### Description

All workflows need a `imagePullPolicy: Always` to force pull all containers, this will not download the container if it already exists it will only validate that the local hash is the same as the remote hash.