### PR TITLE
feat: format (pretty-print) STAC files TDE-759

### DIFF
--- a/templates/argo-tasks/format.yml
+++ b/templates/argo-tasks/format.yml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tpl-at-format
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: source
+            description: Path to format files from
+          - name: target
+            description: (Optional) Target directory (testing)
+            default: ""
+          - name: version
+            description: argo-task Container version to use
+            default: "v2"
+
+      container:
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{= inputs.parameters.version }}"
+        command: [node, /app/index.js]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          - "pretty-print"
+          - "{{= inputs.parameters.source }}"
+          - "{{= sprig.empty(inputs.parameters.target) ? '' : '--target=' + inputs.parameters.target }}"

--- a/workflows/imagery/README.md
+++ b/workflows/imagery/README.md
@@ -105,7 +105,7 @@ graph TD;
     tileindex-validate-->standardise-validate;
     standardise-validate-->create-collection;
     standardise-validate-->create-overview;
-    create-collection-->stac-validate;
+    create-collection-->stac-format-->stac-validate;
     create-overview-->create-config;
 ```
 

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -278,6 +278,16 @@ spec:
                   value: "{{tasks.get-location.outputs.parameters.location}}"
             depends: "standardise-validate"
 
+          - name: stac-format
+            templateRef:
+              name: tpl-at-format
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: "{{tasks.get-location.outputs.parameters.location}}flat/"
+            depends: "create-collection"
+
           - name: stac-validate
             template: stac-validate
             arguments:
@@ -288,7 +298,7 @@ spec:
                 - name: stac-result
                   raw:
                     data: "{{tasks.stac-validate.outputs.result}}"
-            depends: "create-collection"
+            depends: "stac-format"
 
           - name: get-location
             template: get-location


### PR DESCRIPTION
### Description
Add a `WorkflowTemplate` to format files that calls `linz/argo-tasks` `pretty-print` command. This template is used in `imagery-standardising` workflow.

### Intention
Some of the STAC files (`Item`) are not pretty printed. Having a `WorkflowTemplate` allows to format files inside a workflow for newly created files. It can also be ran as a one-off job for existing files.

### Checklist
If not applicable, provide explanation of why.

- [x] Docs updated
- [x] Issue linked in Title