### PR TITLE
fix: correct github secrets access for basemaps etl

### DIFF
--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -12,33 +12,40 @@ spec:
       - name: version_argo_tasks
         description: Version of the basemaps CLI docker container to use
         value: v2
+
       - name: target
+        description: S3 Bucket to use for storing the output
         value: 'linz-basemaps'
         enum:
           - 'linz-basemaps'
           - 'linz-basemaps-staging'
+
       - name: create-pull-request
+        description: Should a pull request be created in linz/basemaps-config
         value: 'true'
         enum:
           - 'true'
           - 'false'
+
   templateDefaults:
     container:
       imagePullPolicy: Always
       image: ''
+
   templates:
     - name: main
       dag:
         tasks:
           - name: vector-etl
             template: vector-etl
+
           - name: create-pull-request
             template: create-pull-request
             arguments:
               parameters:
                 - name: target
-                  value: '{{tasks.vector-etl.outputs.parameters.target}}'
-            when: '{{workflow.parameters.create-pull-request}} == true'
+                  value: '{{ tasks.vector-etl.outputs.parameters.target }}'
+            when: '{{ workflow.parameters.create-pull-request }} == true'
             depends: 'vector-etl'
 
     - name: vector-etl
@@ -52,7 +59,11 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json
-        args: ['--all', '--target', '{{workflow.parameters.target}}', '--output', '/tmp/', '--commit']
+        args:
+          - '--all'
+          - '--target={{ workflow.parameters.target }}'
+          - '--output=/tmp/'
+          - '--commit'
       outputs:
         parameters:
           - name: target
@@ -64,15 +75,19 @@ spec:
         parameters:
           - name: target
       container:
-        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{ workflow.parameters.version_argo_tasks }}
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json
+
           - name: GITHUB_API_TOKEN
             valueFrom:
               secretKeyRef:
                 name: github-linz-basemaps-pat
                 key: pat
-        args: ['bmc', 'create-pr', '--target={{inputs.parameters.target}}', '--vector']
-
+        args:
+          - 'bmc'
+          - 'create-pr'
+          - '--target={{ inputs.parameters.target }}'
+          - '--vector'

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -65,9 +65,6 @@ spec:
           - name: target
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
-        volumeMounts:
-          - name: secret-vol
-            mountPath: '/root/.ssh/'
         command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
@@ -75,11 +72,7 @@ spec:
           - name: GITHUB_API_TOKEN
             valueFrom:
               secretKeyRef:
-                name: github-bot-pat
-                key: github-token
+                name: github-linz-basemaps-pat
+                key: pat
         args: ['bmc', 'create-pr', '--target={{inputs.parameters.target}}', '--vector']
-  volumes:
-    - name: secret-vol
-      secret:
-        secretName: github-linz-basemaps-config
-        defaultMode: 384
+


### PR DESCRIPTION
#### Motivation

Basemaps vector ETL doesnt need the github ssh keys anymore and have been deleted from the cluster, since this workflow still references it, it will no longer start.

#### Modification

Removes the missing secret references and improves the readability of the workflow yaml

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
