### PR TITLE
fix: add missing semaphores config map

### DIFF
--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -55,10 +55,13 @@ async function main(): Promise<void> {
   karpenterProvisioner.addDependency(karpenter);
 
   new ArgoWorkflows(app, 'argo-workflows', {
+    namespace: 'argo',
     clusterName: ClusterName,
     saName: cfnOutputs[CfnOutputKeys.ArgoRunnerServiceAccountName],
     tempBucketName: cfnOutputs[CfnOutputKeys.TempBucketName],
   });
+
+  new ArgoSemaphore(app, 'argo-semaphores', { namespace: 'argo' });
 
   new Cloudflared(app, 'cloudflared', {
     namespace: 'cloudflared',

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -1,6 +1,6 @@
 import { App } from 'cdk8s';
 
-import { ArgoExtras, ArgoSemaphore } from './charts/argo.extras.js';
+import { ArgoExtras } from './charts/argo.extras.js';
 import { ArgoWorkflows } from './charts/argo.workflows.js';
 import { Cloudflared } from './charts/cloudflared.js';
 import { FluentBit } from './charts/fluentbit.js';
@@ -28,7 +28,6 @@ async function main(): Promise<void> {
     githubPat: '/eks/github/linz-basemaps/pat',
   });
 
-  new ArgoSemaphore(app, 'semaphore', {});
   const coredns = new CoreDns(app, 'dns', {});
   const fluentbit = new FluentBit(app, 'fluentbit', {
     saName: cfnOutputs[CfnOutputKeys.FluentBitServiceAccountName],

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -1,6 +1,6 @@
 import { App } from 'cdk8s';
 
-import { ArgoSemaphore } from './charts/argo.semaphores.js';
+import { ArgoExtras, ArgoSemaphore } from './charts/argo.extras.js';
 import { ArgoWorkflows } from './charts/argo.workflows.js';
 import { Cloudflared } from './charts/cloudflared.js';
 import { FluentBit } from './charts/fluentbit.js';
@@ -61,7 +61,11 @@ async function main(): Promise<void> {
     tempBucketName: cfnOutputs[CfnOutputKeys.TempBucketName],
   });
 
-  new ArgoSemaphore(app, 'argo-semaphores', { namespace: 'argo' });
+  new ArgoExtras(app, 'argo-extras', {
+    namespace: 'argo',
+    /** Argo workflows interacts with github give it access to github bot user*/
+    secrets: [{ name: 'github-linz-basemaps-pat', data: { pat: ssmConfig.githubPat } }],
+  });
 
   new Cloudflared(app, 'cloudflared', {
     namespace: 'cloudflared',

--- a/infra/charts/argo.extras.ts
+++ b/infra/charts/argo.extras.ts
@@ -17,7 +17,7 @@ export class ArgoExtras extends Chart {
     id: string,
     props: ChartProps & { secrets: { name: string; data: Record<string, string> }[] },
   ) {
-    super(scope, id, applyDefaultLabels(props, 'argo', 'v1', 'semaphores', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'argo', 'v1', 'extras', 'workflows'));
 
     new kplus.ConfigMap(this, 'semaphores', {
       metadata: { name: 'semaphores' },

--- a/infra/charts/argo.extras.ts
+++ b/infra/charts/argo.extras.ts
@@ -4,8 +4,15 @@ import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.js';
 
-export class ArgoSemaphore extends Chart {
-  constructor(scope: Construct, id: string, props: ChartProps) {
+/**
+ * Configuration for the workflows themselves trying to keep this a little seperate from the argo server setup
+ */
+export class ArgoExtras extends Chart {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: ChartProps & { secrets: { name: string; data: Record<string, string> }[] },
+  ) {
     super(scope, id, applyDefaultLabels(props, 'argo', 'v1', 'semaphores', 'workflows'));
 
     new kplus.ConfigMap(this, 'semaphores', {
@@ -17,5 +24,12 @@ export class ArgoSemaphore extends Chart {
         basemaps_import: '10', // Limit of how many basemaps import workflow instances can run at the same time
       },
     });
+
+    for (const s of props.secrets) {
+      const secret = new kplus.Secret(this, 'secret-' + s.name, { metadata: { name: s.name } });
+      for (const [key, value] of Object.entries(s.data)) {
+        secret.addStringData(key, value);
+      }
+    }
   }
 }

--- a/infra/charts/argo.extras.ts
+++ b/infra/charts/argo.extras.ts
@@ -5,7 +5,11 @@ import { Construct } from 'constructs';
 import { applyDefaultLabels } from '../util/labels.js';
 
 /**
- * Configuration for the workflows themselves trying to keep this a little seperate from the argo server setup
+ * Extra configuration for the workflows themselves
+ *
+ * With the goal that the [ArgoWorkflows](./argo.workflows.ts) chart is focused more on the server setup and
+ * {@link ArgoExtras} to be focused on the workflows running
+ *
  */
 export class ArgoExtras extends Chart {
   constructor(
@@ -18,13 +22,18 @@ export class ArgoExtras extends Chart {
     new kplus.ConfigMap(this, 'semaphores', {
       metadata: { name: 'semaphores' },
       data: {
-        standardising: '2', // Limit of how many standardising workflow instances can run at the same time
-        bulk: '4', // Limit of how many bulk workflow instances can run at the same time
-        bulkcopy: '8', // Limit of how many publish-copy workflow instances can run at the same time
-        basemaps_import: '10', // Limit of how many basemaps import workflow instances can run at the same time
+        // Limit of how many standardising workflow instances can run at the same time
+        standardising: '2',
+        // Limit of how many bulk workflow instances can run at the same time
+        bulk: '4',
+        // Limit of how many publish-copy workflow instances can run at the same time
+        bulkcopy: '8',
+        // Limit of how many basemaps import workflow instances can run at the same time
+        basemaps_import: '10',
       },
     });
 
+    // Secrets used by the workflows
     for (const s of props.secrets) {
       const secret = new kplus.Secret(this, 'secret-' + s.name, { metadata: { name: s.name } });
       for (const [key, value] of Object.entries(s.data)) {

--- a/infra/charts/argo.semaphores.ts
+++ b/infra/charts/argo.semaphores.ts
@@ -6,13 +6,10 @@ import { applyDefaultLabels } from '../util/labels.js';
 
 export class ArgoSemaphore extends Chart {
   constructor(scope: Construct, id: string, props: ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'argo', 'v1', 'semaphores', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'semaphores', 'v1', 'semaphores', 'workflows'));
 
     new kplus.ConfigMap(this, 'semaphores', {
-      metadata: {
-        name: 'semaphores',
-        namespace: 'argo',
-      },
+      metadata: { name: 'semaphores' },
       data: {
         standardising: '2', // Limit of how many standardising workflow instances can run at the same time
         bulk: '4', // Limit of how many bulk workflow instances can run at the same time

--- a/infra/charts/argo.semaphores.ts
+++ b/infra/charts/argo.semaphores.ts
@@ -6,7 +6,7 @@ import { applyDefaultLabels } from '../util/labels.js';
 
 export class ArgoSemaphore extends Chart {
   constructor(scope: Construct, id: string, props: ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'semaphores', 'v1', 'semaphores', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'argo', 'v1', 'semaphores', 'workflows'));
 
     new kplus.ConfigMap(this, 'semaphores', {
       metadata: { name: 'semaphores' },


### PR DESCRIPTION
#### Motivation

These semaphores need to exist for the workflow templates to run

#### Modification

Add the semaphores configmap to list of charts needing to be deployed.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
