### PR TITLE
feat: add thumbnail workflow for topo maps TDE-840

### DIFF
--- a/workflows/topo-maps/create-thumbnails.yaml
+++ b/workflows/topo-maps/create-thumbnails.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: generate-thumbnails-topo50-250
+  namespace: argo
+spec:
+  parallelism: 50
+  nodeSelector:
+    karpenter.sh/capacity-type: "spot"
+  entrypoint: main
+  arguments:
+    parameters:
+      # FIXME: Should use camelCase or underscore?
+      - name: version-argo-tasks
+        value: "v2"
+      - name: version-topo-imagery
+        value: "v3"
+      - name: source
+        value: "s3://linz-workflow-artifacts/mdavidson/test-topo-maps/topo50/"
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: aws-list
+            template: aws-list
+
+          - name: create-thumbnails
+            template: create-thumbnails
+            arguments:
+              parameters:
+                - name: target
+                  value: "{{tasks.get-location.outputs.parameters.location}}intermediate/" #TODO - is this the target
+              artifacts:
+                - name: files
+                  from: "{{ tasks.aws-list.outputs.artifacts.files }}"
+            depends: "aws-list && get-location"
+
+          - name: get-location
+            template: get-location
+
+      outputs:
+        parameters:
+          - name: target
+            valueFrom:
+              parameter: "{{tasks.get-location.outputs.parameters.location}}"
+      # END TEMPLATE `main`
+
+    - name: aws-list
+      inputs:
+      container:
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{workflow.parameters.version-argo-tasks}}
+        command: [node, /app/index.js]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          [
+            "list",
+            "--verbose",
+            "--include",
+            ".*.*.tif?$",
+            "--group",
+            "1000",
+            "--output",
+            "/tmp/file_list.json",
+            "{{workflow.parameters.source}}",
+          ]
+      outputs:
+        artifacts:
+          - name: files
+            path: /tmp/file_list.json
+
+    - name: create-thumbnails
+      retryStrategy:
+        limit: "2"
+      nodeSelector:
+        karpenter.sh/capacity-type: "spot"
+      inputs:
+        parameters:
+          - name: target
+        artifacts:
+          - name: files
+            path: /tmp/file_list.json
+      container:
+        image: "ghcr.io/mdavidson17/topo-imagery:latest"
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 15000m
+            ephemeral-storage: 3Gi
+        volumeMounts:
+          - name: ephemeral
+            mountPath: "/tmp"
+        command:
+          - python
+          - "/app/scripts/thumbnails.py"
+        args:
+          - "--from-file"
+          - "/tmp/file_list.json"
+          - "--target"
+          - "{{inputs.parameters.target}}"
+
+    - name: get-location
+      script:
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        command: [node]
+        source: |
+          const fs = require('fs');
+          const loc = JSON.parse(process.env['ARGO_TEMPLATE']).archiveLocation.s3;
+          const key = loc.key.replace('{{pod.name}}','');
+          fs.writeFileSync('/tmp/location', `s3://${loc.bucket}/${key}`);
+      outputs:
+        parameters:
+          - name: location
+            valueFrom:
+              path: "/tmp/location"
+
+  volumes:
+    - name: ephemeral
+      emptyDir: {}

--- a/workflows/util/README.md
+++ b/workflows/util/README.md
@@ -29,6 +29,8 @@ The output thumbnails will be located within the `./intermediate/` directory of 
 graph TD;
     aws-list-->create-thumbnails;
     get-location-->create-thumbnails;
+    create-thumbnails-->publish-source;
+    create-thumbnails-->publish-thumbnails;
 ```
 
 ### [aws-list](https://github.com/linz/argo-tasks/blob/master/src/commands/list/list.ts)

--- a/workflows/util/README.md
+++ b/workflows/util/README.md
@@ -1,0 +1,44 @@
+# Contents:
+
+- [create-thumbnails](#Create-Thumbnails)
+
+# Create-Thumbnails
+
+This workflow generates thumbnails for the topo50 and topo250 GeoTiffs and TIFF.
+The thumbnails are used on the LINZ website at the [Topo50](https://www.linz.govt.nz/products-services/maps/new-zealand-topographic-maps/topo50-map-chooser) and [Topo250](https://www.linz.govt.nz/products-services/maps/new-zealand-topographic-maps/topo250-map-chooser) Map Chooser Pages.
+
+Thumbnailing uses two gdal_translate steps.
+Upon completion all standardised TIFF and STAC files will be located within the `./intermediate/` directory of the workflow in the artifacts bucket. From here the thumbnails can be moved to `s3://linz-topographic` using the publish-copy workflow.
+
+## Workflow Input Parameters
+
+| Parameter | Type | Default                           | Description                       |
+| --------- | ---- | --------------------------------- | --------------------------------- |
+| source    | str  | s3://linz-topgraphic/maps/topo50/ | the uri (path) to the input tiffs |
+
+## Workflow Outputs
+
+The output thumbnails will be located within the `./intermediate/` directory of the workflow in the artifacts bucket.
+
+## Workflow Description
+
+```mermaid
+graph TD;
+    aws-list-->create-thumbnails;
+    get-location-->create-thumbnails;
+```
+
+### [aws-list](https://github.com/linz/argo-tasks/blob/master/src/commands/list/list.ts)
+
+Recursively loops through the provided source path and lists all the files within this location. Some listing parameters are currently hard-coded due to the current bespoke purpose of this workflow:
+
+- group: `"2000"`
+- include: `".*.*.tif?$"`
+
+### [get-location](./standardising.yaml)
+
+Finds the output location of this workflow within the artifacts bucket.
+
+### [create-thumbnails](https://github.com/linz/topo-imagery/blob/master/scripts/thumbnails.py)
+
+Runs the bespoke gdal_translate commands to generate thumbnails of the topo50 & topo250 Maps.

