### PR TITLE
fix: labels cannot contain "/"

### DIFF
--- a/infra/util/labels.ts
+++ b/infra/util/labels.ts
@@ -22,7 +22,8 @@ export function defaultLabels(
     'app.kubernetes.io/part-of': partOf,
     'app.kubernetes.io/managed-by': 'cdk8s',
     // TODO these are not "well-known" maybe we should move them into the linz namespace?
-    'app.kubernetes.io/git-repository': 'linz/topo-workflows',
+    // Labels cannot include "/" so replace with "__"
+    'app.kubernetes.io/git-repository': 'linz__topo-workflows',
     'app.kubernetes.io/git-hash': getGitBuildInfo().hash,
     'app.kubernetes.io/git-version': getGitBuildInfo().version,
     'app.kubernetes.io/build-id': getGitBuildInfo().buildId,


### PR DESCRIPTION
#### Motivation

Deployments are broken as they use a label with a "/", labels cannot contain "/" in their value


> Service "fluentbit" is invalid: metadata.labels: Invalid value: "linz/topo-workflows": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')


#### Modification

Replaces the "/" in the label with "__"

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
