### PR TITLE
feat(basemaps): Update create-mapsheet workflow to use the cli from argo tasks.

### DIFF
--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -9,8 +9,6 @@ spec:
     parameters:
       - name: version-argo-tasks
         value: 'v2'
-      - name: version-basemaps-cli
-        value: 'v6'
       - name: layer
         value: '104687'
       - name: config
@@ -85,17 +83,17 @@ spec:
             path: /tmp/flatGeobuf.fgb
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
-        command: [node, index.cjs]
+        command: [node, index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
         args:
           [
-            '-V',
+            'bmc',
             'create-mapsheet',
             '--path',
             '/tmp/flatGeobuf.fgb',
-            '--config',
+            '--bm-config',
             '{{=sprig.trim(workflow.parameters.config)}}',
             '--output',
             '/tmp/mapsheet.json',

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -18,7 +18,7 @@ spec:
       - name: include
         value: ''
       - name: exclude
-        value: 'nz_satellite'
+        value: 'nz-satellite'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -84,7 +84,7 @@ spec:
           - name: flatGeobuf
             path: /tmp/flatGeobuf.fgb
       container:
-        image: ghcr.io/linz/basemaps/cli:{{=sprig.trim(workflow.parameters['version-basemaps-cli'])}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters['version-argo-tasks'])}}
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -55,7 +55,7 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
-        args: ['lds-fetch-layer', '{{=sprig.trim(inputs.parameters.layer)}}', '--target', '/tmp/lds-layer']
+        args: ['lds-fetch-layer', '{{=sprig.trim(inputs.parameters.layer)}}', '--target=/tmp/lds-layer']
       outputs:
         artifacts:
           - name: geopackage
@@ -91,16 +91,11 @@ spec:
           [
             'bmc',
             'create-mapsheet',
-            '--path',
-            '/tmp/flatGeobuf.fgb',
-            '--bm-config',
-            '{{=sprig.trim(workflow.parameters.config)}}',
-            '--output',
-            '/tmp/mapsheet.json',
-            '--include',
-            '{{=sprig.trim(workflow.parameters.include)}}',
-            '--exclude',
-            '{{=sprig.trim(workflow.parameters.exclude)}}',
+            '--path=/tmp/flatGeobuf.fgb',
+            '--bm-config={{=sprig.trim(workflow.parameters.config)}}',
+            '--output=/tmp/mapsheet.json',
+            '--include={{=sprig.trim(workflow.parameters.include)}}',
+            '--exclude={{=sprig.trim(workflow.parameters.exclude)}}',
           ]
       outputs:
         artifacts:


### PR DESCRIPTION
#### Motivation
We relocate the create-mapsheet cli into argo-tasks.

#### Modification


#### Checklist
- update the task to use argo-tasks container
- fix the exclude satellite name to align with the new basemaps-config naming convention.

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
