### PR TITLE
test: downgrade kubernetes version to deploy cluster TDE-916

### DIFF
--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -1,4 +1,4 @@
-import { KubectlV28Layer } from '@aws-cdk/lambda-layer-kubectl-v28';
+import { KubectlV27Layer } from '@aws-cdk/lambda-layer-kubectl-v27';
 import { Aws, CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
 import { InstanceType, IVpc, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, ClusterLoggingTypes, IpFamily, KubernetesVersion, NodegroupAmiType } from 'aws-cdk-lib/aws-eks';
@@ -25,7 +25,7 @@ export class LinzEksCluster extends Stack {
   /* Cluster ID */
   id: string;
   /** Version of EKS to use, this must be aligned to the `kubectlLayer` */
-  version = KubernetesVersion.of('1.28');
+  version = KubernetesVersion.V1_27;
   /** Argo needs a temporary bucket to store objects */
   tempBucket: IBucket;
   /* Bucket where read/write roles config files are stored */
@@ -51,7 +51,7 @@ export class LinzEksCluster extends Stack {
       defaultCapacity: 0,
       vpcSubnets: [{ subnetType: SubnetType.PRIVATE_WITH_EGRESS }],
       /** This must align to Cluster version: {@link version} */
-      kubectlLayer: new KubectlV28Layer(this, 'KubeCtlLayer'),
+      kubectlLayer: new KubectlV27Layer(this, 'KubeCtlLayer'),
       /** To prevent IP exhaustion when running huge workflows run using ipv6 */
       ipFamily: IpFamily.IP_V6,
       clusterLogging: [ClusterLoggingTypes.API, ClusterLoggingTypes.CONTROLLER_MANAGER, ClusterLoggingTypes.SCHEDULER],

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,16 +63,6 @@
         "constructs": "^10.0.5"
       }
     },
-    "node_modules/@aws-cdk/lambda-layer-kubectl-v28": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v28/-/lambda-layer-kubectl-v28-2.0.0.tgz",
-      "integrity": "sha512-IudB7xOD5zVivndESTSACA4rhOJtF5oduqI9y0yF/T5vACg16ToEWPUB0LKt3EQuXswxOlrak9mgnhNK33BHJA==",
-      "dev": true,
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.28.0",
-        "constructs": "^10.0.5"
-      }
-    },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@aws-cdk/lambda-layer-kubectl-v28": "^2.0.0",
+        "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
         "@aws-sdk/client-cloudformation": "3.429.0",
         "@aws-sdk/client-eks": "3.429.0",
         "@aws-sdk/client-ssm": "3.429.0",
@@ -52,6 +52,16 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
       "dev": true
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v27": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v27/-/lambda-layer-kubectl-v27-2.0.0.tgz",
+      "integrity": "sha512-BBh4ScPHaD82e7Z3PYXqyLjqfk/3/PRDTJW3x2j4l5f6sHXU041TaXKcFAGBHb1m4aq2UK+fwkIq95mgs3c0dg==",
+      "dev": true,
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.28.0",
+        "constructs": "^10.0.5"
+      }
     },
     "node_modules/@aws-cdk/lambda-layer-kubectl-v28": {
       "version": "2.0.0",
@@ -2578,13 +2588,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2600,7 +2608,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2609,7 +2616,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2624,7 +2630,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2633,13 +2638,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2649,7 +2652,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -2658,7 +2660,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2670,31 +2671,26 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2708,13 +2704,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2723,7 +2717,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2732,13 +2725,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2750,7 +2741,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2759,13 +2749,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2777,7 +2765,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2789,7 +2776,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2798,7 +2784,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2807,7 +2792,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2822,7 +2806,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2839,7 +2822,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2853,7 +2835,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2865,7 +2846,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.8.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2881,7 +2861,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2890,7 +2869,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2899,13 +2877,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format": "npx prettier . -w"
   },
   "devDependencies": {
+    "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
     "@aws-cdk/lambda-layer-kubectl-v28": "^2.0.0",
     "@aws-sdk/client-cloudformation": "3.429.0",
     "@aws-sdk/client-eks": "3.429.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
-    "@aws-cdk/lambda-layer-kubectl-v28": "^2.0.0",
     "@aws-sdk/client-cloudformation": "3.429.0",
     "@aws-sdk/client-eks": "3.429.0",
     "@aws-sdk/client-ssm": "3.429.0",


### PR DESCRIPTION
#### Motivation

In order to test and ensure that [the upgrade procedure/doc](https://github.com/linz/topo-workflows/blob/master/docs/infrastructure/kubernetes.version.md) works

#### Modification

Downgrade Kubernetes

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
