### PR TITLE
ci: CDK cannot ask for deploy approval without terminal TDE-926

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,8 @@ jobs:
         run: |
           npx cdk deploy ${{ env.CLUSTER_NAME }} \
             -c maintainer-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }} \
-            -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }}
+            -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }} \
+            --require-approval never
 
       # Configure the Kubernetes cluster with CDK8s
       - name: (CDK8s) Synth


### PR DESCRIPTION
#### Motivation

Sometimes `cdk deploy` asks for approval confirmation. Because using `cdk deploy` part of the CI is not possible to interact with it, we need to bypass this approval.

```
Deployment failed: Error: "--require-approval" is enabled and stack includes security-sensitive updates, but terminal (TTY) is not attached so we are unable to get a confirmation from the user
```

#### Modification

Using `--require-approval never` will bypass the confirmation.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