--- a/workflows/util/README.md
+++ b/workflows/util/README.md
@@ -12,9 +12,12 @@ Upon completion all standardised TIFF and STAC files will be located within the 
 
 ## Workflow Input Parameters
 
-| Parameter | Type | Default                           | Description                       |
-| --------- | ---- | --------------------------------- | --------------------------------- |
-| source    | str  | s3://linz-topgraphic/maps/topo50/ | the uri (path) to the input tiffs |
+| Parameter   | Type | Default                           | Description                                                                                                                                                      |
+| ----------- | ---- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| source      | str  | s3://linz-topgraphic/maps/topo50/ | the uri (path) to the input tiffs                                                                                                                                |
+| target      | str  | s3://linz-                        | the target uri (path) to copy the input and thumbnails                                                                                                           |
+| transform   | str  | f                                 | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
+| copy-option | str  | no-clobber                        | `--no-clobber` Skip overwriting existing files. `--force` Overwrite all files. `--force-no-clobber` Overwrite only changed files, skip unchanged files. tiffs    |
 
 ## Workflow Outputs
 

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: generate-thumbnails-topo50-250
+  name: create-thumbnails
   namespace: argo
 spec:
   parallelism: 50
@@ -28,12 +28,12 @@ spec:
           - name: aws-list
             template: aws-list
 
-          - name: create-thumbnails
-            template: create-thumbnails
+          - name: thumbnails
+            template: thumbnails
             arguments:
               parameters:
                 - name: target
-                  value: "{{tasks.get-location.outputs.parameters.location}}intermediate/" #TODO - is this the target
+                  value: "{{tasks.get-location.outputs.parameters.location}}thumbnails/"
               artifacts:
                 - name: files
                   from: "{{ tasks.aws-list.outputs.artifacts.files }}"
@@ -74,7 +74,7 @@ spec:
           - name: files
             path: /tmp/file_list.json
 
-    - name: create-thumbnails
+    - name: thumbnails
       retryStrategy:
         limit: "2"
       nodeSelector:

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -17,7 +17,13 @@ spec:
       - name: version-topo-imagery
         value: "v3"
       - name: source
-        value: "s3://linz-topographic/maps/topo50/"
+        value: "s3://linz-topographic-upload/maps/topo50/"
+      - name: target
+        value: "s3://linz-"
+      - name: transform
+        value: "f"
+      - name: copy-option
+        value: "--no-clobber"
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -27,6 +33,9 @@ spec:
         tasks:
           - name: aws-list
             template: aws-list
+
+          - name: get-location
+            template: get-location
 
           - name: thumbnails
             template: thumbnails
@@ -39,8 +48,37 @@ spec:
                   from: "{{ tasks.aws-list.outputs.artifacts.files }}"
             depends: "aws-list && get-location"
 
-          - name: get-location
-            template: get-location
+          - name: publish-source
+            templateRef:
+              name: publish-copy
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: "{{workflow.parameters.source}}"
+                - name: include
+                  value: ".*.*.tif?$"
+                - name: group
+                  value: "1000"
+                - name: group-size
+                  value: "100Gi"
+            depends: "thumbnails"
+
+          - name: publish-thumbnails
+            templateRef:
+              name: publish-copy
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: "{{tasks.get-location.outputs.parameters.location}}thumbnails/"
+                - name: include
+                  value: ".jpg?$"
+                - name: group
+                  value: "1000"
+                - name: group-size
+                  value: "100Gi"
+            depends: "thumbnails"
 
       outputs:
         parameters:

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -64,7 +64,7 @@ spec:
             "--include",
             ".*.*.tif?$",
             "--group",
-            "1000",
+            "2000",
             "--output",
             "/tmp/file_list.json",
             "{{workflow.parameters.source}}",

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -79,12 +79,6 @@ spec:
                 - name: group-size
                   value: "100Gi"
             depends: "thumbnails"
-
-      outputs:
-        parameters:
-          - name: target
-            valueFrom:
-              parameter: "{{tasks.get-location.outputs.parameters.location}}"
       # END TEMPLATE `main`
 
     - name: aws-list

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -17,7 +17,7 @@ spec:
       - name: version-topo-imagery
         value: "v3"
       - name: source
-        value: "s3://linz-workflow-artifacts/mdavidson/test-topo-maps/topo50/"
+        value: "s3://linz-topographic/maps/topo50/"
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -86,7 +86,7 @@ spec:
           - name: files
             path: /tmp/file_list.json
       container:
-        image: "ghcr.io/mdavidson17/topo-imagery:latest"
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-{{=sprig.trim(workflow.parameters['version-topo-imagery'])}}"
         resources:
           requests:
             memory: 7.8Gi


### PR DESCRIPTION
Thumbnail workflow created for the processing of the topo50 and 250 maps

**971** topo50 thumbnails in 8m31s (including pod pending time):
- [workflow](https://argo.linzaccess.com/workflows/argo/generate-thumbnails-topo50-250-44q4g?tab=workflow&nodeId=artifact:s3:s3.amazonaws.com:linz-workflow-artifacts:2023-08/22-generate-thumbnails-topo50-250-44q4g/)
- `s3://linz-workflow-artifacts/2023-08/22-generate-thumbnails-topo50-250-44q4g/intermediate/`