### PR TITLE
fix: add publish-copy bulkcopy semaphore

### DIFF
--- a/config/semaphores.yml
+++ b/config/semaphores.yml
@@ -6,4 +6,4 @@ metadata:
 data:
   standardising: "2" # Limit of how many standardising workflow instances can run at the same time
   bulk: "4" # Limit of how many bulk workflow instances can run at the same time
-  publish_copy: "8" # Limit of how many publish-copy workflow instances can run at the same time
+  bulkcopy: "8" # Limit of how many publish-copy workflow instances can run at the same time

--- a/config/semaphores.yml
+++ b/config/semaphores.yml
@@ -6,3 +6,4 @@ metadata:
 data:
   standardising: "2" # Limit of how many standardising workflow instances can run at the same time
   bulk: "4" # Limit of how many bulk workflow instances can run at the same time
+  publish_copy: "8" # Limit of how many publish-copy workflow instances can run at the same time

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -9,6 +9,11 @@ spec:
   nodeSelector:
     karpenter.sh/capacity-type: "spot"
   entrypoint: main
+  synchronization:
+    semaphore:
+      configMapKeyRef:
+        name: semaphores
+        key: bulkcopy
   arguments:
     parameters:
       - name: version-argo-tasks


### PR DESCRIPTION
To limit the number of publish-copy workflows that can run concurrently to 8