### PR TITLE
refactor: publish-copy & publish-odr TDE-868

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -143,8 +143,6 @@ See https://github.com/linz/argo-tasks#stac-github-import
 
 ### Template usage
 
-Create a manifest file for a user specificed source and target that includes `.tiff`, `.json`, and `.tfw` files from the source.
-
 ```yaml
 - name: push-to-github
   templateRef:

--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -77,3 +77,88 @@ steps:
       # for example using with a --from-file
       # ./test-cli --from-file=/tmp/group/input/{{inputs.parameters.group_id}}.json
 ```
+
+## argo-tasks/copy - `tpl-copy`
+
+Template for copying a manifest of files between two locations.  
+See https://github.com/linz/argo-tasks#copy
+
+### Template usage
+
+Copy the input parameter manifest file without overriding.
+
+```yaml
+- name: copy
+  templateRef:
+    name: tpl-copy
+    template: main
+  arguments:
+    parameters:
+      - name: copy-option
+        value: "--no-clobber"
+      - name: file
+        value: "{{item}}"
+      - name: version-argo-tasks
+        value: "{{workflow.parameters.version-argo-tasks}}"
+  depends: "create-manifest"
+  withParam: "{{tasks.create-manifest.outputs.parameters.files}}"
+```
+
+## argo-tasks/create-manifest - `tpl-create-manifest`
+
+Template for creating a manifest to be copied and their target path.  
+See https://github.com/linz/argo-tasks#create-manifest
+
+### Template usage
+
+Create a manifest file for a user specificed source and target that includes `.tiff`, `.json`, and `.tfw` files from the source.
+
+```yaml
+- name: create-manifest
+  templateRef:
+    name: tpl-create-manifest
+    template: main
+  arguments:
+    parameters:
+      - name: source
+        value: "{{inputs.parameters.source}}"
+      - name: target
+        value: "{{workflow.parameters.target}}"
+      - name: include
+        value: ".tiff?$|.json$|.tfw$"
+      - name: exclude
+        value: ""
+      - name: group
+        value: "1000"
+      - name: group-size
+        value: "100Gi"
+      - name: version-argo-tasks
+        value: "{{workflow.parameters.version-argo-tasks}}"
+```
+
+## argo-tasks/push-to-github - `tpl-push-to-github`
+
+Template for Formatting and Pushing STAC Collections to Github
+See https://github.com/linz/argo-tasks#stac-github-import
+
+### Template usage
+
+Create a manifest file for a user specificed source and target that includes `.tiff`, `.json`, and `.tfw` files from the source.
+
+```yaml
+- name: push-to-github
+  templateRef:
+    name: tpl-push-to-github
+    template: main
+  arguments:
+    parameters:
+      - name: source
+        value: "{{inputs.parameters.source}}"
+      - name: target
+        value: "{{workflow.parameters.target}}"
+      - name: version-argo-tasks
+        value: "{{workflow.parameters.version-argo-tasks}}"
+      - name: repository
+        value: "elevation"
+  depends: "copy-with-github"
+```

--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -111,7 +111,7 @@ See https://github.com/linz/argo-tasks#create-manifest
 
 ### Template usage
 
