### PR TITLE
fix: fluentbit is not deployed on new nodes

### DIFF
--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -88,8 +88,8 @@ HC_Period 5
         livenessProbe: false,
         readinessProbe: false,
         tolerations: [
-          { key: 'karpenter.sh/capacity-type', value: 'spot', effect: 'NoSchedule', operator: 'Equal' },
-          { key: 'kubernetes.io/arch', value: 'arm64', effect: 'NoSchedule', operator: 'Equal' },
+          { key: 'karpenter.sh/capacity-type', operator: 'Equal', value: 'spot', effect: 'NoSchedule' },
+          { key: 'kubernetes.io/arch', operator: 'Equal', value: 'arm64', effect: 'NoSchedule' },
         ],
       },
     });

--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -87,6 +87,10 @@ HC_Period 5
         // FIXME: `livenessProbe` and `readinessProbe` deactivated https://github.com/aws/eks-charts/issues/995
         livenessProbe: false,
         readinessProbe: false,
+        tolerations: [
+          { key: 'karpenter.sh/capacity-type', value: 'spot', effect: 'NoSchedule', operator: 'Equal' },
+          { key: 'kubernetes.io/arch', value: 'arm64', effect: 'NoSchedule', operator: 'Equal' },
+        ],
       },
     });
   }


### PR DESCRIPTION
#### Motivation

Fluentbit is not deployed on new nodes because of the karpenter provisioner taints.

#### Modification

Add a toleration to the daemon set matching the provisioner taints.

#### Checklist



- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
