### PR TITLE
fix: argo sa arn is wrong

### DIFF
--- a/config/eks/cluster.ts
+++ b/config/eks/cluster.ts
@@ -212,6 +212,6 @@ export class LinzEksCluster extends Stack {
       namespace: 'argo',
     });
     argoRunnerSa.node.addDependency(argoNs);
-    new CfnOutput(this, 'ArgoRunnerServiceAccountRoleArn', { value: fluentBitSa.role.roleArn });
+    new CfnOutput(this, 'ArgoRunnerServiceAccountRoleArn', { value: argoRunnerSa.role.roleArn });
   }
 }


### PR DESCRIPTION
#### Motivation

The Argo service account ARN stored in cloudformation was the fluentbit one (copiy-paste mistake).

#### Modification

Change it to the right Argo SA ARN

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
