### PR TITLE
fix(cogify): adjust resource requests

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -228,6 +228,8 @@ spec:
           requests:
             memory: 15.6Gi
             cpu: 15000m
+          limits:
+            memory: 15.6Gi
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
         command: [node, /app/node_modules/.bin/cogify]
         env:

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -228,6 +228,7 @@ spec:
           requests:
             memory: 15.6Gi
             cpu: 15000m
+            ephemeral-storage: 100Gi
           limits:
             memory: 15.6Gi
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}


### PR DESCRIPTION
Cogify is running out of memory and running the disk out of IOPS adjust the requests to get a bigger share of each instance.