-Create a manifest file for a user specificed source and target that includes `.tiff`, `.json`, and `.tfw` files from the source.
+Create a manifest file for a user specified source and target that includes `.tiff`, `.json`, and `.tfw` files from the source.
 
 ```yaml
 - name: create-manifest

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -43,7 +43,7 @@ spec:
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: "{{inputs.parameters.aws-role-config-path}}"
+            value: "s3://linz-bucket-config/config.json,{{inputs.parameters.aws-role-config-path}}"
         args:
           [
             "copy",

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -32,7 +32,7 @@ spec:
 
           - name: aws-role-config-path
             description: The path(s) to the aws configs that enable writing to buckets
-            default: "s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config.json"
+            default: "s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json"
 
       container:
         image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -23,7 +23,7 @@ spec:
             default: "v2"
 
           - name: copy-option
-            description: `--no-clobber` Skip overwriting existing files. `--force` Overwrite all files. `--force-no-clobber` Overwrite only changed files, skip unchanged files.
+            description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.
             default: "--no-clobber"
             enum:
               - "--no-clobber"

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template for copying data using a manifest file
+  # See TODO Github link
+  name: tpl-copy
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: "2"
+      inputs:
+        parameters:
+          - name: file
+            description: TODO
+
+          - name: version-argo-tasks
+            description: version of argo-tasks to use
+            default: "v2"
+
+          - name: copy-option
+            description: TODO
+            default: "--no-clobber"
+            enum:
+              - "--no-clobber"
+              - "--force"
+              - "--force-no-clobber"
+
+          - name: aws-role-config-path
+            description: TODO
+            default: "s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config.json"
+
+      container:
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 2000m
+        command: [node, /app/index.js]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: "{{inputs.parameters.aws-role-config-path}}"
+        args:
+          [
+            "copy",
+            "{{inputs.parameters.copy-option}}",
+            "{{inputs.parameters.file}}",
+          ]

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -1,8 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  # Template for copying data using a manifest file
-  # See TODO Github link
+  # Template for copying a manifest of files between two locations
+  # See https://github.com/linz/argo-tasks#copy
   name: tpl-copy
 spec:
   templateDefaults:
@@ -16,14 +16,14 @@ spec:
       inputs:
         parameters:
           - name: file
-            description: TODO
+            description: Path to the manifest file detailing source and target
 
           - name: version-argo-tasks
             description: version of argo-tasks to use
             default: "v2"
 
           - name: copy-option
-            description: TODO
+            description: `--no-clobber` Skip overwriting existing files. `--force` Overwrite all files. `--force-no-clobber` Overwrite only changed files, skip unchanged files.
             default: "--no-clobber"
             enum:
               - "--no-clobber"
@@ -31,7 +31,7 @@ spec:
               - "--force-no-clobber"
 
           - name: aws-role-config-path
-            description: TODO
+            description: The path(s) to the aws configs that enable writing to buckets
             default: "s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config.json"
 
       container:

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -32,7 +32,7 @@ spec:
             default: ""
 
           - name: copy-option
-            description: `--no-clobber` Skip overwriting existing files. `--force` Overwrite all files. `--force-no-clobber` Overwrite only changed files, skip unchanged files.
+            description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.
             default: "--no-clobber"
             enum:
               - "--no-clobber"

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -1,8 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  # Template for creating a manifest
-  # See TODO Github link
+  # Template for creating a manifest to be copied and their target path
+  # See https://github.com/linz/argo-tasks#create-manifest
   name: tpl-create-manifest
 spec:
   templateDefaults:
@@ -24,15 +24,15 @@ spec:
             default: "v2"
 
           - name: include
-            description: TODO
+            description: A regular expression to match object path(s) or name(s) from within the source path to include in the copy
             default: ".tiff?$|.json$|.tfw$"
 
           - name: exclude
-            description: TODO
+            description: A regular expression to match object path(s) or name(s) from within the source path to exclude in the copy
             default: ""
 
           - name: copy-option
-            description: TODO
+            description: `--no-clobber` Skip overwriting existing files. `--force` Overwrite all files. `--force-no-clobber` Overwrite only changed files, skip unchanged files.
             default: "--no-clobber"
             enum:
               - "--no-clobber"
@@ -40,15 +40,15 @@ spec:
               - "--force-no-clobber"
 
           - name: group
-            description: TODO
+            description: The maximum number of files for each pod to copy (will use the value of `group` or `group-size` that is reached first)
             default: "1000"
 
           - name: group-size
-            description: TODO
+            description: The maximum group size of files for each pod to copy (will use the value of `group` or `group-size` that is reached first)
             default: "100Gi"
 
           - name: transform
-            description: TODO
+            description: String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation.
             default: "f"
 
       outputs:

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -1,0 +1,85 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template for creating a manifest
+  # See TODO Github link
+  name: tpl-create-manifest
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: source
+            description: location of data to publish
+
+          - name: target
+            description: location to publish data to
+
+          - name: version-argo-tasks
+            description: version of argo-tasks to use
+            default: "v2"
+
+          - name: include
+            description: TODO
+            default: ".tiff?$|.json$|.tfw$"
+
+          - name: exclude
+            description: TODO
+            default: ""
+
+          - name: copy-option
+            description: TODO
+            default: "--no-clobber"
+            enum:
+              - "--no-clobber"
+              - "--force"
+              - "--force-no-clobber"
+
+          - name: group
+            description: TODO
+            default: "1000"
+
+          - name: group-size
+            description: TODO
+            default: "100Gi"
+
+          - name: transform
+            description: TODO
+            default: "f"
+
+      outputs:
+        parameters:
+          - name: files
+            valueFrom:
+              path: /tmp/file_list.json
+
+      container:
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(inputs.parameters['version-argo-tasks'])}}"
+        command: [node, /app/index.js]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          [
+            "create-manifest",
+            "--verbose",
+            "--include",
+            "{{=sprig.trim(inputs.parameters.include)}}",
+            "--exclude",
+            "{{inputs.parameters.exclude}}",
+            "--group",
+            "{{=sprig.trim(inputs.parameters.group)}}",
+            "--group-size",
+            "{{=sprig.trim(inputs.parameters['group-size'])}}",
+            "--output",
+            "/tmp/file_list.json",
+            "--target",
+            "{{=sprig.trim(inputs.parameters.target)}}",
+            "{{=sprig.trim(inputs.parameters.source)}}",
+            "--transform",
+            "{{=sprig.trim(inputs.parameters.transform)}}",
+          ]

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -16,7 +16,7 @@ spec:
       inputs:
         parameters:
           - name: source
-            description: location of data to publish
+            description: location where the source collection.json file is
 
           - name: target
             description: location to publish data to

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -26,7 +26,7 @@ spec:
             default: "v2"
 
           - name: repository
-            description: Reposistory Name (only used when Identified that push to github is required)
+            description: Repository Name (only used when identified that push to GitHub is required)
             default: "elevation"
             enum:
               - "elevation"

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -1,0 +1,62 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # TODO Template for Pushing to Github
+  # See TODO Github link
+  name: tpl-push-to-github
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: "2"
+      inputs:
+        parameters:
+          - name: source
+            description: location of data to publish
+
+          - name: target
+            description: location to publish data to
+
+          - name: version-argo-tasks
+            description: version of argo-tasks to use
+            default: "v2"
+
+          - name: repo
+            description: TODO
+            default: "elevation"
+            enum:
+              - "elevation"
+
+      container:
+        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(inputs.parameters['version-argo-tasks'])}}"
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+          - name: GIT_AUTHOR_NAME
+            value: "{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}[bot]"
+          - name: GIT_AUTHOR_EMAIL
+            value: "{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}@linz.govt.nz"
+        volumeMounts:
+          - name: secret-volume
+            mountPath: "/root/.ssh/"
+        command: [node, /app/index.js]
+        args:
+          [
+            "stac",
+            "github-import",
+            "--source",
+            "{{=sprig.trim(inputs.parameters.source)}}",
+            "--target",
+            "{{=sprig.trim(inputs.parameters.target)}}",
+            "--repo-name",
+            "linz/{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}",
+          ]
+  volumes:
+    - name: secret-volume
+      secret:
+        secretName: "github-linz-{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}"
+        defaultMode: 384

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -19,7 +19,7 @@ spec:
             description: location where the source collection.json file is
 
           - name: target
-            description: location to publish data to
+            description: location where the destination collection.json file will be
 
           - name: version-argo-tasks
             description: version of argo-tasks to use

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -1,8 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  # TODO Template for Pushing to Github
-  # See TODO Github link
+  # Template for Formatting and Pushing STAC Collections to Github
+  # See https://github.com/linz/argo-tasks#stac-github-import
   name: tpl-push-to-github
 spec:
   templateDefaults:
@@ -25,11 +25,12 @@ spec:
             description: version of argo-tasks to use
             default: "v2"
 
-          - name: repo
-            description: TODO
+          - name: repository
+            description: Reposistory Name (only used when Identified that push to github is required)
             default: "elevation"
             enum:
               - "elevation"
+              - "imagery"
 
       container:
         image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(inputs.parameters['version-argo-tasks'])}}"
@@ -37,9 +38,9 @@ spec:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
           - name: GIT_AUTHOR_NAME
-            value: "{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}[bot]"
+            value: "{{=sprig.regexFind(inputs.parameters.repository, inputs.parameters.target)}}[bot]"
           - name: GIT_AUTHOR_EMAIL
-            value: "{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}@linz.govt.nz"
+            value: "{{=sprig.regexFind(inputs.parameters.repository, inputs.parameters.target)}}@linz.govt.nz"
         volumeMounts:
           - name: secret-volume
             mountPath: "/root/.ssh/"
@@ -53,10 +54,10 @@ spec:
             "--target",
             "{{=sprig.trim(inputs.parameters.target)}}",
             "--repo-name",
-            "linz/{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}",
+            "linz/{{=sprig.regexFind(inputs.parameters.repository, inputs.parameters.target)}}",
           ]
   volumes:
     - name: secret-volume
       secret:
-        secretName: "github-linz-{{=sprig.regexFind(inputs.parameters.repo, inputs.parameters.target)}}"
+        secretName: "github-linz-{{=sprig.regexFind(inputs.parameters.repository, inputs.parameters.target)}}"
         defaultMode: 384

--- a/workflows/imagery/README.md
+++ b/workflows/imagery/README.md
@@ -2,6 +2,7 @@
 
 - [Standardising](#Standardising)
 - [Publish-copy](#Publish-copy)
+- [publish-odr](#Publish-odr)
 - [Standardising-publish-import](#Standardising-publish-import)
 - [tests](#Tests)
 
@@ -224,6 +225,15 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 **include:** Although only `.tif(f)` and `.tfw` files are required, there should not be any `.json` files in with the uploaded imagery, so this option can be left at the default.
 
 **copy-option:** `--no-clobber`
+
+# Publish-odr
+
+## Workflow Description
+
+This workflow replicates `publish-copy` however it allows publishing to `s3://nz-imagery`(the registry of open data).
+**This workflow should not be run using the Argo UI, instead follow the instruction [here](https://github.com/linz/imagery/tree/master/workflow-parameters/README.md)**
+
+See the [publish-copy template](#publish-copy) for more information.
 
 # Standardising-publish-import
 

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-mdavidson-pubcop
+  name: publish-copy
   namespace: argo
 spec:
   parallelism: 50
@@ -138,4 +138,3 @@ spec:
                 - name: repo
                   value: "elevation"
             depends: "copy-with-github"
-    # END: TEMPLATE MAIN

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -135,6 +135,6 @@ spec:
                   value: "{{workflow.parameters.target}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
-                - name: repo
+                - name: repository
                   value: "elevation"
             depends: "copy-with-github"

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -69,7 +69,7 @@ spec:
                   value: "{{inputs.parameters.group-size}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
-            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}" # THIS
+            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}"
 
           - name: create-manifest
             templateRef:

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: publish-copy
+  name: test-mdavidson-pubcop
   namespace: argo
 spec:
   parallelism: 50
