### PR TITLE
fix: maintainers can't describe the cluster TDE-926

### DIFF
--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -11,6 +11,7 @@ import {
   Role,
   ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { createHash } from 'crypto';
@@ -76,6 +77,9 @@ export class LinzEksCluster extends Stack {
     for (const roleArn of props.maintainerRoleArns) {
       const roleId = `MaintainerRole-${createHash('sha256').update(roleArn).digest('hex').slice(0, 12)}`;
       const role = Role.fromRoleArn(this, roleId, roleArn, { defaultPolicyName: this.stackName });
+      role.addToPrincipalPolicy(
+        new iam.PolicyStatement({ actions: ['eks:DescribeCluster'], resources: [this.cluster.clusterArn] }),
+      );
       this.cluster.awsAuth.addMastersRole(role);
     }
 


### PR DESCRIPTION
#### Motivation

```
➜ aws eks update-kubeconfig --name Workflows --region ap-southeast-2

An error occurred (AccessDeniedException) when calling the DescribeCluster operation: User: arn:aws:sts::019359803926:assumed-role/WorkflowMaintainerRole/RClarke@linz.govt.nz is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:ap-southeast-2:019359803926:cluster/Workflows
```

#### Modification

Add the missing policy

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
