### PR TITLE
feat: allow copy --force when moving maps and thumbnails TDE-841

### DIFF
--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -24,6 +24,10 @@ spec:
         value: "f"
       - name: copy-option
         value: "--no-clobber"
+        enum:
+          - "--no-clobber"
+          - "--force"
+          - "--force-no-clobber"
   templateDefaults:
     container:
       imagePullPolicy: Always


### PR DESCRIPTION
If a new release of Topo maps contains some already existing maps (already published), the resolution process is to overwrite the existing files.