@@ -50,7 +50,9 @@ spec:
       dag:
         tasks:
           - name: create-manifest-github
-            template: create-manifest
+            templateRef:
+              name: tpl-create-manifest
+              template: main
             arguments:
               parameters:
                 - name: source
@@ -67,9 +69,12 @@ spec:
                   value: "{{inputs.parameters.group-size}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
-            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}"
+            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}" # THIS
+
           - name: create-manifest
-            template: create-manifest
+            templateRef:
+              name: tpl-create-manifest
+              template: main
             arguments:
               parameters:
                 - name: source
@@ -87,8 +92,11 @@ spec:
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
             depends: "create-manifest-github.Skipped"
+
           - name: copy-with-github
-            template: copy
+            templateRef:
+              name: tpl-copy
+              template: main
             arguments:
               parameters:
                 - name: copy-option
@@ -99,8 +107,11 @@ spec:
                   value: "{{workflow.parameters.version-argo-tasks}}"
             depends: "create-manifest-github.Succeeded"
             withParam: "{{tasks.create-manifest-github.outputs.parameters.files}}"
+
           - name: copy
-            template: copy
+            templateRef:
+              name: tpl-copy
+              template: main
             arguments:
               parameters:
                 - name: copy-option
@@ -111,106 +122,20 @@ spec:
                   value: "{{workflow.parameters.version-argo-tasks}}"
             depends: "create-manifest"
             withParam: "{{tasks.create-manifest.outputs.parameters.files}}"
