### PR TITLE
feat: initial eks namespaces TDE-915

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,10 +1,12 @@
-# Kubernetes configuration with CDK8s
+# Kubernetes configuration with CDK8s and AWS-CDK
 
-Collection of Kubernetes resources.
+Collection of AWS & Kubernetes resources.
 
 ## Components
 
-Main entry point: [app](./app.ts)
+Main entry point: [cdk8s](./cdk8s.ts) and [cdk](./cdk.ts) 
+
+Generally all Kubernetes resources are defined with cdk8s and anything that needs AWS interactions such as service accounts are defined with CDK.
 
 - argo - Argo workflows for use with [linz/topo-workflows](https://github.com/linz/topo-workflows)
 

--- a/config/eks/cluster.ts
+++ b/config/eks/cluster.ts
@@ -81,6 +81,7 @@ export class LinzEksCluster extends Stack {
   configureEks(): void {
     // Use fluent bit to ship logs from eks into aws
     const fluentBitNs = this.cluster.addManifest('FluentBitNamespace', {
+      apiVersion: 'v1',
       kind: 'Namespace',
       metadata: { name: 'fluent-bit' },
     });
@@ -90,12 +91,16 @@ export class LinzEksCluster extends Stack {
     });
     fluentBitSa.node.addDependency(fluentBitNs); // Ensure the namespace created first
 
-    // basic  constructs for
-    const argoNs = this.cluster.addManifest('ArgoNameSpace', { kind: 'Namespace', metadata: { name: 'argo' } });
+    // Basic constructs for argo to be deployed into
+    const argoNs = this.cluster.addManifest('ArgoNameSpace', {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: 'argo' },
+    });
     const argoRunnerSa = this.cluster.addServiceAccount('ArgoRunnerServiceAccount', {
       name: 'argo-runner-sa',
       namespace: 'argo',
     });
-    argoNs.node.addDependency(argoRunnerSa);
+    argoRunnerSa.node.addDependency(argoNs);
   }
 }

--- a/config/eks/cluster.ts
+++ b/config/eks/cluster.ts
@@ -68,5 +68,34 @@ export class LinzEksCluster extends Stack {
     // Grant the AWS Admin user ability to view the cluster
     const accountAdminRole = Role.fromRoleName(this, 'AccountAdminRole', 'AccountAdminRole');
     this.cluster.awsAuth.addMastersRole(accountAdminRole);
+
+    this.configureEks();
+  }
+
+  /**
+   * Setup the basic interactions between EKS and some of its components
+   *
+   * This should generally be limited to things that require direct interaction with AWS eg service accounts
+   * or name space creation
+   */
+  configureEks(): void {
+    // Use fluent bit to ship logs from eks into aws
+    const fluentBitNs = this.cluster.addManifest('FluentBitNamespace', {
+      kind: 'Namespace',
+      metadata: { name: 'fluent-bit' },
+    });
+    const fluentBitSa = this.cluster.addServiceAccount('FluentBitServiceAccount', {
+      name: 'fluent-bit-sa',
+      namespace: 'fluent-bit',
+    });
+    fluentBitSa.node.addDependency(fluentBitNs); // Ensure the namespace created first
+
+    // basic  constructs for
+    const argoNs = this.cluster.addManifest('ArgoNameSpace', { kind: 'Namespace', metadata: { name: 'argo' } });
+    const argoRunnerSa = this.cluster.addServiceAccount('ArgoRunnerServiceAccount', {
+      name: 'argo-runner-sa',
+      namespace: 'argo',
+    });
+    argoNs.node.addDependency(argoRunnerSa);
   }
 }


### PR DESCRIPTION
#### Motivation

Some resources need to interact with k8s and others directly with AWS so we are using both CDK and AWS-CDK. To enable resources to be deployed we need to scaffhold out the starting blocks such as namespaces so that service accounts can be deployed using AWS-CDK.

#### Modification

Create a structure for initial EKS / AWS deployments in CDK and start to define what components are in CDK vs CDK8s
