### PR TITLE
feat: lint inputs before publish TDE-857

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -1,5 +1,13 @@
 # ArgoTasks Templates
 
+## Contents:
+
+- [Group](##argo-tasks/group)
+- [Copy](##argo-tasks/copy)
+- [Create Manifest](##argo-tasks/create-manifest)
+- [Push to Github](##argo-tasks/push-to-github)
+- [Lint Inputs](##argo-tasks/lint-inputs)
+
 ## argo-tasks/group - `tpl-at-group`
 
 Group inputs into outputs to be used with `withParam` to run one task per grouping
@@ -159,4 +167,25 @@ See https://github.com/linz/argo-tasks#stac-github-import
       - name: repository
         value: 'elevation'
   depends: 'copy-with-github'
+```
+
+## argo-tasks/lint-inputs
+
+Template for linting the inputs to the publish workflows, to be run before data is moved/published to public locations.
+See https://github.com/linz/argo-tasks#lint-inputs
+
+### Template usage
+
+```yaml
+- name: lint-inputs
+  templateRef:
+    name: tpl-at-lint-inputs
+    template: main
+  arguments:
+    parameters:
+      - name: version
+        value: '{{workflow.parameters.version-argo-tasks}}'
+      - name: path
+        value: '{{workflow.parameters.target}}'
+  when: '{{workflow.parameters.skip-lint}} != true'
 ```

--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -187,5 +187,5 @@ See https://github.com/linz/argo-tasks#lint-inputs
         value: '{{workflow.parameters.version-argo-tasks}}'
       - name: path
         value: '{{workflow.parameters.target}}'
-  when: '{{workflow.parameters.skip-lint}} != true'
+  when: '{{workflow.parameters.lint}} == true'
 ```

--- a/templates/argo-tasks/lint-inputs.yml
+++ b/templates/argo-tasks/lint-inputs.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:

--- a/templates/argo-tasks/lint-inputs.yml
+++ b/templates/argo-tasks/lint-inputs.yml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from linz/argo-tasks
+  # see https://github.com/linz/argo-tasks#lint-inputs
+  name: tpl-at-lint-inputs
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: path
+            description: s3 path to lint
+
+          - name: version
+            description: argo-task Container version to use
+            default: 'v2'
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{= inputs.parameters.version }}'
+        command: [node, /app/index.js]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          - 'lint-inputs'
+          - '{{inputs.parameters.path}}'

--- a/workflows/imagery/README.md
+++ b/workflows/imagery/README.md
@@ -179,7 +179,7 @@ Copy files from one S3 location to another. This workflow is intended to be used
 
 ```mermaid
 graph TD;
-    create-manifest-->copy-.->push-to-github;
+    lint-inputs-->create-manifest-->copy-.->push-to-github;
 ```
 
 \* `push-to-github` is an optional task run only for `s3://linz-imagery/`
@@ -201,6 +201,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 | group       | int   | 1000                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group-size` that is reached first).                                          |
 | group-size  | str   | 100Gi                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group-size` that is reached first).                                      |
 | transform   | str   | `f`                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
+| skip-lint   | str   | `false`                                       | False: lint the target path; True: skip linting of target path - to be used when publishing to a location other than `linz-imagery` or using a non-standard path |
 
 ## Examples
 
@@ -226,11 +227,13 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 **copy-option:** `--no-clobber`
 
+**skip-lint:** `true`
+
 # Publish-odr
 
 ## Workflow Description
 
-This workflow replicates `publish-copy` however it allows publishing to `s3://nz-imagery`(the registry of open data).
+This workflow replicates `publish-copy` however it allows publishing to `s3://nz-imagery` (the registry of open data).
 **This workflow should not be run using the Argo UI, instead follow the instruction [here](https://github.com/linz/imagery/tree/master/workflow-parameters/README.md)**
 
 See the [publish-copy template](#publish-copy) for more information.

--- a/workflows/imagery/README.md
+++ b/workflows/imagery/README.md
@@ -201,7 +201,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 | group       | int   | 1000                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group-size` that is reached first).                                          |
 | group-size  | str   | 100Gi                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group-size` that is reached first).                                      |
 | transform   | str   | `f`                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
-| skip-lint   | str   | `false`                                       | False: lint the target path; True: skip linting of target path - to be used when publishing to a location other than `linz-imagery` or using a non-standard path |
+| lint        | str   | `true`                                        | true: lint the target path; false: skip linting of target path - to be used when publishing to a location other than `linz-imagery` or using a non-standard path |
 
 ## Examples
 
@@ -227,7 +227,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 **copy-option:** `--no-clobber`
 
-**skip-lint:** `true`
+**lint:** `true`
 
 # Publish-odr
 

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -37,8 +37,8 @@ spec:
         value: '100Gi'
       - name: transform
         value: 'f'
-      - name: 'skip-lint'
-        value: 'false'
+      - name: 'lint'
+        value: 'true'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -64,7 +64,7 @@ spec:
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: path
                   value: '{{workflow.parameters.target}}'
-            when: '{{workflow.parameters.skip-lint}} != true'
+            when: '{{workflow.parameters.lint}} == true'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -37,6 +37,8 @@ spec:
         value: '100Gi'
       - name: transform
         value: 'f'
+      - name: 'skip-lint'
+        value: 'false'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -52,6 +54,17 @@ spec:
           - name: group-size
       dag:
         tasks:
+          - name: lint-inputs
+            templateRef:
+              name: tpl-at-lint-inputs
+              template: main
+            arguments:
+              parameters:
+                - name: version
+                  value: '{{workflow.parameters.version-argo-tasks}}'
+                - name: path
+                  value: '{{workflow.parameters.target}}'
+            when: '{{workflow.parameters.skip-lint}} != true'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest

--- a/workflows/imagery/publish-copy.yaml
+++ b/workflows/imagery/publish-copy.yaml
@@ -64,7 +64,7 @@ spec:
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: path
                   value: '{{workflow.parameters.target}}'
-            when: '{{workflow.parameters.lint}} == true'
+            when: '{{workflow.parameters.lint}}'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -37,6 +37,8 @@ spec:
         value: '100Gi'
       - name: transform
         value: 'f'
+      - name: skip-lint
+        value: 'false'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -51,6 +53,17 @@ spec:
           - name: group-size
       dag:
         tasks:
+          - name: lint-inputs
+            templateRef:
+              name: tpl-at-lint-inputs
+              template: main
+            arguments:
+              parameters:
+                - name: version
+                  value: '{{workflow.parameters.version-argo-tasks}}'
+                - name: path
+                  value: '{{workflow.parameters.target}}'
+            when: '{{workflow.parameters.skip-lint}} != true'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -63,7 +63,7 @@ spec:
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: path
                   value: '{{workflow.parameters.target}}'
-            when: '{{workflow.parameters.lint}} == true'
+            when: '{{workflow.parameters.lint}}'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest

--- a/workflows/imagery/publish-odr.yaml
+++ b/workflows/imagery/publish-odr.yaml
@@ -37,7 +37,7 @@ spec:
         value: '100Gi'
       - name: transform
         value: 'f'
-      - name: skip-lint
+      - name: lint
         value: 'false'
   templateDefaults:
     container:
@@ -63,7 +63,7 @@ spec:
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: path
                   value: '{{workflow.parameters.target}}'
-            when: '{{workflow.parameters.skip-lint}} != true'
+            when: '{{workflow.parameters.lint}} == true'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest


### PR DESCRIPTION
#### Motivation

To be sure that the target paths in the publish workflows follow conventions by linting.

#### Modification

new linting step added to the start of `publish-copy` and `publish-odr`
This step can be skipped with the new parameter `skip-lint: 'true'`

#### Checklist

_If not applicable, provide explanation of why._

~~- [ ] Tests updated~~ - there are no tests but the template was tested manually
- [x] Docs updated
- [x] Issue linked in Title