+
           - name: push-to-github
-            template: push-to-github
+            templateRef:
+              name: tpl-push-to-github
+              template: main
             arguments:
               parameters:
                 - name: source
                   value: "{{inputs.parameters.source}}"
+                - name: target
+                  value: "{{workflow.parameters.target}}"
+                - name: version-argo-tasks
+                  value: "{{workflow.parameters.version-argo-tasks}}"
+                - name: repo
+                  value: "elevation"
             depends: "copy-with-github"
-    - name: create-manifest
-      inputs:
-        parameters:
-          - name: source
-          - name: include
-          - name: exclude
-          - name: group
-          - name: group-size
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
-        command: [node, /app/index.js]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-        args:
-          [
-            "create-manifest",
-            "--verbose",
-            "--include",
-            "{{=sprig.trim(inputs.parameters.include)}}",
-            "--exclude",
-            "{{inputs.parameters.exclude}}",
-            "--group",
-            "{{=sprig.trim(inputs.parameters.group)}}",
-            "--group-size",
-            "{{=sprig.trim(inputs.parameters['group-size'])}}",
-            "--output",
-            "/tmp/file_list.json",
-            "--target",
-            "{{=sprig.trim(workflow.parameters.target)}}",
-            "{{=sprig.trim(inputs.parameters.source)}}",
-            "--transform",
-            "{{=sprig.trim(workflow.parameters.transform)}}",
-          ]
-      outputs:
-        parameters:
-          - name: files
-            valueFrom:
-              path: /tmp/file_list.json
-    - name: copy
-      retryStrategy:
-        limit: "2"
-      inputs:
-        parameters:
-          - name: file
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
-        resources:
-          requests:
-            memory: 7.8Gi
-            cpu: 2000m
-        command: [node, /app/index.js]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config.json
-        args:
-          [
-            "copy",
-            "{{workflow.parameters.copy-option}}",
-            "{{inputs.parameters.file}}",
-          ]
-    - name: push-to-github
-      retryStrategy:
-        limit: "2"
-      inputs:
-        parameters:
-          - name: source
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-          - name: GIT_AUTHOR_NAME
-            value: "{{=sprig.regexFind('elevation', workflow.parameters.target)}}[bot]"
-          - name: GIT_AUTHOR_EMAIL
-            value: "{{=sprig.regexFind('elevation', workflow.parameters.target)}}@linz.govt.nz"
-        volumeMounts:
-          - name: secret-volume
-            mountPath: "/root/.ssh/"
-        command: [node, /app/index.js]
-        args:
-          [
-            "stac",
-            "github-import",
-            "--source",
-            "{{=sprig.trim(inputs.parameters.source)}}",
-            "--target",
-            "{{=sprig.trim(workflow.parameters.target)}}",
-            "--repo-name",
-            "linz/{{=sprig.regexFind('elevation', workflow.parameters.target)}}",
-          ]
-  volumes:
-    - name: secret-volume
-      secret:
-        secretName: "github-linz-{{=sprig.regexFind('elevation', workflow.parameters.target)}}"
-        defaultMode: 384
+    # END: TEMPLATE MAIN

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -142,4 +142,3 @@ spec:
                 - name: repo
                   value: "imagery"
             depends: "copy-with-github"
