### PR TITLE
ci: point ci at the new workflows cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,26 +25,25 @@ jobs:
       - name: format
         run: npm run format -- --fix=false # ensure eslint is not configured to --fix
 
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
 
-      # - name: Setup kubectl
-      #   uses: azure/setup-kubectl@v3
-      #   with:
-      #     version: 'latest'
+      - name: AWS Configure
+        uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-region: ap-southeast-2
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
-      # - name: AWS Configure
-      #   uses: aws-actions/configure-aws-credentials@v1.6.1
-      #   with:
-      #     aws-region: ap-southeast-2
-      #     mask-aws-account-id: true
-      #     role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+      - name: Login to EKS
+        run: |
+          aws eks update-kubeconfig --name Workflows --region ap-southeast-2 --role-arn ${{ secrets.AWS_EKS_ROLE }}
 
-      # - name: Login to EKS
-      #   run: |
-      #     aws eks update-kubeconfig --name Workflow --region ap-southeast-2 --role-arn ${{ secrets.AWS_EKS_ROLE }}
-
-      # - name: Check EKS connection
-      #   run: |
-      #     kubectl get nodes
+      - name: Check EKS connection
+        run: |
+          kubectl get nodes
 
       # - name: Install Argo
       #   run: |


### PR DESCRIPTION
#### Motivation

To test our recovery process we are building a new eks cluster from scratch with ipv6 to enable future growth

#### Modification

Move the CI process to the new cluster

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
