### PR TITLE
docs: add helm support step TDE-902

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -57,6 +57,13 @@ Login to AWS
 
 Generate the kubernetes configuration yaml into `dist/`
 
+add Helm repositories (<https://cdk8s.io/docs/latest/basics/helm/#helm-support>)
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+helm repo add argo https://argoproj.github.io/argo-helm
+```
+
 ```shell
 npx cdk8s synth
 ```


### PR DESCRIPTION
#### Motivation

In order to use CDK8S `Helm` construct, the repository needs to be added in the local installation of Helm.

#### Modification

Add the add repositories to Helm step.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
