### PR TITLE
fix: use template rcode NOERROR to prevent timeouts

### DIFF
--- a/cdk8s.yaml
+++ b/cdk8s.yaml
@@ -1,4 +1,4 @@
-app: npx tsx config/cdk8s.ts
+app: npx tsx config/cdk8s.old.cluster.ts
 language: typescript
 imports:
   - https://raw.githubusercontent.com/aws/karpenter/main/pkg/apis/crds/karpenter.sh_provisioners.yaml

--- a/cdk8s.yaml
+++ b/cdk8s.yaml
@@ -1,4 +1,4 @@
-app: npx tsx config/cdk8s.old.cluster.ts
+app: npx tsx config/cdk8s.ts
 language: typescript
 imports:
   - https://raw.githubusercontent.com/aws/karpenter/main/pkg/apis/crds/karpenter.sh_provisioners.yaml

--- a/config/charts/kube-system.coredns.ts
+++ b/config/charts/kube-system.coredns.ts
@@ -19,7 +19,11 @@ import { applyDefaultLabels } from '../util/labels.js';
  * - `.` - everything else
  *
  * The internal cluster allows `ipv6` resolutions, while `.` prevents `AAAA` resolutions using
- * `rewrite stop type AAAA A`
+ * ```
+ *  template ANY AAAA {
+ *     rcode NOERROR
+ * }
+ * ```
  *
  */
 export class CoreDns extends Chart {

--- a/config/charts/kube-system.coredns.ts
+++ b/config/charts/kube-system.coredns.ts
@@ -51,7 +51,9 @@ cluster.local:53 {
     log
     errors
     health
-    rewrite stop type AAAA A
+    template ANY AAAA {
+      rcode NOERROR
+    }
     prometheus :9153
     forward . /etc/resolv.conf
     cache 30

--- a/docs/dns.configuration.md
+++ b/docs/dns.configuration.md
@@ -73,6 +73,11 @@ file: index.mjs
 
 ```javascript
 fetch('https://google.com').then((c) => console.log(c));
+
+import * as dns from 'dns/promises'
+
+await dns.resolve('google.com', 'A');
+await dns.resolve('google.com', 'AAAA');
 ```
 
 ```bash


### PR DESCRIPTION
#### Motivation

When using `rewrite stop type AAAA A` DNS resolution would often hang for 30+seconds on the clients waiting for a response

#### Modification

Instantly respond to AAAA requests with a empty NOERROR to force clients to use A records for external hosts.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
