### PR TITLE
feat: cdk8s Argo Workflows TDE-904

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -18,6 +18,9 @@ Main entry point: [app](./cdk8s.ts)
 
 ### Argo Workflows
 
+Argo Workflows is used to run the workflows inside K8s.
+It is deployed using its [Helm chart](https://github.com/argoproj/argo-helm/tree/main/charts/argo-workflows).
+
 #### Semaphores
 
 ConfigMap that list the synchronization limits for parallel execution of the workflows.
@@ -28,7 +31,6 @@ TODO
 
 ### Generate code
 
-Generate code from Helm:
 It is possible to generate a specific Helm construct for the component if their chart includes a `value.schema.json`. This is useful to provide typing hints when specifying their configuration (<https://github.com/cdk8s-team/cdk8s/blob/master/docs/cli/import.md#values-schema>)
 
 To generate the Helm Construct for a specific Chart, follow the instructions [here](https://github.com/cdk8s-team/cdk8s/blob/master/docs/cli/import.md#values-schema):
@@ -37,22 +39,11 @@ Specify the output for the imports:
 
 `--output infra/imports/`
 
-However, some of the component Helm charts do not have a `values.schema.json`. For those we won't generate any code and use the default `Helm` construct:
+However, some of the component Helm charts do not have a `values.schema.json`. And that the case for most of our components:
 
 - aws-for-fluent-bit (<https://github.com/aws/eks-charts/issues/1011>)
 - Karpenter
-
-### Working with Helm charts
-
-#### Generate code
-
-It is possible to generate a specific Helm construct for the component if their chart includes a `value.schema.json`. This is useful to provide typing hints when specifying their configuration (<https://github.com/cdk8s-team/cdk8s/blob/master/docs/cli/import.md#values-schema>)
-
-To generate the Helm Construct for a specific Chart, follow the instructions [here](https://github.com/cdk8s-team/cdk8s/blob/master/docs/cli/import.md#values-schema)
-
-However, some of the component Helm charts do not have a `values.schema.json`. For those we won't generate any code and use the default `Helm` construct:
-
-- aws-for-fluent-bit (<https://github.com/aws/eks-charts/issues/1011>)
+- Argo workflows
 
 ## Usage (for test)
 

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
   karpenterProvisioner.addDependency(karpenter);
 
   new ArgoWorkflows(app, 'argo-workflows', {
-    clusterName: ClusterName,
+    clusterName,
     saName: cfnOutputs[CfnOutputKeys.Argo.RunnerServiceAccountName],
     tempBucketName: cfnOutputs[CfnOutputKeys.Argo.TempBucketName],
   });

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -13,9 +13,12 @@ const app = new App();
 async function main(): Promise<void> {
   // Get cloudformation outputs
   const cfnOutputs = await getCfnOutputs(ClusterName);
-  const missingKeys = [...Object.values(CfnOutputKeys.Karpenter), ...Object.values(CfnOutputKeys.FluentBit)].filter(
-    (f) => cfnOutputs[f] == null,
-  );
+  //FIXME: is there a better way to do that?
+  const missingKeys = [
+    ...Object.values(CfnOutputKeys.Karpenter),
+    ...Object.values(CfnOutputKeys.FluentBit),
+    ...Object.values(CfnOutputKeys.Argo),
+  ].filter((f) => cfnOutputs[f] == null);
   if (missingKeys.length > 0) {
     throw new Error(`Missing CloudFormation Outputs for keys ${missingKeys.join(', ')}`);
   }

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -1,6 +1,7 @@
 import { App } from 'cdk8s';
 
 import { ArgoSemaphore } from './charts/argo.semaphores';
+import { ArgoWorkflows } from './charts/argo.workflows';
 import { FluentBit } from './charts/fluentbit';
 import { Karpenter, KarpenterProvisioner } from './charts/karpenter';
 import { CoreDns } from './charts/kube-system.coredns';
@@ -44,6 +45,12 @@ async function main(): Promise<void> {
   });
 
   karpenterProvisioner.addDependency(karpenter);
+
+  new ArgoWorkflows(app, 'argo-workflows', {
+    clusterName: ClusterName,
+    saName: cfnOutputs[CfnOutputKeys.Argo.RunnerServiceAccountName],
+    tempBucketName: cfnOutputs[CfnOutputKeys.Argo.TempBucketName],
+  });
 
   app.synth();
 }

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -13,7 +13,6 @@ const app = new App();
 async function main(): Promise<void> {
   // Get cloudformation outputs
   const cfnOutputs = await getCfnOutputs(ClusterName);
-  //FIXME: is there a better way to do that?
   const missingKeys = [
     ...Object.values(CfnOutputKeys.Karpenter),
     ...Object.values(CfnOutputKeys.FluentBit),

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
   new ArgoSemaphore(app, 'semaphore', {});
   const coredns = new CoreDns(app, 'dns', {});
   const fluentbit = new FluentBit(app, 'fluentbit', {
-    saRoleName: cfnOutputs[CfnOutputKeys.FluentBit.ServiceAccountName],
+    saName: cfnOutputs[CfnOutputKeys.FluentBit.ServiceAccountName],
     clusterName: ClusterName,
   });
   fluentbit.addDependency(coredns);
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
   const karpenter = new Karpenter(app, 'karpenter', {
     clusterName: ClusterName,
     clusterEndpoint: cfnOutputs[CfnOutputKeys.Karpenter.ClusterEndpoint],
-    saRoleName: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountName],
+    saName: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountName],
     saRoleArn: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountRoleArn],
     instanceProfile: cfnOutputs[CfnOutputKeys.Karpenter.DefaultInstanceProfile],
   });
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
   const karpenterProvisioner = new KarpenterProvisioner(app, 'karpenter-provisioner', {
     clusterName: ClusterName,
     clusterEndpoint: cfnOutputs[CfnOutputKeys.Karpenter.ClusterEndpoint],
-    saRoleName: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountName],
+    saName: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountName],
     saRoleArn: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountRoleArn],
     instanceProfile: cfnOutputs[CfnOutputKeys.Karpenter.DefaultInstanceProfile],
   });

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -4,16 +4,32 @@ import { Construct } from 'constructs';
 import { applyDefaultLabels } from '../util/labels.js';
 
 export interface ArgoWorkflowsProps {
+  /** Name of the temporary bucket used to store artifacts
+   *
+   * @example "linz-workflows-scratch"
+   */
   tempBucketName: string;
+  /** Name of the Service Account used to run workflows
+   *
+   * @example "workflow-runner-sa"
+   */
   saName: string;
+  /** Name of the EKS cluster
+   *
+   * @example "Workflows"
+   */
   clusterName: string;
 }
 
-const argoWorkflowsChartVersion = '0.34.0';
+/** This is the version of the Helm chart for Argo Workflows
+ *
+ * (Do not mix up with Argo Workflows application version)
+ */
+const version = '0.34.0';
 
 export class ArgoWorkflows extends Chart {
   constructor(scope: Construct, id: string, props: ArgoWorkflowsProps & ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'argo-workflows', argoWorkflowsChartVersion, 'logs', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'argo-workflows', version, 'logs', 'workflows'));
 
     const artifactRepository = {
       archiveLogs: true,
@@ -41,7 +57,7 @@ export class ArgoWorkflows extends Chart {
       releaseName: 'argo-workflows',
       repo: 'https://argoproj.github.io/argo-helm',
       namespace: 'argo',
-      version: argoWorkflowsChartVersion,
+      version: version,
       values: {
         server: {
           replicas: 2,

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -1,0 +1,87 @@
+import { Chart, ChartProps, Duration, Helm } from 'cdk8s';
+import { Construct } from 'constructs';
+
+import { applyDefaultLabels } from '../util/labels.js';
+
+export interface ArgoWorkflowsProps {
+  tempBucketName: string;
+  saName: string;
+  clusterName: string;
+}
+
+const argoWorkflowsChartVersion = '0.34.0';
+
+export class ArgoWorkflows extends Chart {
+  constructor(scope: Construct, id: string, props: ArgoWorkflowsProps & ChartProps) {
+    super(scope, id, applyDefaultLabels(props, 'argo-workflows', argoWorkflowsChartVersion, 'logs', 'workflows'));
+
+    const artifactRepository = {
+      archiveLogs: true,
+      useStaticCredentials: false,
+      s3: {
+        accessKeySecret: { key: 'accesskey', name: '' },
+        secretKeySecret: { key: 'secretkey', name: '' },
+        bucket: props.tempBucketName,
+        keyFormat:
+          '{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}-{{workflow.name}}/{{pod.name}}',
+        region: 'ap-southeast-2',
+        endpoint: 's3.amazonaws.com',
+        useSDKCreds: true,
+        insecure: false,
+      },
+    };
+
+    const DefaultNodeSelector = {
+      'eks.amazonaws.com/capacityType': 'ON_DEMAND',
+      'kubernetes.io/arch': 'amd64',
+    };
+
+    new Helm(this, 'argo-workflows', {
+      chart: 'argo-workflows',
+      releaseName: 'argo-workflows',
+      repo: 'https://argoproj.github.io/argo-helm',
+      namespace: 'argo',
+      version: argoWorkflowsChartVersion,
+      values: {
+        server: {
+          replicas: 2,
+          extraEnv: [
+            /** Disable the "first time" popups that pop up every time  */
+            { name: 'FIRST_TIME_USER_MODAL', value: 'false' },
+            { name: 'FEEDBACK_MODAL', value: 'false' },
+            { name: 'NEW_VERSION_MODAL', value: 'false' },
+          ],
+          nodeSelector: { ...DefaultNodeSelector },
+          extraArgs: ['--auth-mode=server'],
+        },
+        artifactRepository,
+        controller: {
+          nodeSelector: { ...DefaultNodeSelector },
+          workflowNamespaces: ['argo'],
+          extraArgs: [],
+          replicas: 2,
+          workflowDefaults: {
+            spec: {
+              serviceAccountName: 'workflow-runner-sa',
+              ttlStrategy: { secondsAfterCompletion: Duration.days(7).toSeconds() },
+              podGC: { strategy: 'OnPodCompletion' },
+              tolerations: [
+                {
+                  key: 'karpenter.sh/capacity-type',
+                  operator: 'Equal',
+                  value: 'spot',
+                  effect: 'NoSchedule',
+                },
+              ],
+              parallelism: 3,
+            },
+          },
+        },
+        workflow: {
+          rbac: { create: true },
+          serviceAccount: { create: false, name: props.saName },
+        },
+      },
+    });
+  }
+}

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -4,32 +4,43 @@ import { Construct } from 'constructs';
 import { applyDefaultLabels } from '../util/labels.js';
 
 export interface ArgoWorkflowsProps {
-  /** Name of the temporary bucket used to store artifacts
+  /**
+   * Name of the temporary bucket used to store artifacts
    *
    * @example "linz-workflows-scratch"
    */
   tempBucketName: string;
-  /** Name of the Service Account used to run workflows
+  /**
+   * Name of the Service Account used to run workflows
    *
    * @example "workflow-runner-sa"
    */
   saName: string;
-  /** Name of the EKS cluster
+  /**
+   * Name of the EKS cluster
    *
    * @example "Workflows"
    */
   clusterName: string;
 }
 
-/** This is the version of the Helm chart for Argo Workflows
+/**
+ * This is the version of the Helm chart for Argo Workflows https://github.com/argoproj/argo-helm/blob/25d7b519bc7fc37d2820721cd648f3a3403d0e38/charts/argo-workflows/Chart.yaml#L6
  *
  * (Do not mix up with Argo Workflows application version)
  */
-const version = '0.34.0';
+const chartVersion = '0.34.0';
+
+/**
+ * This is the version of Argo Workflows for the `chartVersion` we're using
+ * https://github.com/argoproj/argo-helm/blob/2730dc24c7ad69b98d3206705a5ebf5cb34dd96b/charts/argo-workflows/Chart.yaml#L2
+ *
+ */
+const appVersion = 'v3.4.11';
 
 export class ArgoWorkflows extends Chart {
   constructor(scope: Construct, id: string, props: ArgoWorkflowsProps & ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'argo-workflows', version, 'logs', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'argo-workflows', appVersion, 'logs', 'workflows'));
 
     const artifactRepository = {
       archiveLogs: true,
@@ -57,7 +68,7 @@ export class ArgoWorkflows extends Chart {
       releaseName: 'argo-workflows',
       repo: 'https://argoproj.github.io/argo-helm',
       namespace: 'argo',
-      version: version,
+      version: chartVersion,
       values: {
         server: {
           replicas: 2,

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -62,7 +62,7 @@ export class ArgoWorkflows extends Chart {
           replicas: 2,
           workflowDefaults: {
             spec: {
-              serviceAccountName: 'workflow-runner-sa',
+              serviceAccountName: props.saName,
               ttlStrategy: { secondsAfterCompletion: Duration.days(7).toSeconds() },
               podGC: { strategy: 'OnPodCompletion' },
               tolerations: [

--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -6,7 +6,15 @@ import { applyDefaultLabels } from '../util/labels.js';
 /** version of the Helm chart (not FluentBit app) */
 const awsForFluentBitVersion = '0.1.31';
 export interface FluentBitProps {
-  saRoleName: string;
+  /** Name of the Service Account used to run workflows
+   *
+   * @example "fluentbit-sa"
+   */
+  saName: string;
+  /** Name of the EKS cluster
+   *
+   * @example "Workflows"
+   */
   clusterName: string;
 }
 
@@ -48,7 +56,7 @@ HC_Period 5
       values: {
         fullnameOverride: 'fluentbit',
         input: { parser: FluentParserName, dockerMode: 'Off' },
-        serviceAccount: { name: props.saRoleName, create: false },
+        serviceAccount: { name: props.saName, create: false },
         cloudWatchLogs: {
           enabled: true,
           region: 'ap-southeast-2',

--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -3,15 +3,29 @@ import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.js';
 
-/** version of the Helm chart (not FluentBit app) */
-const awsForFluentBitVersion = '0.1.31';
+/**
+ * version of the Helm chart (not FluentBit app)
+ *
+ * https://github.com/aws/eks-charts/blob/a644fd925ca091d881b3a42aace268322f484455/stable/aws-for-fluent-bit/Chart.yaml#L4
+ * */
+const chartVersion = '0.1.31';
+
+/**
+ * version of the application
+ *
+ * https://github.com/aws/eks-charts/blob/a644fd925ca091d881b3a42aace268322f484455/stable/aws-for-fluent-bit/Chart.yaml#L5C11-L5C29
+ */
+const appVersion = '2.31.12.20231011';
+
 export interface FluentBitProps {
-  /** Name of the Service Account used to run workflows
+  /**
+   * Name of the Service Account used to run workflows
    *
    * @example "fluentbit-sa"
    */
   saName: string;
-  /** Name of the EKS cluster
+  /**
+   * Name of the EKS cluster
    *
    * @example "Workflows"
    */
@@ -20,7 +34,7 @@ export interface FluentBitProps {
 
 export class FluentBit extends Chart {
   constructor(scope: Construct, id: string, props: FluentBitProps & ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'aws-for-fluent-bit', awsForFluentBitVersion, 'logs', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'aws-for-fluent-bit', appVersion, 'logs', 'workflows'));
 
     const FluentParserName = 'containerd';
     // This needs to be properly formatted, and it was taken directly from https://github.com/microsoft/fluentbit-containerd-cri-o-json-log
@@ -52,7 +66,7 @@ HC_Period 5
       chart: 'aws-for-fluent-bit',
       repo: 'https://aws.github.io/eks-charts',
       namespace: 'fluentbit',
-      version: awsForFluentBitVersion,
+      version: chartVersion,
       values: {
         fullnameOverride: 'fluentbit',
         input: { parser: FluentParserName, dockerMode: 'Off' },

--- a/infra/charts/karpenter.ts
+++ b/infra/charts/karpenter.ts
@@ -38,15 +38,22 @@ export interface KarpenterProps {
   instanceProfile: string;
 }
 
+/**
+ * Karpenter chart version and application version are following the same increments
+ *
+ * https://github.com/aws/karpenter/blob/7c989a2bfae43d4e73235aca0af50b8008c67b68/charts/karpenter/Chart.yaml#L5C10-L5C16
+ */
+const version = '0.31.0';
+
 export class Karpenter extends Chart {
   constructor(scope: Construct, id: string, props: KarpenterProps & ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'karpenter', 'v0.31.0', 'karpenter', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'karpenter', version, 'karpenter', 'workflows'));
 
     // Deploying the CRD
     const crd = new Helm(this, 'karpenter-crd', {
       chart: 'oci://public.ecr.aws/karpenter/karpenter-crd',
       namespace: 'karpenter',
-      version: 'v0.31.1',
+      version,
     });
 
     // Karpenter is using `oci` rather than regular helm repo: https://gallery.ecr.aws/karpenter/karpenter.
@@ -67,7 +74,7 @@ export class Karpenter extends Chart {
     const karpenter = new Helm(this, 'karpenter', {
       chart: 'oci://public.ecr.aws/karpenter/karpenter',
       namespace: 'karpenter',
-      version: 'v0.31.1',
+      version,
       values: {
         fullnameOverride: 'karpenter', // override the karpenter-abcxywz
         serviceAccount: {

--- a/infra/charts/karpenter.ts
+++ b/infra/charts/karpenter.ts
@@ -13,15 +13,15 @@ export interface KarpenterProps {
    **/
   clusterName: string;
   /**
-   * Role Arn for the service account to use
-   *
-   * @example "arn:aws:iam::1234567890:role/KarpenterSa"
-   * */
-  saRoleName: string;
-  /**
    * Name of the service account for karpenter
    *
    * @example "karpenter-sa"
+   * */
+  saName: string;
+  /**
+   * Role Arn for the service account to use
+   *
+   * @example "arn:aws:iam::1234567890:role/KarpenterSa"
    */
   saRoleArn: string;
   /**
@@ -72,7 +72,7 @@ export class Karpenter extends Chart {
         fullnameOverride: 'karpenter', // override the karpenter-abcxywz
         serviceAccount: {
           create: false,
-          name: props.saRoleName,
+          name: props.saName,
           annotations: { 'eks.amazonaws.com/role-arn': props.saRoleArn },
         },
         settings: {

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -12,4 +12,8 @@ export const CfnOutputKeys = {
   FluentBit: {
     ServiceAccountName: 'FluentBitServiceAccountName',
   },
+  Argo: {
+    RunnerServiceAccountName: 'ArgoRunnerServiceAccountName',
+    TempBucketName: 'TempBucketName',
+  },
 };

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -216,7 +216,6 @@ export class LinzEksCluster extends Stack {
       namespace: 'argo',
     });
     argoRunnerSa.node.addDependency(argoNs);
-    new CfnOutput(this, 'ArgoRunnerServiceAccountRoleArn', { value: argoRunnerSa.role.roleArn });
     new CfnOutput(this, CfnOutputKeys.Argo.RunnerServiceAccountName, { value: argoRunnerSa.serviceAccountName });
 
     // give read/write on the temporary (scratch) bucket

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -49,6 +49,7 @@ export class LinzEksCluster extends Stack {
         },
       ],
     });
+    new CfnOutput(this, CfnOutputKeys.Argo.TempBucketName, { value: this.tempBucket.bucketName });
 
     this.configBucket = Bucket.fromBucketName(this, 'BucketConfig', 'linz-bucket-config');
 
@@ -180,7 +181,6 @@ export class LinzEksCluster extends Stack {
       roles: [this.nodeRole.roleName],
       instanceProfileName: `${this.cluster.clusterName}-${this.id}`, // Must be specified to avoid CFN error
     });
-
     // Save configuration for CDK8s to access it
     new CfnOutput(this, CfnOutputKeys.Karpenter.DefaultInstanceProfile, { value: instanceProfile.ref });
     new CfnOutput(this, CfnOutputKeys.Karpenter.ClusterEndpoint, { value: this.cluster.clusterEndpoint });
@@ -203,7 +203,6 @@ export class LinzEksCluster extends Stack {
       new PolicyStatement({ actions: ['logs:PutRetentionPolicy'], resources: ['*'], effect: Effect.ALLOW }),
     );
     fluentBitSa.node.addDependency(fluentBitNs); // Ensure the namespace created first
-
     new CfnOutput(this, CfnOutputKeys.FluentBit.ServiceAccountName, { value: fluentBitSa.serviceAccountName });
 
     // Basic constructs for argo to be deployed into
@@ -218,5 +217,6 @@ export class LinzEksCluster extends Stack {
     });
     argoRunnerSa.node.addDependency(argoNs);
     new CfnOutput(this, 'ArgoRunnerServiceAccountRoleArn', { value: argoRunnerSa.role.roleArn });
+    new CfnOutput(this, CfnOutputKeys.Argo.RunnerServiceAccountName, { value: argoRunnerSa.serviceAccountName });
   }
 }

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -212,11 +212,16 @@ export class LinzEksCluster extends Stack {
       metadata: { name: 'argo' },
     });
     const argoRunnerSa = this.cluster.addServiceAccount('ArgoRunnerServiceAccount', {
-      name: 'argo-runner-sa',
+      name: 'workflow-runner-sa',
       namespace: 'argo',
     });
     argoRunnerSa.node.addDependency(argoNs);
     new CfnOutput(this, 'ArgoRunnerServiceAccountRoleArn', { value: argoRunnerSa.role.roleArn });
     new CfnOutput(this, CfnOutputKeys.Argo.RunnerServiceAccountName, { value: argoRunnerSa.serviceAccountName });
+
+    // give read/write on the temporary (scratch) bucket
+    this.tempBucket.grantReadWrite(argoRunnerSa.role);
+    // give permission to the sa to assume a role
+    argoRunnerSa.role.addToPrincipalPolicy(new PolicyStatement({ actions: ['sts:AssumeRole'], resources: ['*'] }));
   }
 }

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -115,7 +115,6 @@ export class LinzEksCluster extends Stack {
    * or name space creation
    */
   configureEks(): void {
-    // Karpenter
     this.tempBucket.grantReadWrite(this.nodeRole);
     this.configBucket.grantRead(this.nodeRole);
     this.nodeRole.addToPrincipalPolicy(new PolicyStatement({ actions: ['sts:AssumeRole'], resources: ['*'] }));
@@ -125,6 +124,7 @@ export class LinzEksCluster extends Stack {
       groups: ['system:bootstrappers', 'system:nodes'],
     });
 
+    // Karpenter - Node autoscaler
     const namespace = this.cluster.addManifest('namespace', {
       apiVersion: 'v1',
       kind: 'Namespace',
@@ -187,7 +187,7 @@ export class LinzEksCluster extends Stack {
     new CfnOutput(this, CfnOutputKeys.Karpenter.ServiceAccountRoleArn, { value: serviceAccount.role.roleArn });
     new CfnOutput(this, CfnOutputKeys.Karpenter.ServiceAccountName, { value: serviceAccount.serviceAccountName });
 
-    // Use fluent bit to ship logs from eks into aws
+    // FluentBit - to ship logs from eks into aws
     const fluentBitNs = this.cluster.addManifest('FluentBitNamespace', {
       apiVersion: 'v1',
       kind: 'Namespace',
@@ -205,7 +205,7 @@ export class LinzEksCluster extends Stack {
     fluentBitSa.node.addDependency(fluentBitNs); // Ensure the namespace created first
     new CfnOutput(this, CfnOutputKeys.FluentBit.ServiceAccountName, { value: fluentBitSa.serviceAccountName });
 
-    // Basic constructs for argo to be deployed into
+    // Argo Workflows
     const argoNs = this.cluster.addManifest('ArgoNameSpace', {
       apiVersion: 'v1',
       kind: 'Namespace',


### PR DESCRIPTION
#### Motivation

Deploy Argo Workflows using its Helm chart via CDK8s

#### Modification

Namespace and service accounts are managed in `aws-cdk`.
Helm Chart is deployed with CDK8s.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - No tests for this feature
- [x] Docs updated
- [x] Issue linked in Title
