### PR TITLE
feat: Pin actions to hashes TDE-934

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build, Format and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: linz/action-typescript@v3
+      - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # pin@v3
 
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
@@ -30,16 +30,16 @@ jobs:
       CLUSTER_NAME: Workflows
 
     steps:
-      - uses: linz/action-typescript@v3
+      - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # pin@v3
 
       # Configure access to AWS / EKS
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # pin@v3
         with:
           version: 'latest'
 
       - name: AWS Configure
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: linz/action-pull-request-lint@v1
+      - uses: linz/action-pull-request-lint@290a98eb0ac22b16476c147ce402eff61171e042 # pin@v1
         with:
           conventional: 'error' # require conventional pull request title (default: "error" options: "error", "warn", "off")
 


### PR DESCRIPTION
#### Motivation

Make sure we run specific versions of actions, rather than moving tags.

#### Modification

Done with pin-github-action <https://github.com/mheap/pin-github-action> 1.8.0 using `npx pin-github-action .github/workflows/*.yml`.

Dependabot should support updating in the same fashion <https://github.com/dependabot/dependabot-core/issues/8277#issuecomment-1782819752>.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated (N/A)
- [ ] Docs updated (N/A)
- [x] Issue linked in Title
