### PR TITLE
docs: update elastic data view name for workflow logs TDE-921

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ In the **Workflows** page:
 ### Logs in Elasticsearch
 
 Elasticsearch is an analytics engine, it allows us to store, search and analyse AWS logs.  
-Elasticsearch can be accessed through https://myapplications.microsoft.com/
+Elasticsearch can be accessed through https://myapplications.microsoft.com/.
 
 #### Example Filters:
 
-:warning: Make sure you are using `li-topo-production*` and set the correct time filter.
+:warning: Make sure you are using the `workflow` data view and set the correct time filter.
 
 _All Logs for a Workflow:_
 


### PR DESCRIPTION
#### Motivation
Workflow logs are now in a specific group. See https://github.com/linz/aws-log-config/pull/790.

#### Modification

Update documentation related to the elastic search data view to use to see workflow logs.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated: N/A for documentation
- [x] Docs updated
- [x] Issue linked in Title
