### PR TITLE
feat: update default target values for basemaps import BM-822

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -25,10 +25,10 @@ spec:
 
       - name: target
         description: Target location for output COGs
-        value: "linz-basemaps"
+        value: "s3://linz-basemaps"
         enum:
-          - "linz-basemaps"
-          - "linz-basemaps-staging"
+          - "s3://linz-basemaps"
+          - "s3://linz-basemaps-staging"
 
       - name: tile_matrix
         description: Output tile matrix, ";" separated list

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -25,10 +25,10 @@ spec:
 
       - name: target
         description: Target location for output COGs
-        value: "s3://linz-basemaps"
+        value: "s3://linz-basemaps/"
         enum:
-          - "s3://linz-basemaps"
-          - "s3://linz-basemaps-staging"
+          - "s3://linz-basemaps/"
+          - "s3://linz-basemaps-staging/"
 
       - name: tile_matrix
         description: Output tile matrix, ";" separated list


### PR DESCRIPTION
#### Description

Changes the defaults for basemaps imagery import cogify workflow to be full s3:// locations.

#### Intention

The previous values were taken from the non-cogify import workflow, which used the `make-cog` command. This has a magic `--aws` flag which transforms the targets into s3:// bucket locations. The equivalent cogify commands on the other hand require the actual path itself.

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
