### PR TITLE
ci: re-lint workflows after deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,3 +75,8 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           kubectl apply -f config/*.yml --namespace argo
+      # Re-lint the workflows after deployment because their dependencies is test with deployement.
+      - name: Re-Lint workflows
+        run: |
+          ./argo-linux-amd64 lint templates/ -n argo
+          ./argo-linux-amd64 lint workflows/ -n argo


### PR DESCRIPTION
The first `Lint workflows` is not testing against the workflows dependencies deployed in the same actions (as it's deployed after)...