### PR TITLE
feat: give maintainers access to the EKS cluster TDE-926

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       - name: (CDK) Deploy
         run: |
           npx cdk deploy ${{ env.CLUSTER_NAME }} \
-            -c admin-role-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WF_MAINTENER_ROLE }} \
+            -c admin-role-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }} \
             -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }}
 
       # Configure the Kubernetes cluster with CDK8s

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       - name: (CDK) Deploy
         run: |
           npx cdk deploy ${{ env.CLUSTER_NAME }} \
-            -c ci-role-arn=${{ secrets.AWS_CI_ROLE }} \
+            -c admin-role-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WF_MAINTENER_ROLE }} \
             -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }}
 
       # Configure the Kubernetes cluster with CDK8s

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       - name: (CDK) Deploy
         run: |
           npx cdk deploy ${{ env.CLUSTER_NAME }} \
-            -c admin-role-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }} \
+            -c maintainer-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }} \
             -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }}
 
       # Configure the Kubernetes cluster with CDK8s

--- a/infra/__test__/arn.test.ts
+++ b/infra/__test__/arn.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { App } from 'aws-cdk-lib';
+
+import { tryGetContextArn, tryGetContextArns, validateRoleArn } from '../eks/arn.js';
+
+describe('roleArnValidator', () => {
+  it('should error if arn is not a valid role', () => {
+    assert.throws(() => validateRoleArn(''));
+    assert.throws(() => validateRoleArn('ABC'));
+    assert.throws(() => validateRoleArn(1));
+    assert.throws(() => validateRoleArn(null));
+  });
+
+  it('should allow role arns', () => {
+    const arn = validateRoleArn('arn:aws:iam::1234567890:role/AccountAdminRole');
+    assert.equal(arn.service, 'iam');
+    assert.equal(arn.resource, 'role');
+    assert.equal(arn.partition, 'aws');
+  });
+
+  it('should not allow *', () => {
+    assert.throws(() => validateRoleArn('arn:aws:iam::1234567890:role/*'));
+  });
+});
+
+describe('tryGetContextArn', () => {
+  it('should parse from the context, validate, and return the role arn', () => {
+    const app = new App();
+    app.node.setContext('admin-role', 'arn:aws:iam::1234567890:role/AccountAdminRole');
+    const roleArn = tryGetContextArn(app.node, 'admin-role');
+    assert.equal(roleArn, 'arn:aws:iam::1234567890:role/AccountAdminRole');
+  });
+});
+
+describe('tryGetContextArns', () => {
+  it('should parse from the context, validate, and return the list of role arns', () => {
+    const app = new App();
+    app.node.setContext(
+      'admin-roles',
+      'arn:aws:iam::1234567890:role/AccountAdminRole,arn:aws:iam::1234567890:role/AccountCiRole',
+    );
+    const roleArns = tryGetContextArns(app.node, 'admin-roles');
+
+    assert.notEqual(roleArns, null);
+    // TODO: Is there another way to avoid complaining about being null in a test?
+    if (roleArns) {
+      assert.equal(roleArns[0], 'arn:aws:iam::1234567890:role/AccountAdminRole');
+      assert.equal(roleArns[1], 'arn:aws:iam::1234567890:role/AccountCiRole');
+    }
+  });
+});

