### PR TITLE
fix(cogify): lower concurrency and set resource limits to memory = 2x cpu

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -226,11 +226,9 @@ spec:
       container:
         resources:
           requests:
-            memory: 15.6Gi
-            cpu: 15000m
-            ephemeral-storage: 100Gi
-          limits:
-            memory: 15.6Gi
+            memory: 30Gi
+            cpu: 16000m
+            ephemeral-storage: 98Gi # 2 pods per 200GB of storage
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
         command: [node, /app/node_modules/.bin/cogify]
         env:
@@ -239,6 +237,7 @@ spec:
         args:
           - "create"
           - "--from-file={{= inputs.artifacts.covering_grouped.path }}{{inputs.parameters.covering_grouped_id}}.json"
+          - "--concurrency=2"
 
     # Create a basemaps configuration file to view the imagery
     - name: create-config

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -227,7 +227,7 @@ spec:
         resources:
           requests:
             memory: 30Gi
-            cpu: 16000m
+            cpu: 15000m # AWS gives 2x cpu cores = memory for most instances
             ephemeral-storage: 98Gi # 2 pods per 200GB of storage
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
         command: [node, /app/node_modules/.bin/cogify]


### PR DESCRIPTION
### Motivation

We are still getting pods killed by `OOMKilled`, possibly caused by too many gdal_translates happening at the same time.

### Modification

Remove memory `limits` and double the requested memory
Lower concurrency of gdal_translates to 2 per pod rather than 4 per pod

