### PR TITLE
feat: upgrade k8s to test process TDE-916

### DIFF
--- a/docs/infrastructure/kubernetes.version.md
+++ b/docs/infrastructure/kubernetes.version.md
@@ -6,6 +6,8 @@ Because Kubernetes deprecates quickly and releases often, we need to keep our ku
 
 ## Upgrade steps
 
+**It is a [good idea](https://cdk8s.io/docs/latest/plus/#i-operate-kubernetes-version-1xx-which-cdk8s-library-should-i-be-using) to check if a `CDK8s` version matches the Kubernetes version you want to upgrade to.**
+
 Below is an example of upgrading from v1.27 to v1.28
 
 1. Update lambda-layer version to the matching version number

--- a/docs/infrastructure/kubernetes.version.md
+++ b/docs/infrastructure/kubernetes.version.md
@@ -6,7 +6,27 @@ Because Kubernetes deprecates quickly and releases often, we need to keep our ku
 
 ## Upgrade steps
 
+### Upgrade `cdk8s-plus`
+
 **It is a [good idea](https://cdk8s.io/docs/latest/plus/#i-operate-kubernetes-version-1xx-which-cdk8s-library-should-i-be-using) to check if a `CDK8s-plus` version matches the Kubernetes version you want to upgrade to.**
+
+If there is a version matching to the Kubernetes version to upgrade to, upgrade CDK8s-plus before proceeding to upgrade Kubernetes steps.
+
+1. Install the new version
+
+```bash
+npm install --save-dev cdk8s-plus-27
+```
+
+2. Remove the previous version
+
+```bash
+npm rm cdk8s-plus-26
+```
+
+If there is no version matching, keep the version installed and proceed to upgrade Kubernetes steps.
+
+### Upgrade Kubernetes
 
 Below is an example of upgrading from v1.27 to v1.28
 

--- a/docs/infrastructure/kubernetes.version.md
+++ b/docs/infrastructure/kubernetes.version.md
@@ -6,7 +6,7 @@ Because Kubernetes deprecates quickly and releases often, we need to keep our ku
 
 ## Upgrade steps
 
-**It is a [good idea](https://cdk8s.io/docs/latest/plus/#i-operate-kubernetes-version-1xx-which-cdk8s-library-should-i-be-using) to check if a `CDK8s` version matches the Kubernetes version you want to upgrade to.**
+**It is a [good idea](https://cdk8s.io/docs/latest/plus/#i-operate-kubernetes-version-1xx-which-cdk8s-library-should-i-be-using) to check if a `CDK8s-plus` version matches the Kubernetes version you want to upgrade to.**
 
 Below is an example of upgrading from v1.27 to v1.28
 

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -1,4 +1,4 @@
-import { KubectlV27Layer } from '@aws-cdk/lambda-layer-kubectl-v27';
+import { KubectlV28Layer } from '@aws-cdk/lambda-layer-kubectl-v28';
 import { Aws, CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
 import { InstanceType, IVpc, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, ClusterLoggingTypes, IpFamily, KubernetesVersion, NodegroupAmiType } from 'aws-cdk-lib/aws-eks';
@@ -25,7 +25,7 @@ export class LinzEksCluster extends Stack {
   /* Cluster ID */
   id: string;
   /** Version of EKS to use, this must be aligned to the `kubectlLayer` */
-  version = KubernetesVersion.V1_27;
+  version = KubernetesVersion.of('1.28');
   /** Argo needs a temporary bucket to store objects */
   tempBucket: IBucket;
   /* Bucket where read/write roles config files are stored */
@@ -51,7 +51,7 @@ export class LinzEksCluster extends Stack {
       defaultCapacity: 0,
       vpcSubnets: [{ subnetType: SubnetType.PRIVATE_WITH_EGRESS }],
       /** This must align to Cluster version: {@link version} */
-      kubectlLayer: new KubectlV27Layer(this, 'KubeCtlLayer'),
+      kubectlLayer: new KubectlV28Layer(this, 'KubeCtlLayer'),
       /** To prevent IP exhaustion when running huge workflows run using ipv6 */
       ipFamily: IpFamily.IP_V6,
       clusterLogging: [ClusterLoggingTypes.API, ClusterLoggingTypes.CONTROLLER_MANAGER, ClusterLoggingTypes.SCHEDULER],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
+        "@aws-cdk/lambda-layer-kubectl-v28": "^2.0.0",
         "@aws-sdk/client-cloudformation": "3.429.0",
         "@aws-sdk/client-eks": "3.429.0",
         "@aws-sdk/client-ssm": "3.429.0",
@@ -53,10 +53,10 @@
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
       "dev": true
     },
-    "node_modules/@aws-cdk/lambda-layer-kubectl-v27": {
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v28": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v27/-/lambda-layer-kubectl-v27-2.0.0.tgz",
-      "integrity": "sha512-BBh4ScPHaD82e7Z3PYXqyLjqfk/3/PRDTJW3x2j4l5f6sHXU041TaXKcFAGBHb1m4aq2UK+fwkIq95mgs3c0dg==",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v28/-/lambda-layer-kubectl-v28-2.0.0.tgz",
+      "integrity": "sha512-IudB7xOD5zVivndESTSACA4rhOJtF5oduqI9y0yF/T5vACg16ToEWPUB0LKt3EQuXswxOlrak9mgnhNK33BHJA==",
       "dev": true,
       "peerDependencies": {
         "aws-cdk-lib": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "npx prettier . -w"
   },
   "devDependencies": {
-    "@aws-cdk/lambda-layer-kubectl-v27": "^2.0.0",
+    "@aws-cdk/lambda-layer-kubectl-v28": "^2.0.0",
     "@aws-sdk/client-cloudformation": "3.429.0",
     "@aws-sdk/client-eks": "3.429.0",
     "@aws-sdk/client-ssm": "3.429.0",


### PR DESCRIPTION
#### Motivation

Testing [the process of upgrading Kubernetes](https://github.com/linz/topo-workflows/blob/master/docs/infrastructure/kubernetes.version.md#upgrade-kubernetes-versions).

#### Modification

- Upgrade Kubernetes in the Cluster stack so `cdk deploy` will upgrade the EKS cluster (ran the commands in the [doc](https://github.com/linz/topo-workflows/blob/master/docs/infrastructure/kubernetes.version.md#upgrade-steps)):

```
[~] AWS::Lambda::LayerVersion KubeCtlLayer KubeCtlLayerF044A2BC replace
 ├─ [~] Content (requires replacement)
 │   └─ [~] .S3Key:
 │       ├─ [-] 8e18eb5caccd2617fb76e648fa6a35dc0ece98c4681942bc6861f41afdff6a1b.zip
 │       └─ [+] b4d47e4f1c5e8fc2df2cd474ede548de153300d332ba8d582b7c1193e61cbe1e.zip
 ├─ [~] Description (requires replacement)
 │   ├─ [-] /opt/kubectl/kubectl 1.27; /opt/helm/helm 3.12
 │   └─ [+] /opt/kubectl/kubectl 1.28; /opt/helm/helm 3.13
 └─ [~] Metadata
     └─ [~] .aws:asset:path:
         ├─ [-] asset.8e18eb5caccd2617fb76e648fa6a35dc0ece98c4681942bc6861f41afdff6a1b.zip
         └─ [+] asset.b4d47e4f1c5e8fc2df2cd474ede548de153300d332ba8d582b7c1193e61cbe1e.zip
[~] Custom::AWSCDK-EKS-Cluster EksWorkflows/Resource/Resource EksWorkflows8ECBBC49 
 └─ [~] Config
     └─ [~] .version:
         ├─ [-] 1.27
         └─ [+] 1.28
```

- Manual step, after this PR get merged and GH Actions successed, to [upgrade EC2 nodes ](https://github.com/linz/topo-workflows/blob/master/docs/infrastructure/kubernetes.version.md#cycle-out-ec2-nodes-to-the-new-version)
- No `CDK8s-plus` version matching this new K8s version, yet.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
