### PR TITLE
feat: approval step in publish-copy TDE-853

### DIFF
--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -49,6 +49,10 @@ spec:
           - name: group-size
       dag:
         tasks:
+          - name: approval
+            template: approval
+            when: "{{=sprig.regexMatch('s3://linz-(elevation|imagery)/', workflow.parameters.target)}}"
+
           - name: create-manifest-github
             template: create-manifest
             arguments:
@@ -56,7 +60,7 @@ spec:
                 - name: source
                   value: "{{inputs.parameters.source}}"
                 - name: target
-                  value: "{{workflow.parameters.target}}"
+                  value: "{{tasks.approval.outputs.parameters.target}}"
                 - name: include
                   value: "{{inputs.parameters.include}}"
                 - name: exclude
@@ -68,6 +72,8 @@ spec:
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
             when: "{{=sprig.regexMatch('s3://linz-(elevation|imagery)/', workflow.parameters.target)}}"
+            depends: "approval"
+
           - name: create-manifest
             template: create-manifest
             arguments:
@@ -86,7 +92,8 @@ spec:
                   value: "{{inputs.parameters.group-size}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
-            depends: "create-manifest-github.Skipped"
+            depends: "create-manifest-github.Skipped && approval"
+
           - name: copy-with-github
             template: copy
             arguments:
@@ -99,6 +106,7 @@ spec:
                   value: "{{workflow.parameters.version-argo-tasks}}"
             depends: "create-manifest-github.Succeeded"
             withParam: "{{tasks.create-manifest-github.outputs.parameters.files}}"
+
           - name: copy
             template: copy
             arguments:
@@ -111,17 +119,36 @@ spec:
                   value: "{{workflow.parameters.version-argo-tasks}}"
             depends: "create-manifest"
             withParam: "{{tasks.create-manifest.outputs.parameters.files}}"
+
           - name: push-to-github
             template: push-to-github
             arguments:
               parameters:
                 - name: source
                   value: "{{inputs.parameters.source}}"
+                - name: target
+                  value: "{{tasks.approval.outputs.parameters.target}}"
             depends: "copy-with-github"
+            # END
+
+    - name: approval
+      suspend: {}
+      inputs:
+        parameters:
+          - name: target
+            value: "{{workflow.parameters.target}}"
+            description: "Confirm the correct target path?"
+      outputs:
+        parameters:
+          - name: target
+            valueFrom:
+              supplied: {}
+
     - name: create-manifest
       inputs:
         parameters:
           - name: source
+          - name: target
           - name: include
           - name: exclude
           - name: group
@@ -147,7 +174,7 @@ spec:
             "--output",
             "/tmp/file_list.json",
             "--target",
-            "{{=sprig.trim(workflow.parameters.target)}}",
+            "{{=sprig.trim(inputs.parameters.target)}}",
             "{{=sprig.trim(inputs.parameters.source)}}",
             "--transform",
             "{{=sprig.trim(workflow.parameters.transform)}}",
@@ -157,6 +184,7 @@ spec:
           - name: files
             valueFrom:
               path: /tmp/file_list.json
+
     - name: copy
       retryStrategy:
         limit: "2"
@@ -179,21 +207,23 @@ spec:
             "{{workflow.parameters.copy-option}}",
             "{{inputs.parameters.file}}",
           ]
+
     - name: push-to-github
       retryStrategy:
         limit: "2"
       inputs:
         parameters:
           - name: source
+          - name: target
       container:
         image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
           - name: GIT_AUTHOR_NAME
-            value: "{{=sprig.regexFind('(elevation|imagery)', workflow.parameters.target)}}[bot]"
+            value: "{{=sprig.regexFind('(elevation|imagery)', inputs.parameters.target)}}[bot]"
           - name: GIT_AUTHOR_EMAIL
-            value: "{{=sprig.regexFind('(elevation|imagery)', workflow.parameters.target)}}@linz.govt.nz"
+            value: "{{=sprig.regexFind('(elevation|imagery)', inputs.parameters.target)}}@linz.govt.nz"
         volumeMounts:
           - name: secret-volume
             mountPath: "/root/.ssh/"
@@ -205,12 +235,12 @@ spec:
             "--source",
             "{{=sprig.trim(inputs.parameters.source)}}",
             "--target",
-            "{{=sprig.trim(workflow.parameters.target)}}",
+            "{{=sprig.trim(inputs.parameters.target)}}",
             "--repo-name",
-            "linz/{{=sprig.regexFind('(elevation|imagery)', workflow.parameters.target)}}",
+            "linz/{{=sprig.regexFind('(elevation|imagery)', inputs.parameters.target)}}",
           ]
   volumes:
     - name: secret-volume
       secret:
-        secretName: "github-linz-{{=sprig.regexFind('(elevation|imagery)', workflow.parameters.target)}}"
+        secretName: "github-linz-{{=sprig.regexFind('(elevation|imagery)', tasks.approval.outputs.parameters.target)}}"
         defaultMode: 384

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -132,7 +132,8 @@ spec:
             # END
 
     - name: approval
-      suspend: {}
+      suspend:
+        duration: "60"
       inputs:
         parameters:
           - name: target

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -142,6 +142,7 @@ spec:
         parameters:
           - name: target
             valueFrom:
+              default: "{{workflow.parameters.target}}"
               supplied: {}
 
     - name: create-manifest


### PR DESCRIPTION
**Spike Findings:**
**Filtering:**
- The approval step can be filtered to only run when the target starts with `s3://linz-imagery` / `s3://linz-elevation` /`s3://nz-imagery/`
**Parameters:**
- The approval step could allow the user to correct the target / reconfirm the target

**UI**
- It is not clear that approval is required when looking at the running workflows in list view
- It is clear a workflow needs approval when viewing the specific workflow

**Timeout**
- Can add a duration step/task to automatically resume the workflow after a certain period of time (somewhat defeats the purpose in our case?)
- If you want to abort a workflow after a certain duration of time if not approved you have to use the following workaround at the moment: take user confirmation (`YES`/`NO`) defaulted to `NO` add a timeout of 1hr if `parameter = NO` run `abort workflow` task (https://github.com/argoproj/argo-workflows/discussions/8365#discussioncomment-6419368).

**CLI Resume Commands:**
```bash
# Resume a workflow that has been suspended:

  argo resume *wf*

# Resume multiple workflows:

  argo resume *wf* *wf-1* *wf-2*     

# Resume the latest workflow:

  argo resume @latest

# Resume Workflow with Change to Target:
# TODO: unsure if possible to specify paramters from CLI https://argoproj.github.io/argo-workflows/intermediate-inputs/
```

**Docs:**
[Suspending Workflows](https://argoproj.github.io/argo-workflows/walk-through/suspending/)
[Resuming Workflows](https://argoproj.github.io/argo-workflows/cli/argo_resume/)

**UI Screenshots:**

Workflow structure example (skipping approval):
![image](https://github.com/linz/topo-workflows/assets/33814653/215404b7-b958-431f-abe1-b146b1473c7c)

Approval Message:
(If the target is re-typed in the dialog box the new target will be used)
![workflow](https://github.com/linz/topo-workflows/assets/33814653/6bc86455-6f41-4807-a115-d6ed5389343c)

