### PR TITLE
docs: De-dupe code found elsewhere in the repo TDE-917

### DIFF
--- a/docs/training/workshop.md
+++ b/docs/training/workshop.md
@@ -465,94 +465,9 @@ For more in-depth information, see:
 
 ### Parallelising a task to run in multiple pods
 
-The example below uses `{{item}}` to run pods in parallel. This expands a single workflow task into multiple parallel steps using a list output from a previous task. It also passes the output from the `aws-list` task to the `stac-print-path` task.
+The example below uses `{{item}}` to run pods in parallel. This expands a single workflow task into multiple parallel steps using a list output from a previous task. It also passes the output from the `aws-list` task to the `stac-print-path` task. Example workflow file:
 
-```yaml
----
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: test-output-parallel-
-spec:
-  nodeSelector:
-    karpenter.sh/capacity-type: "spot"
-  parallelism: 20
-  nodeSelector:
-    karpenter.sh/capacity-type: "spot"
-  serviceAccountName: workflow-runner-sa
-  entrypoint: main
-  arguments:
-    parameters:
-      - name: uri
-        value: "s3://linz-imagery-staging/test/stac-validate/"
-  templateDefaults:
-    container:
-      imagePullPolicy: Always
-  templates:
-    - name: main
-      dag:
-        tasks:
-          - name: aws-list
-            template: aws-list
-            arguments:
-              parameters:
-                - name: uri
-                  value: "{{workflow.parameters.uri}}"
-                - name: include
-                  value: "json$"
-          - name: stac-print-path
-            template: stac-print-path
-            arguments:
-              parameters:
-                - name: file
-                  value: "{{item}}"
-            depends: "aws-list"
-            withParam: "{{tasks.aws-list.outputs.parameters.files}}"
-    - name: aws-list
-      inputs:
-        parameters:
-          - name: uri
-          - name: include
-      container:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:v2"
-        command: [node, /app/index.js]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-        args:
-          [
-            "list",
-            "--verbose",
-            "--include",
-            "{{inputs.parameters.include}}",
-            "--group",
-            "4",
-            "--output",
-            "/tmp/file_list.json",
-            "{{inputs.parameters.uri}}",
-          ]
-      outputs:
-        parameters:
-          - name: files
-            valueFrom:
-              path: /tmp/file_list.json
-    - name: stac-print-path
-      inputs:
-        parameters:
-          - name: file
-      script:
-        image: "019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:v2"
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
-        command:
-          - "bash"
-        source: |
-          PATH_OUT=$(echo "{{inputs.parameters.file}}" | sed 's/,/ /g; s/\[/ /g; s/\]/ /g')
-          echo $PATH_OUT
-```
-
-Example workflow file: [wf_output_parallel.yaml](examples/wf_output_parallel.yaml)
+https://github.com/linz/topo-workflows/blob/fb952073c01e3f34c2f66c24b70b6f4df68b15b2/docs/training/examples/wf_output_parallel.yaml#L1-L81
 
 The output should look like this in the Argo UI:
 


### PR DESCRIPTION
#### Motivation

Avoid duplicating the full contents of files elsewhere in the repo inside the workshop Markdown.

#### Modification

Simplifies the job of keeping the code in sync.

#### Checklist

- [ ] Tests updated (No tests)
- [x] Docs updated
- [x] Issue linked in Title
