### PR TITLE
docs:  restructure to allow expansion on the components in use

### DIFF
--- a/docs/infrastructure/components/argo.workflows.md
+++ b/docs/infrastructure/components/argo.workflows.md
@@ -1,0 +1,4 @@
+# Argo Workflows
+
+Argo Workflows is used to run the workflows inside K8s.
+It is deployed using its [Helm chart](https://github.com/argoproj/argo-helm/tree/main/charts/argo-workflows).

--- a/docs/infrastructure/components/karpenter.md
+++ b/docs/infrastructure/components/karpenter.md
@@ -1,0 +1,1 @@
+# Karpenter

--- a/docs/infrastructure/helm.md
+++ b/docs/infrastructure/helm.md
@@ -10,6 +10,6 @@ Specify the output for the imports:
 
 However, some of the component Helm charts do not have a `values.schema.json`. And that the case for most of our components:
 
-- aws-for-fluent-bit (<https://github.com/aws/eks-charts/issues/1011>)
-- Karpenter
-- Argo workflows
+- [aws-for-fluent-bit](./components/fluentbit.md) (<https://github.com/aws/eks-charts/issues/1011>)
+- [Karpenter](./components/karpenter.md)
+- [Argo workflows](./components/argo.workflows.md)

--- a/docs/infrastructure/helm.md
+++ b/docs/infrastructure/helm.md
@@ -1,0 +1,15 @@
+# Working with Helm & CDK8s
+
+It is possible to generate a specific Helm construct for the component if their chart includes a `value.schema.json`. This is useful to provide typing hints when specifying their configuration (<https://github.com/cdk8s-team/cdk8s/blob/master/docs/cli/import.md#values-schema>)
+
+To generate the Helm Construct for a specific Chart, follow the instructions [here](https://github.com/cdk8s-team/cdk8s/blob/master/docs/cli/import.md#values-schema):
+
+Specify the output for the imports:
+
+`--output infra/imports/`
+
+However, some of the component Helm charts do not have a `values.schema.json`. And that the case for most of our components:
+
+- aws-for-fluent-bit (<https://github.com/aws/eks-charts/issues/1011>)
+- Karpenter
+- Argo workflows

--- a/docs/infrastructure/initial.deployment.md
+++ b/docs/infrastructure/initial.deployment.md
@@ -1,0 +1,14 @@
+# Initial deployment
+
+The initial deployment is a two step process where AWS-CDK is used to create a EKS cluster then CDK8s is used to deploy the applications into the cluster.
+
+
+## Custom Resource Definitions
+
+The first time a cluster is deployed Custom Resource Definitions (CRD) will not exist, when `kubectl` is used to deploy the CRDs for [Karpenter](./components/karpenter.md) and [Argo Workflows](./components/argo.workflows.md) it does not wait for the CRDs to finish deploying before starting the next step.
+
+This means that any resources that require a CRD will fail to deploy with a error similar to 
+
+> resource mapping not found for name: "karpenter-template" namespace: "" from "dist/0003-karpenter-provisioner.k8s.yaml": no matches for kind "AWSNodeTemplate" in version "karpenter.k8s.aws/v1alpha1"
+
+To work around this problem the first deployment can be repeated, as the CRDs are deployed early in the deployment process.


### PR DESCRIPTION
#### Motivation

The infrastructure README is starting to get very cluttered with notes and tips, split the notes and components into their own files

#### Modification

Split more infrastructure docs into /docs

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
