### PR TITLE
refactor: remove scratch bucket creation from eks stack TDE-930

### DIFF
--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     namespace: 'argo',
     clusterName: ClusterName,
     saName: cfnOutputs[CfnOutputKeys.ArgoRunnerServiceAccountName],
-    tempBucketName: cfnOutputs[CfnOutputKeys.TempBucketName],
+    tempBucketName: `linz-${ClusterName}-scratch`, // our conventional name for Argo artifact bucket
   });
 
   new ArgoExtras(app, 'argo-extras', {

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -7,7 +7,7 @@ import { EventExporter } from './charts/event.exporter.js';
 import { FluentBit } from './charts/fluentbit.js';
 import { Karpenter, KarpenterProvisioner } from './charts/karpenter.js';
 import { CoreDns } from './charts/kube-system.coredns.js';
-import { CfnOutputKeys, ClusterName, validateKeys } from './constants.js';
+import { CfnOutputKeys, ClusterName, ScratchBucketName, validateKeys } from './constants.js';
 import { getCfnOutputs } from './util/cloud.formation.js';
 import { fetchSsmParameters } from './util/ssm.js';
 
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     namespace: 'argo',
     clusterName: ClusterName,
     saName: cfnOutputs[CfnOutputKeys.ArgoRunnerServiceAccountName],
-    tempBucketName: `linz-${ClusterName}-scratch`, // our conventional name for Argo artifact bucket
+    tempBucketName: ScratchBucketName,
   });
 
   new ArgoExtras(app, 'argo-extras', {

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,5 +1,7 @@
 /* Cluster name */
 export const ClusterName = 'Workflows';
+/* LINZ conventional name for Argo Workflows artifact bucket */
+export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
 
 /* CloudFormation Output to access from CDK8s */
 export const CfnOutputKeys = {

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -12,8 +12,6 @@ export const CfnOutputKeys = {
   FluentBitServiceAccountName: 'FluentBitServiceAccountName',
 
   ArgoRunnerServiceAccountName: 'ArgoRunnerServiceAccountName',
-
-  TempBucketName: 'TempBucketName',
 } as const;
 
 /** The list of possible keys */

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -14,7 +14,7 @@ import {
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
-import { CfnOutputKeys } from '../constants.js';
+import { CfnOutputKeys, ScratchBucketName } from '../constants.js';
 
 interface EksClusterProps extends StackProps {
   /** Optional CI User to grant access to the cluster */
@@ -38,7 +38,7 @@ export class LinzEksCluster extends Stack {
     super(scope, id, props);
     this.id = id;
 
-    this.tempBucket = Bucket.fromBucketName(this, 'Scratch', `linz-${id.toLowerCase()}-scratch`);
+    this.tempBucket = Bucket.fromBucketName(this, 'Scratch', ScratchBucketName);
 
     this.configBucket = Bucket.fromBucketName(this, 'BucketConfig', 'linz-bucket-config');
 

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -1,5 +1,5 @@
 import { KubectlV28Layer } from '@aws-cdk/lambda-layer-kubectl-v28';
-import { Aws, CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { Aws, CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
 import { InstanceType, IVpc, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, ClusterLoggingTypes, IpFamily, KubernetesVersion, NodegroupAmiType } from 'aws-cdk-lib/aws-eks';
 import {
@@ -11,7 +11,7 @@ import {
   Role,
   ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
-import { BlockPublicAccess, Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
+import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
 import { CfnOutputKeys } from '../constants.js';

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -27,7 +27,7 @@ export class LinzEksCluster extends Stack {
   /** Version of EKS to use, this must be aligned to the `kubectlLayer` */
   version = KubernetesVersion.of('1.28');
   /** Argo needs a temporary bucket to store objects */
-  tempBucket: Bucket;
+  tempBucket: IBucket;
   /* Bucket where read/write roles config files are stored */
   configBucket: IBucket;
   vpc: IVpc;
@@ -38,21 +38,7 @@ export class LinzEksCluster extends Stack {
     super(scope, id, props);
     this.id = id;
 
-    this.tempBucket = new Bucket(this, 'Scratch', {
-      /** linz-workflows-scratch */
-      bucketName: `linz-${id.toLowerCase()}-scratch`,
-      removalPolicy: RemovalPolicy.RETAIN,
-      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-      lifecycleRules: [
-        {
-          /** All artifacts are deleted after 90 days */
-          expiration: Duration.days(90),
-          /** This bucket is not used for multipart uploads so clean them up quickly */
-          abortIncompleteMultipartUploadAfter: Duration.days(3),
-        },
-      ],
-    });
-    new CfnOutput(this, CfnOutputKeys.TempBucketName, { value: this.tempBucket.bucketName });
+    this.tempBucket = Bucket.fromBucketName(this, 'Scratch', `linz-${id.toLowerCase()}-scratch`);
 
     this.configBucket = Bucket.fromBucketName(this, 'BucketConfig', 'linz-bucket-config');
 


### PR DESCRIPTION
#### Motivation

Creating the scratch bucket outside of the EKS stack will allow us to delete the cluster.

#### Modification

Remove the bucket creation from the EKS stack. Another PR in our internal infrastructure repository will be created to handle this bucket creation.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
