### PR TITLE
fix: copy template bucket config ordering

### DIFF
--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -42,7 +42,7 @@ spec:
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: "{{inputs.parameters.aws-role-config-path}}"
+            value: "{{inputs.parameters.aws-role-config-path}},s3://linz-bucket-config/config.json"
         args:
           [
             "copy",

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -32,7 +32,6 @@ spec:
 
           - name: aws-role-config-path
             description: The path(s) to the aws configs that enable writing to buckets
-            default: "s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json"
 
       container:
         image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:argo-tasks-{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}"
@@ -43,7 +42,7 @@ spec:
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: "s3://linz-bucket-config/config.json,{{inputs.parameters.aws-role-config-path}}"
+            value: "{{inputs.parameters.aws-role-config-path}}"
         args:
           [
             "copy",


### PR DESCRIPTION
The Argo Tasks copy command will register the first matching role, which in the case of 'linz-imagery' was the read role, causing copying to `linz-imagery` to fail.
It may be something that can be fixed in Argo Tasks or chunkd if there is a robust way to work out the naming/logic of the roles.
I also removed the default values as we probably want to explicitly specify the write roles in the upstream workflow.