-    # END TEMPLATE MAIN

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -139,6 +139,6 @@ spec:
                   value: "{{workflow.parameters.target}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
-                - name: repo
+                - name: repository
                   value: "imagery"
             depends: "copy-with-github"

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -129,7 +129,7 @@ spec:
 
           - name: push-to-github
             templateRef:
-              name: push-to-github
+              name: tpl-push-to-github
               template: main
             arguments:
               parameters:

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -50,7 +50,9 @@ spec:
       dag:
         tasks:
           - name: create-manifest-github
-            template: create-manifest
+            templateRef:
+              name: tpl-create-manifest
+              template: main
             arguments:
               parameters:
                 - name: source
@@ -68,8 +70,11 @@ spec:
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
             when: "{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}}"
+
           - name: create-manifest
-            template: create-manifest
+            templateRef:
+              name: tpl-create-manifest
+              template: main
             arguments:
               parameters:
                 - name: source
@@ -87,8 +92,11 @@ spec:
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
             depends: "create-manifest-github.Skipped"
+
           - name: copy-with-github
-            template: copy
+            templateRef:
+              name: tpl-copy
+              template: main
             arguments:
               parameters:
                 - name: copy-option
@@ -97,10 +105,15 @@ spec:
                   value: "{{item}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
+                - name: aws-role-config-path
+                  value: "s3://linz-bucket-config/config-write.open-data-registry.json,s3://linz-bucket-config/config.json"
             depends: "create-manifest-github.Succeeded"
             withParam: "{{tasks.create-manifest-github.outputs.parameters.files}}"
+
           - name: copy
-            template: copy
+            templateRef:
+              name: tpl-copy
+              template: main
             arguments:
               parameters:
                 - name: copy-option
