### PR TITLE
refactor: simplify cfn output logic

### DIFF
--- a/infra/util/cloud.formation.ts
+++ b/infra/util/cloud.formation.ts
@@ -3,21 +3,12 @@ import { CloudFormation } from '@aws-sdk/client-cloudformation';
 export async function getCfnOutputs(stackName: string): Promise<Record<string, string>> {
   const cfn = new CloudFormation();
   const searchStacks = await cfn.describeStacks({ StackName: stackName });
-  cfn.listExports;
   const outputs: Record<string, string> = {};
-  const stacks = (searchStacks && searchStacks.Stacks) || [];
-  const stack = stacks.find((s) => s.StackName === stackName);
+  const stack = searchStacks?.Stacks?.find((s) => s.StackName === stackName);
+  if (stack?.Outputs == null) throw new Error(`Unable to find stack "${stackName}"`);
 
-  if (!stack) {
-    throw new Error(`Unable to find stack "${stackName}"`);
-  }
-  if (!stack.Outputs) {
-    throw new Error(`There is no output for stack "${stackName}"`);
-  }
   stack.Outputs.forEach(({ OutputKey, OutputValue }) => {
-    if (OutputKey && OutputValue) {
-      outputs[OutputKey] = OutputValue;
-    }
+    if (OutputKey != null && OutputValue != null) outputs[OutputKey] = OutputValue;
   });
   return outputs;
 }


### PR DESCRIPTION
#### Motivation

Use syntatical sugar to reduce the number of explicit checks needed

#### Modification

- Uses modern javascript syntax sugar  
- Avoids using `!object` or `if(object)` to prevent type conversions

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
