### PR TITLE
feat: update permissions for cogify import workflow BM-822

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -185,7 +185,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.basemaps.json
         args:
           - "cover"
           - "--tile-matrix={{ inputs.parameters.tile_matrix }}"
@@ -228,7 +228,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.basemaps.json
         args:
           - "create"
           - "--from-file={{= inputs.artifacts.covering_grouped.path }}{{inputs.parameters.covering_grouped_id}}.json"
@@ -244,7 +244,7 @@ spec:
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.basemaps.json
         args:
           - "config"
           - "{{ inputs.parameters.path }}"
@@ -276,7 +276,7 @@ spec:
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-write.basemaps.json,s3://linz-bucket-config/config.json
+            value: s3://linz-bucket-config/config.basemaps.json
         args:
           - "-V"
           - "create-overview"


### PR DESCRIPTION
#### Description

Fixes bucket permissions for `basemaps-imagery-import-cogify`.

#### Intention

Does what PR https://github.com/linz/topo-workflows/pull/159 aimed to do, but did not work, as multiple comma separated sources for role config files were not supported.

#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in title