--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -8,16 +8,16 @@ const app = new App();
 
 async function main(): Promise<void> {
   const accountId = app.node.tryGetContext('aws-account-id') ?? process.env['CDK_DEFAULT_ACCOUNT'];
-  const ciRoleArn = tryGetContextArn(app.node, 'ci-role-arn');
+  const maintainerArns = tryGetContextArns(app.node, 'maintainer-arns');
 
-  if (ciRoleArn == null) throw new Error('Missing context: ci-role-arn');
+  if (maintainerArns == null) throw new Error('Missing context: maintainer-arns');
   if (accountId == null) {
     throw new Error("Missing AWS Account information, set with either '-c aws-account-id' or $CDK_DEFAULT_ACCOUNT");
   }
 
   new LinzEksCluster(app, ClusterName, {
     env: { region: 'ap-southeast-2', account: accountId },
-    ciRoleArn,
+    maintainerRoleArns: maintainerArns,
   });
 
   app.synth();

--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -1,23 +1,23 @@
 import { App } from 'aws-cdk-lib';
 
 import { ClusterName } from './constants.js';
-import { tryGetContextArn } from './eks/arn.js';
+import { tryGetContextArns } from './eks/arn.js';
 import { LinzEksCluster } from './eks/cluster.js';
 
 const app = new App();
 
 async function main(): Promise<void> {
   const accountId = app.node.tryGetContext('aws-account-id') ?? process.env['CDK_DEFAULT_ACCOUNT'];
-  const maintainerArns = tryGetContextArns(app.node, 'maintainer-arns');
+  const maintainerRoleArns = tryGetContextArns(app.node, 'maintainer-arns');
 
-  if (maintainerArns == null) throw new Error('Missing context: maintainer-arns');
+  if (maintainerRoleArns == null) throw new Error('Missing context: maintainer-arns');
   if (accountId == null) {
     throw new Error("Missing AWS Account information, set with either '-c aws-account-id' or $CDK_DEFAULT_ACCOUNT");
   }
 
   new LinzEksCluster(app, ClusterName, {
     env: { region: 'ap-southeast-2', account: accountId },
-    maintainerRoleArns: maintainerArns,
+    maintainerRoleArns,
   });
 
   app.synth();

--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -1,7 +1,7 @@
 import { App } from 'aws-cdk-lib';
 
 import { ClusterName } from './constants.js';
-import { tryGetContextArn } from './eks/arns.js';
+import { tryGetContextArn } from './eks/arn.js';
 import { LinzEksCluster } from './eks/cluster.js';
 
 const app = new App();

--- a/infra/eks/arn.ts
+++ b/infra/eks/arn.ts
@@ -42,8 +42,11 @@ export function tryGetContextArn(node: Node, context: string): string | null {
  * @returns arns if they are valid, null otherwise
  */
 export function tryGetContextArns(node: Node, context: string): string[] | null {
-  const ctx = node.tryGetContext(context);
+  let ctx = node.tryGetContext(context);
   if (ctx == null) return null;
+  if (typeof ctx === 'string') {
+    ctx = ctx.split(',');
+  }
   if (!Array.isArray(ctx)) throw new Error('Failed to parse ARN, is not a string[]');
   for (const arn of ctx) validateRoleArn(arn);
   return ctx;

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -75,7 +75,7 @@ export class LinzEksCluster extends Stack {
     //allow the maintainer roles access to the cluster
     for (const roleArn of props.maintainerRoleArns) {
       const roleId = `MaintainerRole-${createHash('sha256').update(roleArn).digest('hex').slice(0, 12)}`;
-      const role = Role.fromRoleArn(this, roleId, roleArn);
+      const role = Role.fromRoleArn(this, roleId, roleArn, { defaultPolicyName: this.stackName });
       this.cluster.awsAuth.addMastersRole(role);
     }
 

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -17,8 +17,8 @@ import { Construct } from 'constructs';
 import { CfnOutputKeys, ScratchBucketName } from '../constants.js';
 
 interface EksClusterProps extends StackProps {
-  /** Optional CI User to grant access to the cluster */
-  ciRoleArn?: string;
+  /** CI User to grant access to the cluster */
+  ciRoleArn: string;
 }
 
 export class LinzEksCluster extends Stack {
@@ -76,10 +76,8 @@ export class LinzEksCluster extends Stack {
     this.cluster.awsAuth.addMastersRole(accountAdminRole);
 
     // If defined allow the CI user access to the cluster
-    if (props.ciRoleArn) {
-      const ciRole = Role.fromRoleArn(this, 'CiRole', props.ciRoleArn);
-      this.cluster.awsAuth.addMastersRole(ciRole);
-    }
+    const ciRole = Role.fromRoleArn(this, 'CiRole', props.ciRoleArn);
+    this.cluster.awsAuth.addMastersRole(ciRole);
 
     // This is the role that the new nodes will start as
     this.nodeRole = new Role(this, 'NodeRole', {

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -13,6 +13,7 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
+import { createHash } from 'crypto';
 
 import { CfnOutputKeys, ScratchBucketName } from '../constants.js';
 
@@ -73,8 +74,8 @@ export class LinzEksCluster extends Stack {
 
     //allow the maintainer roles access to the cluster
     for (const roleArn of props.maintainerRoleArns) {
-      // TODO: this can't be CiRole
-      const role = Role.fromRoleArn(this, 'CiRole', roleArn);
+      const roleId = createHash('sha256').update(roleArn).digest('hex').slice(0, 12);
+      const role = Role.fromRoleArn(this, roleId, roleArn);
       this.cluster.awsAuth.addMastersRole(role);
     }
 

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -74,7 +74,7 @@ export class LinzEksCluster extends Stack {
 
     //allow the maintainer roles access to the cluster
     for (const roleArn of props.maintainerRoleArns) {
-      const roleId = createHash('sha256').update(roleArn).digest('hex').slice(0, 12);
+      const roleId = `MaintainerRole-${createHash('sha256').update(roleArn).digest('hex').slice(0, 12)}`;
       const role = Role.fromRoleArn(this, roleId, roleArn);
       this.cluster.awsAuth.addMastersRole(role);
     }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "lint": "npx eslint . --ignore-path .gitignore",
-    "format": "npx prettier . -w"
+    "format": "npx prettier . -w",
+    "test": "node --loader tsx --test infra/**/*.test.ts"
   },
   "devDependencies": {
     "@aws-cdk/lambda-layer-kubectl-v28": "^2.0.0",


### PR DESCRIPTION
#### Motivation

Maintainers should have direct access to the EKS Cluster.

#### Modification

Pass the maintainer role ARNs as a CDK context argument so they can be added as master on the cluster

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
