### PR TITLE
fix: add source to workflow

### DIFF
--- a/workflows/imagery/standardising-publish-import.yaml
+++ b/workflows/imagery/standardising-publish-import.yaml
@@ -16,6 +16,8 @@ spec:
         key: bulk
   arguments:
     parameters:
+      - name: source
+        value: ""
       - name: cutline # optional standardising cutline
         value: ""
       - name: collection-id # optional
@@ -54,6 +56,10 @@ spec:
             templateRef:
               name: imagery-standardising
               template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: "{{workflow.parameters.source}}"
         - - name: publish
             templateRef:
               name: publish-copy


### PR DESCRIPTION
The merging of https://github.com/linz/topo-workflows/pull/161 linted against the old version of standardising so missed this required fix which broke Wentao's PR here: https://github.com/linz/topo-workflows/actions/runs/6333551973/job/17201837027?pr=179