### PR TITLE
feat: Argo Workflows archive feature using RDS TDE-731

### DIFF
--- a/docs/infrastructure/components/argo.workflows.md
+++ b/docs/infrastructure/components/argo.workflows.md
@@ -2,3 +2,4 @@
 
 Argo Workflows is used to run the workflows inside K8s.
 It is deployed using its [Helm chart](https://github.com/argoproj/argo-helm/tree/main/charts/argo-workflows).
+An AWS RDS PostgreSQL database instance is used to provide persistent storage for the Archived Workflows feature.

--- a/docs/infrastructure/initial.deployment.md
+++ b/docs/infrastructure/initial.deployment.md
@@ -1,13 +1,15 @@
 # Initial deployment
 
-The initial deployment is a two step process where AWS-CDK is used to create a EKS cluster then CDK8s is used to deploy the applications into the cluster.
+The initial deployment is a two step process:
 
+1. AWS-CDK is used to create a EKS cluster and AWS RDS Postgres Instance.
+2. CDK8s is used to deploy the applications into the cluster.
 
 ## Custom Resource Definitions
 
 The first time a cluster is deployed Custom Resource Definitions (CRD) will not exist, when `kubectl` is used to deploy the CRDs for [Karpenter](./components/karpenter.md) and [Argo Workflows](./components/argo.workflows.md) it does not wait for the CRDs to finish deploying before starting the next step.
 
-This means that any resources that require a CRD will fail to deploy with a error similar to 
+This means that any resources that require a CRD will fail to deploy with a error similar to
 
 > resource mapping not found for name: "karpenter-template" namespace: "" from "dist/0003-karpenter-provisioner.k8s.yaml": no matches for kind "AWSNodeTemplate" in version "karpenter.k8s.aws/v1alpha1"
 

--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -9,7 +9,6 @@ const app = new App();
 async function main(): Promise<void> {
   const accountId = app.node.tryGetContext('aws-account-id') ?? process.env['CDK_DEFAULT_ACCOUNT'];
   const ciRoleArn = tryGetContextArn(app.node, 'ci-role-arn');
-  const argoDbSnapshotName = app.node.tryGetContext('db-snapshot-name');
 
   if (ciRoleArn == null) throw new Error('Missing context: ci-role-arn');
   if (accountId == null) {
@@ -19,7 +18,6 @@ async function main(): Promise<void> {
   new LinzEksCluster(app, ClusterName, {
     env: { region: 'ap-southeast-2', account: accountId },
     ciRoleArn,
-    argoDbSnapshotName,
   });
 
   app.synth();

--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -9,6 +9,7 @@ const app = new App();
 async function main(): Promise<void> {
   const accountId = app.node.tryGetContext('aws-account-id') ?? process.env['CDK_DEFAULT_ACCOUNT'];
   const ciRoleArn = tryGetContextArn(app.node, 'ci-role-arn');
+  const argoDbSnapshotName = app.node.tryGetContext('db-snapshot-name');
 
   if (ciRoleArn == null) throw new Error('Missing context: ci-role-arn');
   if (accountId == null) {
@@ -18,6 +19,7 @@ async function main(): Promise<void> {
   new LinzEksCluster(app, ClusterName, {
     env: { region: 'ap-southeast-2', account: accountId },
     ciRoleArn,
+    argoDbSnapshotName,
   });
 
   app.synth();

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -27,6 +27,9 @@ async function main(): Promise<void> {
 
     // Personal access token to gain access to linz-basemaps github user
     githubPat: '/eks/github/linz-basemaps/pat',
+
+    // Argo Database connection password
+    argoDbPassword: '/eks/argo/postgres/password',
   });
 
   const coredns = new CoreDns(app, 'dns', {});
@@ -59,6 +62,8 @@ async function main(): Promise<void> {
     clusterName: ClusterName,
     saName: cfnOutputs[CfnOutputKeys.ArgoRunnerServiceAccountName],
     tempBucketName: ScratchBucketName,
+    argoDbEndpoint: cfnOutputs[CfnOutputKeys.ArgoDbEndpoint],
+    argoDbPassword: ssmConfig.argoDbPassword,
   });
 
   new ArgoExtras(app, 'argo-extras', {

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -30,6 +30,11 @@ export interface ArgoWorkflowsProps {
    * @example "argodb-argodb4be14fa2-p8yjinijwbro.cmpyjhgv78aj.ap-southeast-2.rds.amazonaws.com"
    */
   argoDbEndpoint: string;
+  /**
+   * The Argo database password
+   *
+   * @example "eighoo5room0aeM^ahz0Otoh4aakiipo"
+   */
   argoDbPassword: string;
 }
 

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -78,7 +78,7 @@ export class ArgoWorkflows extends Chart {
       },
       nodeStatusOffLoad: true,
       archive: true,
-      // archiveTTL: '180d', default is never expire archived workflows
+      archiveTTL: '', // never expire archived workflows
       postgresql: {
         host: props.argoDbEndpoint,
         port: 5432,

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,11 +1,17 @@
 /* Cluster name */
 export const ClusterName = 'Workflows';
+/* Cluster name */
+export const ArgoDbName = 'ArgoDb';
 /* LINZ conventional name for Argo Workflows artifact bucket */
 export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
+/* Argo Database user */
+export const ArgoDbUser = 'argo_user';
 
 /* CloudFormation Output to access from CDK8s */
 export const CfnOutputKeys = {
   ClusterEndpoint: 'ClusterEndpoint',
+
+  ArgoDbEndpoint: 'ArgoDbEndpoint',
 
   KarpenterServiceAccountName: 'KarpenterServiceAccountName',
   KarpenterServiceAccountRoleArn: 'KarpenterServiceAccountRoleArn',

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,9 +1,9 @@
 /* Cluster name */
-export const ClusterName = 'WorkflowsAF';
+export const ClusterName = 'Workflows';
 /* LINZ conventional name for Argo Workflows artifact bucket */
 export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
 /* Argo Database Instance name */
-export const ArgoDbInstanceName = 'ArgoDbAF';
+export const ArgoDbInstanceName = 'ArgoDb';
 /* Argo Database name */
 export const ArgoDbName = 'argo';
 /* Argo Database user */

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,9 +1,11 @@
 /* Cluster name */
 export const ClusterName = 'Workflows';
-/* Cluster name */
-export const ArgoDbName = 'ArgoDb';
 /* LINZ conventional name for Argo Workflows artifact bucket */
 export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
+/* Argo Database Instance name */
+export const ArgoDbInstanceName = 'ArgoDb';
+/* Argo Database user */
+export const ArgoDbName = 'argo';
 /* Argo Database user */
 export const ArgoDbUser = 'argo_user';
 

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -4,7 +4,7 @@ export const ClusterName = 'WorkflowsAF';
 export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
 /* Argo Database Instance name */
 export const ArgoDbInstanceName = 'ArgoDbAF';
-/* Argo Database user */
+/* Argo Database name */
 export const ArgoDbName = 'argo';
 /* Argo Database user */
 export const ArgoDbUser = 'argo_user';

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,9 +1,9 @@
 /* Cluster name */
-export const ClusterName = 'Workflows';
+export const ClusterName = 'WorkflowsAF';
 /* LINZ conventional name for Argo Workflows artifact bucket */
 export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
 /* Argo Database Instance name */
-export const ArgoDbInstanceName = 'ArgoDb';
+export const ArgoDbInstanceName = 'ArgoDbAF';
 /* Argo Database user */
 export const ArgoDbName = 'argo';
 /* Argo Database user */

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -20,8 +20,8 @@ import {
   Role,
   ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
-import { Credentials, DatabaseInstance, DatabaseInstanceEngine, PostgresEngineVersion } from 'aws-cdk-lib/aws-rds';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import { Credentials, DatabaseInstance, DatabaseInstanceEngine, PostgresEngineVersion } from 'aws-cdk-lib/aws-rds';
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { createHash } from 'crypto';

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -24,7 +24,7 @@ import { Credentials, DatabaseInstance, DatabaseInstanceEngine, PostgresEngineVe
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
-import { ArgoDbName, ArgoDbInstanceName, ArgoDbUser, CfnOutputKeys, ScratchBucketName } from '../constants.js';
+import { ArgoDbInstanceName, ArgoDbName, ArgoDbUser, CfnOutputKeys, ScratchBucketName } from '../constants.js';
 
 interface EksClusterProps extends StackProps {
   /** Optional CI User to grant access to the cluster */
@@ -99,7 +99,7 @@ export class LinzEksCluster extends Stack {
        * Instances are requested in order listed.
        * https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types
        **/
-     instanceTypes: ['c6i.large', 'c6a.large'].map((f) => new InstanceType(f)),
+      instanceTypes: ['c6i.large', 'c6a.large'].map((f) => new InstanceType(f)),
       minSize: 2,
       amiType: NodegroupAmiType.BOTTLEROCKET_X86_64,
       subnets: { subnetType: SubnetType.PRIVATE_WITH_EGRESS },

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -20,7 +20,13 @@ import {
   Role,
   ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
-import { Credentials, DatabaseInstance, DatabaseInstanceEngine, PostgresEngineVersion } from 'aws-cdk-lib/aws-rds';
+import {
+  Credentials,
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  DatabaseInstanceFromSnapshot,
+  PostgresEngineVersion,
+} from 'aws-cdk-lib/aws-rds';
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
@@ -29,6 +35,8 @@ import { ArgoDbInstanceName, ArgoDbName, ArgoDbUser, CfnOutputKeys, ScratchBucke
 interface EksClusterProps extends StackProps {
   /** Optional CI User to grant access to the cluster */
   ciRoleArn?: string;
+  /** Optional paraqmeter to restore Argo workflow archive from a database snapshot */
+  argoDbSnapshotName?: string;
 }
 
 export class LinzEksCluster extends Stack {
@@ -69,23 +77,57 @@ export class LinzEksCluster extends Stack {
       clusterLogging: [ClusterLoggingTypes.API, ClusterLoggingTypes.CONTROLLER_MANAGER, ClusterLoggingTypes.SCHEDULER],
     });
 
-    this.argoDb = new DatabaseInstance(this, ArgoDbInstanceName, {
-      engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_15_3 }),
-      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
-      vpc: this.vpc,
-      publiclyAccessible: false,
-      databaseName: ArgoDbName,
-      allocatedStorage: 10,
-      maxAllocatedStorage: 40,
-      credentials: Credentials.fromPassword(ArgoDbUser, SecretValue.ssmSecure('/eks/argo/postgres/password')),
-      deletionProtection: false,
-      removalPolicy: RemovalPolicy.SNAPSHOT,
-      backupRetention: Duration.days(7),
-      deleteAutomatedBackups: false,
-      storageEncrypted: false,
-      multiAz: true,
-      enablePerformanceInsights: true,
-    });
+    // TODO: reduce parameter duplication
+    // const dbCommonParams = {
+    //   engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_15_3 }),
+    //   instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+    //   vpc: this.vpc,
+    //   publiclyAccessible: false,
+    //   allocatedStorage: 10,
+    //   maxAllocatedStorage: 40,
+    //   multiAz: true,
+    //   enablePerformanceInsights: true,
+    //   deletionProtection: false,
+    //   removalPolicy: RemovalPolicy.SNAPSHOT,
+    //   backupRetention: Duration.days(7),
+    //   deleteAutomatedBackups: false,
+    //   }
+
+    if (!props.argoDbSnapshotName) {
+      this.argoDb = new DatabaseInstance(this, ArgoDbInstanceName, {
+        engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_15_3 }),
+        instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+        vpc: this.vpc,
+        databaseName: ArgoDbName,
+        credentials: Credentials.fromPassword(ArgoDbUser, SecretValue.ssmSecure('/eks/argo/postgres/password')),
+        storageEncrypted: false,
+        publiclyAccessible: false,
+        allocatedStorage: 10,
+        maxAllocatedStorage: 40,
+        multiAz: true,
+        enablePerformanceInsights: true,
+        deletionProtection: false,
+        removalPolicy: RemovalPolicy.SNAPSHOT,
+        backupRetention: Duration.days(7),
+        deleteAutomatedBackups: false,
+      });
+    } else {
+      this.argoDb = new DatabaseInstanceFromSnapshot(this, ArgoDbInstanceName, {
+        engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_15_3 }),
+        instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+        vpc: this.vpc,
+        snapshotIdentifier: props.argoDbSnapshotName,
+        publiclyAccessible: false,
+        allocatedStorage: 10,
+        maxAllocatedStorage: 40,
+        multiAz: true,
+        enablePerformanceInsights: true,
+        deletionProtection: false,
+        removalPolicy: RemovalPolicy.SNAPSHOT,
+        backupRetention: Duration.days(7),
+        deleteAutomatedBackups: false,
+      });
+    };
 
     const eksSG = SecurityGroup.fromSecurityGroupId(this, 'ArgoSG', this.cluster.clusterSecurityGroupId, {});
     this.argoDb.connections.allowFrom(eksSG, Port.tcp(5432), 'EKS to Argo Database');

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -1,5 +1,5 @@
 import { KubectlV28Layer } from '@aws-cdk/lambda-layer-kubectl-v28';
-import { Aws, CfnOutput, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { Aws, CfnOutput, RemovalPolicy, SecretValue, Stack, StackProps } from 'aws-cdk-lib';
 import {
   InstanceClass,
   InstanceSize,
@@ -24,7 +24,7 @@ import { Credentials, DatabaseInstance, DatabaseInstanceEngine, PostgresEngineVe
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
-import { ArgoDbUser, CfnOutputKeys, ScratchBucketName } from '../constants.js';
+import { ArgoDbName, ArgoDbUser, CfnOutputKeys, ScratchBucketName } from '../constants.js';
 
 interface EksClusterProps extends StackProps {
   /** Optional CI User to grant access to the cluster */
@@ -69,7 +69,7 @@ export class LinzEksCluster extends Stack {
       clusterLogging: [ClusterLoggingTypes.API, ClusterLoggingTypes.CONTROLLER_MANAGER, ClusterLoggingTypes.SCHEDULER],
     });
 
-    this.argoDb = new DatabaseInstance(this, 'ArgoDb', {
+    this.argoDb = new DatabaseInstance(this, ArgoDbName, {
       engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_15_3 }),
       instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
       vpc: this.vpc,

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -29,8 +29,6 @@ import { ArgoDbInstanceName, ArgoDbName, ArgoDbUser, CfnOutputKeys, ScratchBucke
 interface EksClusterProps extends StackProps {
   /** Optional CI User to grant access to the cluster */
   ciRoleArn?: string;
-  /** Optional paraqmeter to restore Argo workflow archive from a database snapshot */
-  argoDbSnapshotName?: string;
 }
 
 export class LinzEksCluster extends Stack {

--- a/infra/util/ssm.ts
+++ b/infra/util/ssm.ts
@@ -7,7 +7,7 @@ const ssm = new SSM();
  *
  * @example
  * ```typescript
- * const result = fetchSsmParameters({ clientId: '/eks/client-id' })
+ * const result = fetchSsmParameters({ clientId: '/eks/client-id', dbPassword: '/eks/rds/password'})
  * result.clientId // Value of '/eks/client-id'
  * ```
  *
@@ -15,7 +15,7 @@ const ssm = new SSM();
  */
 export async function fetchSsmParameters<T extends Record<string, string>>(query: T): Promise<T> {
   console.log('FetchSSM', Object.values(query));
-  const ret = await ssm.getParameters({ Names: Object.values(query) });
+  const ret = await ssm.getParameters({ Names: Object.values(query), WithDecryption: true });
 
   const output: Record<string, string> = {};
   const missing: string[] = [];


### PR DESCRIPTION
#### Motivation

The aim of this change is to enable the Archived Workflows in Argo so that older workflow runs can be referenced in the future e.g. to see what was run when, what parameters were used.

#### Modification

This change provisions an AWS RDS PostgreSQL database and configures Argo Workflows to use it, so that the Archived Workflows feature is enabled.

#### Checklist

- [N/A] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
