### PR TITLE
fix: update basemaps-imagery-import-cogify metadata for WorkflowTemplate BM-822

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  generateName: basemaps-imagery-import-cogify-
+  name: basemaps-imagery-import-cogify
   namespace: argo
 spec:
   parallelism: 100


### PR DESCRIPTION
#### Description

Use `name` key not `generateName` in the metadata section for `basemaps-imagery-import-cogify` workflow template. This now matches the metadata sections for other workflow templates which use `name` not `generateName`.

#### Intention

While the yaml file passed `argo lint` and was able to be merged, it failed deployment to the argo server ([see build logs](https://github.com/linz/topo-workflows/actions/runs/5944408541/job/16121623608)) with the following error:
```
error: from basemaps-imagery-import-cogify-: cannot use generate name with apply
```

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
