### PR TITLE
feat: add write permissions for basemaps buckets BM-822

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -185,7 +185,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
+            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
         args:
           - "cover"
           - "--tile-matrix={{ inputs.parameters.tile_matrix }}"
@@ -228,7 +228,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
+            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
         args:
           - "create"
           - "--from-file={{= inputs.artifacts.covering_grouped.path }}{{inputs.parameters.covering_grouped_id}}.json"
@@ -244,7 +244,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
+            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
         args:
           - "config"
           - "{{ inputs.parameters.path }}"
@@ -276,7 +276,7 @@ spec:
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
+            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
         args:
           - "-V"
           - "create-overview"

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -185,7 +185,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
         args:
           - "cover"
           - "--tile-matrix={{ inputs.parameters.tile_matrix }}"
@@ -228,7 +228,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
         args:
           - "create"
           - "--from-file={{= inputs.artifacts.covering_grouped.path }}{{inputs.parameters.covering_grouped_id}}.json"
@@ -244,7 +244,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
         args:
           - "config"
           - "{{ inputs.parameters.path }}"
@@ -276,7 +276,7 @@ spec:
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.json,s3://linz-bucket-config/config-write.basemaps.json
         args:
           - "-V"
           - "create-overview"


### PR DESCRIPTION
#### Description

Adds ability for `basemaps-imagery-import-cogify` workflow to write to Basemaps buckets.

#### Intention

Testing was done outputting too `s3://linz-imagery-artifacts` so it was missed that the workflow did not have write permission to `s3://linz-basemaps`.

#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title