### PR TITLE
feat: add argo schema url for all argo docs

### DIFF
--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -8,6 +10,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   entrypoint: main
   templates:
     - name: main

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -8,6 +10,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   entrypoint: main
   templates:
     - name: main

--- a/templates/argo-tasks/group.yml
+++ b/templates/argo-tasks/group.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -8,6 +10,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   entrypoint: main
   templates:
     - name: main

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -8,6 +9,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   entrypoint: main
   templates:
     - name: main

--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -8,6 +10,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   entrypoint: main
   templates:
     - name: main

--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -15,6 +16,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/basemaps/create-overview-all.yaml
+++ b/workflows/basemaps/create-overview-all.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -16,6 +17,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/basemaps/create-overview.yaml
+++ b/workflows/basemaps/create-overview.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -17,6 +18,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -14,6 +16,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   arguments:
     parameters:
       - name: version_basemaps_cli
@@ -66,11 +69,11 @@ spec:
 
       - name: cutline_blend
         description: Blending to use for cutline see gdal_translate#cblend
-        value: 20
+        value: '20'
 
       - name: group_size
         description: How many items to pass to each create-cog job
-        value: 20
+        value: '20'
 
   templates:
     # Main entrypoint into the workflow

--- a/workflows/basemaps/imagery-import.yaml
+++ b/workflows/basemaps/imagery-import.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -37,14 +39,14 @@ spec:
       - name: cutline
         value: 's3://linz-basemaps-source/cutline/2020-05-07-cutline-nz-coasts-rural-and-urban.geojson'
       - name: blend
-        value: 20
+        value: '20'
       - name: aligned-level
-        value: 6
+        value: '6'
       - name: create-pull-request
-        value: true
+        value: 'true'
         enum:
-          - true
-          - false
+          - 'true'
+          - 'false'
 
   volumes:
     - name: secret-vol
@@ -54,6 +56,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       inputs:

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -22,6 +24,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -17,13 +18,14 @@ spec:
           - 'linz-basemaps'
           - 'linz-basemaps-staging'
       - name: create-pull-request
-        value: true
+        value: 'true'
         enum:
-          - true
-          - false
+          - 'true'
+          - 'false'
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/imagery/ascii-standardise-publish.yaml
+++ b/workflows/imagery/ascii-standardise-publish.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -49,6 +50,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:
@@ -113,7 +115,6 @@ spec:
               path: '/tmp/location'
 
     - name: aws-list
-      inputs:
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version-argo-tasks}}'
         command: [node, /app/index.js]

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -39,6 +40,8 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
+
   templates:
     - name: main
       inputs:

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -39,6 +40,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       inputs:

--- a/workflows/imagery/standardising-publish-import.yaml
+++ b/workflows/imagery/standardising-publish-import.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -49,6 +50,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       steps:

--- a/workflows/imagery/standardising.yaml
+++ b/workflows/imagery/standardising.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -38,12 +39,12 @@ spec:
           - '50000'
           - 'None'
       - name: validate
-        value: true
+        value: 'true'
         enum:
           - 'false'
           - 'true'
       - name: retile
-        value: false
+        value: 'false'
         enum:
           - 'true'
           - 'false'
@@ -210,6 +211,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       inputs:

--- a/workflows/imagery/tests.yaml
+++ b/workflows/imagery/tests.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -14,6 +16,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: test-script
       script:

--- a/workflows/test/env.yaml
+++ b/workflows/test/env.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -1,4 +1,5 @@
----
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -25,6 +26,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      iamge: ''
   templates:
     - name: main
       dag:

--- a/workflows/test/list.arm.yaml
+++ b/workflows/test/list.arm.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 # Example of using ARM + Spot instances for processing
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -17,6 +19,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/test/list.yaml
+++ b/workflows/test/list.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -14,6 +16,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   templates:
     - name: main
       dag:

--- a/workflows/test/sleep.yml
+++ b/workflows/test/sleep.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -13,5 +15,5 @@ spec:
           requests:
             memory: 3.9Gi
             cpu: 2000m
-        image: ubuntu:22.04
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:latest
         command: ['sleep', '3600']


### PR DESCRIPTION
#### Motivation

Now that there are multiple formats of  yaml documents in this repository it is helpful to be specific for IDEs to know what sort of yaml document each are (k8s vs ArgoWorkflows.

#### Modification

Forces IDE language servers to use a consistent version of the Argo Workflows schemas

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