@@ -109,109 +122,24 @@ spec:
                   value: "{{item}}"
                 - name: version-argo-tasks
                   value: "{{workflow.parameters.version-argo-tasks}}"
+                - name: aws-role-config-path
+                  value: "s3://linz-bucket-config/config-write.open-data-registry.json,s3://linz-bucket-config/config.json"
             depends: "create-manifest"
             withParam: "{{tasks.create-manifest.outputs.parameters.files}}"
+
           - name: push-to-github
-            template: push-to-github
+            templateRef:
+              name: push-to-github
+              template: main
             arguments:
               parameters:
                 - name: source
                   value: "{{inputs.parameters.source}}"
+                - name: target
+                  value: "{{workflow.parameters.target}}"
+                - name: version-argo-tasks
+                  value: "{{workflow.parameters.version-argo-tasks}}"
+                - name: repo
+                  value: "imagery"
             depends: "copy-with-github"
-    - name: create-manifest
-      inputs:
-        parameters:
-          - name: source
-          - name: include
-          - name: exclude
-          - name: group
-          - name: group-size
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
-        command: [node, /app/index.js]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-        args:
-          [
-            "create-manifest",
-            "--verbose",
-            "--include",
-            "{{=sprig.trim(inputs.parameters.include)}}",
-            "--exclude",
-            "{{inputs.parameters.exclude}}",
-            "--group",
-            "{{=sprig.trim(inputs.parameters.group)}}",
-            "--group-size",
-            "{{=sprig.trim(inputs.parameters['group-size'])}}",
-            "--output",
-            "/tmp/file_list.json",
-            "--target",
-            "{{=sprig.trim(workflow.parameters.target)}}",
-            "{{=sprig.trim(inputs.parameters.source)}}",
-            "--transform",
-            "{{=sprig.trim(workflow.parameters.transform)}}",
-          ]
-      outputs:
-        parameters:
-          - name: files
-            valueFrom:
-              path: /tmp/file_list.json
-    - name: copy
-      retryStrategy:
-        limit: "2"
-      inputs:
-        parameters:
-          - name: file
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
-        resources:
-          requests:
-            memory: 7.8Gi
-            cpu: 2000m
-        command: [node, /app/index.js]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config-write.open-data-registry.json,s3://linz-bucket-config/config.json
-        args:
-          [
-            "copy",
-            "--fix-content-type=true",
-            "{{workflow.parameters.copy-option}}",
-            "{{inputs.parameters.file}}",
-          ]
-    - name: push-to-github
-      retryStrategy:
-        limit: "2"
-      inputs:
-        parameters:
-          - name: source
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-          - name: GIT_AUTHOR_NAME
-            value: "{{=sprig.regexFind('imagery', workflow.parameters.target)}}[bot]"
-          - name: GIT_AUTHOR_EMAIL
-            value: "{{=sprig.regexFind('imagery', workflow.parameters.target)}}@linz.govt.nz"
-        volumeMounts:
-          - name: secret-volume
-            mountPath: "/root/.ssh/"
-        command: [node, /app/index.js]
-        args:
-          [
-            "stac",
-            "github-import",
-            "--source",
-            "{{=sprig.trim(inputs.parameters.source)}}",
-            "--target",
-            "{{=sprig.trim(workflow.parameters.target)}}",
-            "--repo-name",
-            "linz/{{=sprig.regexFind('imagery', workflow.parameters.target)}}",
-          ]
-  volumes:
-    - name: secret-volume
-      secret:
-        secretName: "github-linz-{{=sprig.regexFind('imagery', workflow.parameters.target)}}"
-        defaultMode: 384
+    # END TEMPLATE MAIN


### PR DESCRIPTION
**Why:**
Currently the two workflows: `publish-odr` and `publish-copy` are almost direct copies of each other with a lot of duplicate code. This is a risk for future work as the same code will need to be updated in two different places, and it is likely to be forgotten/mistakes made. 

**Description:**
`copy`, `create-manifest` and `publish-to-github` have been pulled out into template workflow-templates that are each called by the tasks in `publish-copy` and `publish-odr`

The alternative option is to remove `publish-odr` and add it as options/parameters to `publish-copy`. I didn't do this as we had discussed wanting to make sure the odr was separate and the future possible enhancements of approval steps / restricting users who can run the workflow. 