### PR TITLE
build: add missing tsconfig

### DIFF
--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -1,13 +1,13 @@
 import { App } from 'aws-cdk-lib';
 
-import { ClusterName } from './constants';
-import { LinzEksCluster } from './eks/cluster';
+import { ClusterName } from './constants.js';
+import { LinzEksCluster } from './eks/cluster.js';
 
 const app = new App();
 
 async function main(): Promise<void> {
   new LinzEksCluster(app, ClusterName, {
-    env: { region: 'ap-southeast-2', account: process.env.CDK_DEFAULT_ACCOUNT },
+    env: { region: 'ap-southeast-2', account: process.env['CDK_DEFAULT_ACCOUNT'] },
   });
 
   app.synth();

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -1,28 +1,21 @@
 import { App } from 'cdk8s';
 
-import { ArgoSemaphore } from './charts/argo.semaphores';
-import { ArgoWorkflows } from './charts/argo.workflows';
-import { Cloudflared } from './charts/cloudflared';
-import { FluentBit } from './charts/fluentbit';
-import { Karpenter, KarpenterProvisioner } from './charts/karpenter';
-import { CoreDns } from './charts/kube-system.coredns';
-import { CfnOutputKeys, ClusterName } from './constants';
-import { getCfnOutputs } from './util/cloud.formation';
-import { fetchSsmParameters } from './util/ssm';
+import { ArgoSemaphore } from './charts/argo.semaphores.js';
+import { ArgoWorkflows } from './charts/argo.workflows.js';
+import { Cloudflared } from './charts/cloudflared.js';
+import { FluentBit } from './charts/fluentbit.js';
+import { Karpenter, KarpenterProvisioner } from './charts/karpenter.js';
+import { CoreDns } from './charts/kube-system.coredns.js';
+import { CfnOutputKeys, ClusterName, validateKeys } from './constants.js';
+import { getCfnOutputs } from './util/cloud.formation.js';
+import { fetchSsmParameters } from './util/ssm.js';
 
 const app = new App();
 
 async function main(): Promise<void> {
   // Get cloudformation outputs
   const cfnOutputs = await getCfnOutputs(ClusterName);
-  const missingKeys = [
-    ...Object.values(CfnOutputKeys.Karpenter),
-    ...Object.values(CfnOutputKeys.FluentBit),
-    ...Object.values(CfnOutputKeys.Argo),
-  ].filter((f) => cfnOutputs[f] == null);
-  if (missingKeys.length > 0) {
-    throw new Error(`Missing CloudFormation Outputs for keys ${missingKeys.join(', ')}`);
-  }
+  validateKeys(cfnOutputs);
 
   const ssmConfig = await fetchSsmParameters({
     // Config for Cloudflared to access argo-server
@@ -38,33 +31,33 @@ async function main(): Promise<void> {
   new ArgoSemaphore(app, 'semaphore', {});
   const coredns = new CoreDns(app, 'dns', {});
   const fluentbit = new FluentBit(app, 'fluentbit', {
-    saName: cfnOutputs[CfnOutputKeys.FluentBit.ServiceAccountName],
+    saName: cfnOutputs[CfnOutputKeys.FluentBitServiceAccountName],
     clusterName: ClusterName,
   });
   fluentbit.addDependency(coredns);
 
   const karpenter = new Karpenter(app, 'karpenter', {
     clusterName: ClusterName,
-    clusterEndpoint: cfnOutputs[CfnOutputKeys.Karpenter.ClusterEndpoint],
-    saName: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountName],
-    saRoleArn: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountRoleArn],
-    instanceProfile: cfnOutputs[CfnOutputKeys.Karpenter.DefaultInstanceProfile],
+    clusterEndpoint: cfnOutputs[CfnOutputKeys.ClusterEndpoint],
+    saName: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountName],
+    saRoleArn: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountRoleArn],
+    instanceProfile: cfnOutputs[CfnOutputKeys.KarpenterDefaultInstanceProfile],
   });
 
   const karpenterProvisioner = new KarpenterProvisioner(app, 'karpenter-provisioner', {
     clusterName: ClusterName,
-    clusterEndpoint: cfnOutputs[CfnOutputKeys.Karpenter.ClusterEndpoint],
-    saName: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountName],
-    saRoleArn: cfnOutputs[CfnOutputKeys.Karpenter.ServiceAccountRoleArn],
-    instanceProfile: cfnOutputs[CfnOutputKeys.Karpenter.DefaultInstanceProfile],
+    clusterEndpoint: cfnOutputs[CfnOutputKeys.ClusterEndpoint],
+    saName: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountName],
+    saRoleArn: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountRoleArn],
+    instanceProfile: cfnOutputs[CfnOutputKeys.KarpenterDefaultInstanceProfile],
   });
 
   karpenterProvisioner.addDependency(karpenter);
 
   new ArgoWorkflows(app, 'argo-workflows', {
     clusterName: ClusterName,
-    saName: cfnOutputs[CfnOutputKeys.Argo.RunnerServiceAccountName],
-    tempBucketName: cfnOutputs[CfnOutputKeys.Argo.TempBucketName],
+    saName: cfnOutputs[CfnOutputKeys.ArgoRunnerServiceAccountName],
+    tempBucketName: cfnOutputs[CfnOutputKeys.TempBucketName],
   });
 
   new Cloudflared(app, 'cloudflared', {

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -3,17 +3,32 @@ export const ClusterName = 'Workflows';
 
 /* CloudFormation Output to access from CDK8s */
 export const CfnOutputKeys = {
-  Karpenter: {
-    ServiceAccountName: 'KarpenterServiceAccountName',
-    ServiceAccountRoleArn: 'KarpenterServiceAccountRoleArn',
-    ClusterEndpoint: 'ClusterEndpoint',
-    DefaultInstanceProfile: 'DefaultInstanceProfile',
-  },
-  FluentBit: {
-    ServiceAccountName: 'FluentBitServiceAccountName',
-  },
-  Argo: {
-    RunnerServiceAccountName: 'ArgoRunnerServiceAccountName',
-    TempBucketName: 'TempBucketName',
-  },
-};
+  ClusterEndpoint: 'ClusterEndpoint',
+
+  KarpenterServiceAccountName: 'KarpenterServiceAccountName',
+  KarpenterServiceAccountRoleArn: 'KarpenterServiceAccountRoleArn',
+  KarpenterDefaultInstanceProfile: 'KarpenterDefaultInstanceProfile',
+
+  FluentBitServiceAccountName: 'FluentBitServiceAccountName',
+
+  ArgoRunnerServiceAccountName: 'ArgoRunnerServiceAccountName',
+
+  TempBucketName: 'TempBucketName',
+} as const;
+
+/** The list of possible keys */
+export type ICfnOutputKeys = keyof typeof CfnOutputKeys;
+/** A map containing a key value pair for every possible CfnOutputKey */
+export type CfnOutputMap = Record<ICfnOutputKeys, string>;
+
+/**
+ *  Assert that all the keys in this Record contains all the expected CfnOutputKeys
+ *
+ * @see {@link CfnOutputKeys}
+ */
+export function validateKeys(cfnOutputs: Record<string, string>): asserts cfnOutputs is CfnOutputMap {
+  const missingKeys = Object.values(CfnOutputKeys).filter((f) => cfnOutputs[f] == null);
+  if (missingKeys.length > 0) {
+    throw new Error(`Missing CloudFormation Outputs for keys ${missingKeys.join(', ')}`);
+  }
+}

--- a/infra/imports/karpenter.k8s.aws.ts
+++ b/infra/imports/karpenter.k8s.aws.ts
@@ -47,7 +47,7 @@ export class AwsNodeTemplate extends ApiObject {
   /**
    * Renders the object to Kubernetes JSON.
    */
-  public toJson(): any {
+  public override toJson(): any {
     const resolved = super.toJson();
 
     return {

--- a/infra/imports/karpenter.sh.ts
+++ b/infra/imports/karpenter.sh.ts
@@ -47,7 +47,7 @@ export class Provisioner extends ApiObject {
   /**
    * Renders the object to Kubernetes JSON.
    */
-  public toJson(): any {
+  public override toJson(): any {
     const resolved = super.toJson();
 
     return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
-    "extends": "@linzjs/style/tsconfig.base.json",
-    "compilerOptions": {
-      "target": "ES2022",
-      "lib": ["ES2022"],
-      "noEmit": true
-    }
+  "extends": "@linzjs/style/tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "noEmit": true
   }
-  
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@linzjs/style/tsconfig.base.json",
+    "compilerOptions": {
+      "target": "ES2022",
+      "lib": ["ES2022"],
+      "noEmit": true
+    }
+  }
+  

--- a/workflows/test/list.arm.yaml
+++ b/workflows/test/list.arm.yaml
@@ -31,21 +31,21 @@ spec:
                   value: '.tiff?$'
     - name: aws-list
 
-      # Request a SPOT & ARM64 
+      # Request a SPOT & ARM64
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
-        kubernetes.io/arch: "arm64"
+        kubernetes.io/arch: 'arm64'
 
       # Ensure the containers tolerate the taints that will be put on them
       tolerations:
-        - key: "kubernetes.io/arch"
-          operator: "Equal"
-          value: "arm64"
-          effect: "NoSchedule"
-        - key: "karpenter.sh/capacity-type"
-          operator: "Equal"
-          value: "spot"
-          effect: "NoSchedule"
+        - key: 'kubernetes.io/arch'
+          operator: 'Equal'
+          value: 'arm64'
+          effect: 'NoSchedule'
+        - key: 'karpenter.sh/capacity-type'
+          operator: 'Equal'
+          value: 'spot'
+          effect: 'NoSchedule'
 
       inputs:
         parameters:


### PR DESCRIPTION
#### Motivation

LINZ has a somewhat standard tsconfig which is relatively strict, we were not using it this attempts to bring this repo up to the stricter tsconfig

#### Modification

The stricter tsconfig requires

All imports end with `.js`, this prevents accidentaly importing directories with `import './foo'` where foo is either a `foo.js` or `foo/index.js`

No unchecked access to maps, this is more complicated as we now need to get a typescript type to say that even value in the CfnOutputs is in the `cfnOutputs` objects, I converted the validation to a `asserts` function guard and to simplify things made the all the CfnOutputKeys keys the same as their values.