### PR TITLE
docs: add docs on linz well known labels TDE-932

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,10 +1,10 @@
 # Kubernetes & Workflow Labels
 
-To make it easier to filter and parse the huge amount of workflows and other objects that are inside our cluster. A number of labels need to be applied to every workflow.
+To make it easier to filter and parse the huge amount of workflows and other objects that are inside our cluster, a number of labels need to be applied to every workflow.
 
-The labels can be used in both [Argo Workflows](./infrastructure/components/argo.workflows.md) and the kubectl command line.
+The labels can be used in both [Argo Workflows](./infrastructure/components/argo.workflows.md) and the `kubectl` command line.
 
-The following list of labels should be used in conjunction with kubernetes [well known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) and [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
+The following list of labels should be used in conjunction with Kubernetes [well known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) and [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
 
 ## Workflows
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -6,39 +6,36 @@ The labels can be used in both [Argo Workflows](./infrastructure/components/argo
 
 The following list of labels should be used in conjunction with kubernetes [well known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) and [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
 
-
 ## Workflows
 
-| Label                                    | Description              | Examples |
-| ------------------- | ---------------------------------------- | ------------------------ |
-| `linz.govt.nz/ticket`                    | JIRA Ticket number                                                               | `TDE-912`, `BM-37`                               |
-| `linz.govt.nz/region`                    | Geographic region that object relates to                                         | "wellington", "auckland"                         |
-| `linz.govt.nz/group`                     | The LINZ group that owns the workflow                                            | "basemaps", "imagery", "test", "util"            |
+| Label                 | Description                              | Examples                              |
+| --------------------- | ---------------------------------------- | ------------------------------------- |
+| `linz.govt.nz/ticket` | JIRA Ticket number                       | `TDE-912`, `BM-37`                    |
+| `linz.govt.nz/region` | Geographic region that object relates to | "wellington", "auckland"              |
+| `linz.govt.nz/group`  | The LINZ group that owns the workflow    | "basemaps", "imagery", "test", "util" |
 
 For the type of data that is being processed
 
-| Label                                    | Description              | Examples |
-| ------------------- | ---------------------------------------- | ------------------------ |
-| `linz.govt.nz/data-type`                    | Type of data being processed                                                     | "raster", "vector"              |
-| `linz.govt.nz/data-sub-type`                | Sub type of data if it exists                                                    | "imagery", "elevation"          |
+| Label                        | Description                   | Examples               |
+| ---------------------------- | ----------------------------- | ---------------------- |
+| `linz.govt.nz/data-type`     | Type of data being processed  | "raster", "vector"     |
+| `linz.govt.nz/data-sub-type` | Sub type of data if it exists | "imagery", "elevation" |
 
 ## Kubernetes Objects
 
 Most other objects deployed via AWS-CDK and CDK8s should also include information about the CICD process that deployed it
 
-| Label                                    | Description              | Examples |
-| ------------------- | ---------------------------------------- | ------------------------ |
-| `linz.govt.nz/git-hash`                | git hash that deployed the object                                                     | "bb3dab2779922094d2b8ecd4c67f30c66b38613d"              |
-| `linz.govt.nz/git-version`             | git version information                                                     | "v6.46.0", "v0.0.1-20-gbb3dab27"          |
-| `linz.govt.nz/git-repo`                | git repository that the object came from                                                    | "linz__topo-workflows"          |
-| `linz.govt.nz/build-id`                | Unique ID of the build that deployed                                                     | "6806791032-1"          |
-
-
+| Label                      | Description                              | Examples                                   |
+| -------------------------- | ---------------------------------------- | ------------------------------------------ |
+| `linz.govt.nz/git-hash`    | git hash that deployed the object        | "bb3dab2779922094d2b8ecd4c67f30c66b38613d" |
+| `linz.govt.nz/git-version` | git version information                  | "v6.46.0", "v0.0.1-20-gbb3dab27"           |
+| `linz.govt.nz/git-repo`    | git repository that the object came from | "linz\_\_topo-workflows"                   |
+| `linz.govt.nz/build-id`    | Unique ID of the build that deployed     | "6806791032-1"                             |
 
 ## Label Usage
 
-
 To list all the pods and show their labels
+
 ```bash
 k get pods -n argo --show-labels
 ```
@@ -49,10 +46,8 @@ Find pods based off component names
 k get pods -n argo -l "app.kubernetes.io/component=server"
 ```
 
-
-Find all pods deployed from linz/topo-workflows, Kubernetes does not work with "/" so repository names are replaced with "__"
+Find all pods deployed from linz/topo-workflows, Kubernetes does not work with "/" so repository names are replaced with "\_\_"
 
 ```bash
 k get all -A -l "linz.govt.nz/git-repo=linz__topo-workflows"
 ```
-

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -29,7 +29,7 @@ Most other objects deployed via AWS-CDK and CDK8s should also include informatio
 | -------------------------- | ---------------------------------------- | ------------------------------------------ |
 | `linz.govt.nz/git-hash`    | git hash that deployed the object        | "bb3dab2779922094d2b8ecd4c67f30c66b38613d" |
 | `linz.govt.nz/git-version` | git version information                  | "v6.46.0", "v0.0.1-20-gbb3dab27"           |
-| `linz.govt.nz/git-repo`    | git repository that the object came from | "linz\_\_topo-workflows"                   |
+| `linz.govt.nz/git-repository`    | git repository that the object came from | "linz\_\_topo-workflows"                   |
 | `linz.govt.nz/build-id`    | Unique ID of the build that deployed     | "6806791032-1"                             |
 
 ## Label Usage

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -12,7 +12,7 @@ The following list of labels should be used in conjunction with kubernetes [well
 | --------------------- | ---------------------------------------- | ------------------------------------- |
 | `linz.govt.nz/ticket` | JIRA Ticket number                       | `TDE-912`, `BM-37`                    |
 | `linz.govt.nz/region` | Geographic region that object relates to | "wellington", "auckland"              |
-| `linz.govt.nz/group`  | The LINZ group that owns the workflow    | "basemaps", "imagery", "test", "util" |
+| `linz.govt.nz/category`  | The LINZ group that owns the workflow    | "basemaps", "imagery", "test", "util" |
 
 For the type of data that is being processed
 
@@ -46,7 +46,7 @@ Find pods based off component names
 k get pods -n argo -l "app.kubernetes.io/component=server"
 ```
 
-Find all pods deployed from linz/topo-workflows, Kubernetes does not work with "/" so repository names are replaced with "\_\_"
+Find all resources deployed from linz/topo-workflows github repository, Kubernetes does not work with "/" so repository names are replaced with "\_\_"
 
 ```bash
 k get all -A -l "linz.govt.nz/git-repo=linz__topo-workflows"

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,58 @@
+# Kubernetes & Workflow Labels
+
+To make it easier to filter and parse the huge amount of workflows and other objects that are inside our cluster. A number of labels need to be applied to every workflow.
+
+The labels can be used in both [Argo Workflows](./infrastructure/components/argo.workflows.md) and the kubectl command line.
+
+The following list of labels should be used in conjunction with kubernetes [well known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) and [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
+
+
+## Workflows
+
+| Label                                    | Description              | Examples |
+| ------------------- | ---------------------------------------- | ------------------------ |
+| `linz.govt.nz/ticket`                    | JIRA Ticket number                                                               | `TDE-912`, `BM-37`                               |
+| `linz.govt.nz/region`                    | Geographic region that object relates to                                         | "wellington", "auckland"                         |
+| `linz.govt.nz/group`                     | The LINZ group that owns the workflow                                            | "basemaps", "imagery", "test", "util"            |
+
+For the type of data that is being processed
+
+| Label                                    | Description              | Examples |
+| ------------------- | ---------------------------------------- | ------------------------ |
+| `linz.govt.nz/data-type`                    | Type of data being processed                                                     | "raster", "vector"              |
+| `linz.govt.nz/data-sub-type`                | Sub type of data if it exists                                                    | "imagery", "elevation"          |
+
+## Kubernetes Objects
+
+Most other objects deployed via AWS-CDK and CDK8s should also include information about the CICD process that deployed it
+
+| Label                                    | Description              | Examples |
+| ------------------- | ---------------------------------------- | ------------------------ |
+| `linz.govt.nz/git-hash`                | git hash that deployed the object                                                     | "bb3dab2779922094d2b8ecd4c67f30c66b38613d"              |
+| `linz.govt.nz/git-version`             | git version information                                                     | "v6.46.0", "v0.0.1-20-gbb3dab27"          |
+| `linz.govt.nz/git-repo`                | git repository that the object came from                                                    | "linz__topo-workflows"          |
+| `linz.govt.nz/build-id`                | Unique ID of the build that deployed                                                     | "6806791032-1"          |
+
+
+
+## Label Usage
+
+
+To list all the pods and show their labels
+```bash
+k get pods -n argo --show-labels
+```
+
+Find pods based off component names
+
+```bash
+k get pods -n argo -l "app.kubernetes.io/component=server"
+```
+
+
+Find all pods deployed from linz/topo-workflows, Kubernetes does not work with "/" so repository names are replaced with "__"
+
+```bash
+k get all -A -l "linz.govt.nz/git-repo=linz__topo-workflows"
+```
+

--- a/infra/util/labels.ts
+++ b/infra/util/labels.ts
@@ -21,12 +21,13 @@ export function defaultLabels(
     'app.kubernetes.io/component': component,
     'app.kubernetes.io/part-of': partOf,
     'app.kubernetes.io/managed-by': 'cdk8s',
-    // TODO these are not "well-known" maybe we should move them into the linz namespace?
+
+    // See /docs/labels.md for more information on LINZ's labels
     // Labels cannot include "/" so replace with "__"
-    'app.kubernetes.io/git-repository': 'linz__topo-workflows',
-    'app.kubernetes.io/git-hash': getGitBuildInfo().hash,
-    'app.kubernetes.io/git-version': getGitBuildInfo().version,
-    'app.kubernetes.io/build-id': getGitBuildInfo().buildId,
+    'linz.govt.nz/git-repository': 'linz__topo-workflows',
+    'linz.govt.nz/git-hash': getGitBuildInfo().hash,
+    'linz.govt.nz/git-version': getGitBuildInfo().version,
+    'linz.govt.nz/build-id': getGitBuildInfo().buildId,
   };
 }
 


### PR DESCRIPTION
#### Motivation

We use a number of undocumented labels across the kubernetes cluster to make it easier to find objects, this adds some background on the labels and how to use them

#### Modification

Add a document to explain the well known labels

#### Checklist

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
