### PR TITLE
fix: correct cloudflare namespace & container

### DIFF
--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -68,6 +68,7 @@ async function main(): Promise<void> {
   });
 
   new Cloudflared(app, 'cloudflared', {
+    namespace: 'cloudflared',
     tunnelId: ssmConfig.tunnelId,
     tunnelSecret: ssmConfig.tunnelSecret,
     tunnelName: ssmConfig.tunnelName,

--- a/infra/charts/cloudflared.ts
+++ b/infra/charts/cloudflared.ts
@@ -46,7 +46,7 @@ export class Cloudflared extends Chart {
       containers: [
         {
           name: 'cloudflared',
-          image: props.accountId + '.dkr.ecr.ap-southeast-2.amazonaws.com/eks:cloudflared-2023.8.2',
+          image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/cloudflared:2023.8.2',
           args: ['tunnel', '--loglevel', 'trace', '--config', '/etc/cloudflared/config/config.yaml', 'run'],
           volumeMounts: [
             { volume: kplus.Volume.fromConfigMap(this, 'mount-config', cm), path: '/etc/cloudflared/config' },


### PR DESCRIPTION
#### Motivation

cloudflared was being deployed into the wrong namespace and using a invalid container link

#### Modification

corrects the namespace and container url.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
