### PR TITLE
feat: add region label to imagery related workflows TDE-957, TDE-955

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -21,6 +21,8 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   arguments:
     parameters:
       - name: version_basemaps_cli
@@ -34,6 +36,28 @@ spec:
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''
+
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
 
       - name: source
         description: Source imagery location "s3://linz-imagery"

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -41,7 +41,7 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
-          - 'antartica'
+          - 'antarctica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -41,10 +41,12 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
+          - 'antartica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'
           - 'gisborne'
+          - 'global'
           - 'hawkes-bay'
           - 'manawatu-whanganui'
           - 'marlborough'
@@ -52,6 +54,7 @@ spec:
           - 'new-zealand'
           - 'northland'
           - 'otago'
+          - 'pacific-islands'
           - 'southland'
           - 'taranaki'
           - 'tasman'

--- a/workflows/basemaps/imagery-import.yaml
+++ b/workflows/basemaps/imagery-import.yaml
@@ -27,7 +27,7 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
-          - 'antartica'
+          - 'antarctica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'

--- a/workflows/basemaps/imagery-import.yaml
+++ b/workflows/basemaps/imagery-import.yaml
@@ -27,10 +27,12 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
+          - 'antartica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'
           - 'gisborne'
+          - 'global'
           - 'hawkes-bay'
           - 'manawatu-whanganui'
           - 'marlborough'
@@ -38,6 +40,7 @@ spec:
           - 'new-zealand'
           - 'northland'
           - 'otago'
+          - 'pacific-islands'
           - 'southland'
           - 'taranaki'
           - 'tasman'

--- a/workflows/basemaps/imagery-import.yaml
+++ b/workflows/basemaps/imagery-import.yaml
@@ -13,6 +13,8 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   entrypoint: main
   arguments:
     parameters:
@@ -21,6 +23,27 @@ spec:
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
       - name: source
         value: ''
       - name: category

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -18,6 +18,7 @@ In addition, a Basemaps link is produced enabling visual QA.
 | Parameter      | Type  | Default                                                                                             | Description                                                                                                                                             |
 | -------------- | ----- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ticket         | str   |                                                                                                     | Ticket ID e.g. 'AIP-55'                                                                                                                                 |
+| region         | enum  |                                                                                                     | Region of the dataset                                                                                                                                   |
 | source         | str   | s3://linz-imagery-staging/test/sample                                                               | the uri (path) to the input tiffs                                                                                                                       |
 | include        | regex | .tiff?$                                                                                             | A regular expression to match object path(s) or name(s) from within the source path to include in standardising\*.                                      |
 | scale          | enum  | 500                                                                                                 | The scale of the TIFFs                                                                                                                                  |
@@ -46,6 +47,7 @@ In addition, a Basemaps link is produced enabling visual QA.
 | Parameter      | Value                                                                                     |
 | -------------- | ----------------------------------------------------------------------------------------- |
 | ticket         | AIP-55                                                                                    |
+| region         | bay-of-plenty                                                                             |
 | source         | s3://linz-imagery-upload/PRJ39741_BOPLASS_Imagery_2021-22/PRJ39741_03/01_GeoTiff/         |
 | include        | .tiff?$                                                                                   |
 | scale          | 2000                                                                                      |
@@ -197,6 +199,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 | Parameter   | Type  | Default                                       | Description                                                                                                                                                      |
 | ----------- | ----- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ticket      | str   |                                               | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
+| region      | enum  |                                               | Region of the dataset                                                                                                                                            |
 | source      | str   | s3://linz-imagery-staging/test/sample/        | The URIs (paths) to the s3 source location                                                                                                                       |
 | target      | str   | s3://linz-imagery-staging/test/sample_target/ | The URIs (paths) to the s3 target location                                                                                                                       |
 | include     | regex | .tiff?\$\|.json\$\|.tfw\$                     | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                      |
@@ -256,6 +259,7 @@ This workflow carries out the steps in the [Standardising](#Standardising) workf
 | Parameter      | Type | Default | Description                                                                                                                                                     |
 | -------------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ticket         | str  |         | Ticket ID e.g. 'AIP-55'                                                                                                                                         |
+| region         | enum |         | Region of the dataset :warning: The name has to be exactly one in the region enum in `standardising.                                                            |
 | source         | str  |         | the uri (path) to the input tiffs e.g. s3://linz-imagery-upload/test/sample                                                                                     |
 | target         | str  |         | the uri (path) to the published tiffs in the format s3://linz-imagery-target-example/region/city-or-sub-region_year_resolution/product/crs/                     |
 | title          | str  |         | Collection title in the format "\*Region/District/City\* \*GSD\* \*Urban/Rural\* Aerial Photos (\*Year-Year\*)"                                                 |
@@ -321,7 +325,7 @@ These are hardcoded due to parameter naming collisions in the downstream Workflo
 ### Submitting from the command line using the `-p` (`--parameter`) option (standardising-publish):
 
 ```bash
-argo submit workflows/raster/standardising-publish-import.yaml -n argo -p ticket="AIP-55" -p source="s3://linz-imagery-source-example/aerial-imagery/new-zealand/christchurch_urban_2021_0.05m_RGB/" -p target="s3://linz-imagery-example/canterbury/christchurch_2021_0.05m/rgb/2193/" -p scale="500" -p group="29" -p cutline="s3://linz-imagery-cutline-example/historical-imagery-cutlines/2023-01-16_84fd68f/SNC50451-combined.fgb" -p title="Christchurch 0.05m Urban Aerial Photos (2021)" -p description="Orthophotography within the Canterbury region captured in the 2021 flying season." -p producer="Aerial Surveys" -p licensor="Toitū Te Whenua Land Information New Zealand" -p start-datetime="2021-11-02" -p end-datetime="2021-12-02"
+argo submit workflows/raster/standardising-publish-import.yaml -n argo -p ticket="AIP-55" -p region="canterbury" -p source="s3://linz-imagery-source-example/aerial-imagery/new-zealand/christchurch_urban_2021_0.05m_RGB/" -p target="s3://linz-imagery-example/canterbury/christchurch_2021_0.05m/rgb/2193/" -p scale="500" -p group="29" -p cutline="s3://linz-imagery-cutline-example/historical-imagery-cutlines/2023-01-16_84fd68f/SNC50451-combined.fgb" -p title="Christchurch 0.05m Urban Aerial Photos (2021)" -p description="Orthophotography within the Canterbury region captured in the 2021 flying season." -p producer="Aerial Surveys" -p licensor="Toitū Te Whenua Land Information New Zealand" -p start-datetime="2021-11-02" -p end-datetime="2021-12-02"
 ```
 
 ### Submitting from the command line using a parameters yaml file and the `-f` (`--parameter-file`) option (standardising-publish):
@@ -334,6 +338,7 @@ _params.yaml_:
 
 ```yaml
 ticket: 'AIP-55'
+region: 'canterbury'
 source: 's3://linz-imagery-source-example/aerial-imagery/new-zealand/christchurch_urban_2021_0.05m_RGB/'
 target: 's3://linz-imagery-example/canterbury/christchurch_2021_0.05m/rgb/2193/'
 scale: '500'
@@ -350,7 +355,7 @@ end-datetime: '2021-12-02'
 ### Submitting from the command line using the `-p` (`--parameter`) option (standardising-publish-import):
 
 ```bash
-argo submit workflows/raster/standardising-publish-import.yaml -n argo -p ticket="AIP-55" -p source="s3://linz-imagery-source-example/aerial-imagery/new-zealand/christchurch_urban_2021_0.05m_RGB/" -p target="s3://linz-imagery-example/canterbury/christchurch_2021_0.05m/rgb/2193/" -p scale="500" -p group="29" -p cutline="s3://linz-imagery-cutline-example/historical-imagery-cutlines/2023-01-16_84fd68f/SNC50451-combined.fgb" -p title="Christchurch 0.05m Urban Aerial Photos (2021)" -p description="Orthophotography within the Canterbury region captured in the 2021 flying season." -p producer="Aerial Surveys" -p licensor="Toitū Te Whenua Land Information New Zealand" -p start-datetime="2021-11-02" -p end-datetime="2021-12-02" -p category="Urban Aerial Photos" -p name="christchurch_2021_0.05m" -p tile-matrix="NZTM2000Quad/WebMercatorQuad" -p blend="20" -p aligned-level="6" -p create-pull-request="true"
+argo submit workflows/raster/standardising-publish-import.yaml -n argo -p ticket="AIP-55" -p region="canterbury" -p source="s3://linz-imagery-source-example/aerial-imagery/new-zealand/christchurch_urban_2021_0.05m_RGB/" -p target="s3://linz-imagery-example/canterbury/christchurch_2021_0.05m/rgb/2193/" -p scale="500" -p group="29" -p cutline="s3://linz-imagery-cutline-example/historical-imagery-cutlines/2023-01-16_84fd68f/SNC50451-combined.fgb" -p title="Christchurch 0.05m Urban Aerial Photos (2021)" -p description="Orthophotography within the Canterbury region captured in the 2021 flying season." -p producer="Aerial Surveys" -p licensor="Toitū Te Whenua Land Information New Zealand" -p start-datetime="2021-11-02" -p end-datetime="2021-12-02" -p category="Urban Aerial Photos" -p name="christchurch_2021_0.05m" -p tile-matrix="NZTM2000Quad/WebMercatorQuad" -p blend="20" -p aligned-level="6" -p create-pull-request="true"
 ```
 
 ### Submitting from the command line using a parameters yaml file and the `-f` (`--parameter-file`) option (standardising-publish-import):
@@ -363,6 +368,7 @@ _params.yaml_:
 
 ```yaml
 ticket: 'AIP-55'
+region: 'canterbury'
 source: 's3://linz-imagery-source-example/aerial-imagery/new-zealand/christchurch_urban_2021_0.05m_RGB/'
 target: 's3://linz-imagery-example/canterbury/christchurch_2021_0.05m/rgb/2193/'
 scale: '500'

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -259,7 +259,7 @@ This workflow carries out the steps in the [Standardising](#Standardising) workf
 | Parameter      | Type | Default | Description                                                                                                                                                     |
 | -------------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ticket         | str  |         | Ticket ID e.g. 'AIP-55'                                                                                                                                         |
-| region         | enum |         | Region of the dataset :warning: The name has to be exactly one in the region enum in `standardising.                                                            |
+| region         | enum |         | Region of the dataset :warning: The name has to be exactly one in the region enum in `standardising`.                                                            |
 | source         | str  |         | the uri (path) to the input tiffs e.g. s3://linz-imagery-upload/test/sample                                                                                     |
 | target         | str  |         | the uri (path) to the published tiffs in the format s3://linz-imagery-target-example/region/city-or-sub-region_year_resolution/product/crs/                     |
 | title          | str  |         | Collection title in the format "\*Region/District/City\* \*GSD\* \*Urban/Rural\* Aerial Photos (\*Year-Year\*)"                                                 |

--- a/workflows/raster/ascii-standardise-publish.yaml
+++ b/workflows/raster/ascii-standardise-publish.yaml
@@ -19,11 +19,34 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   arguments:
     parameters:
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
       - name: source
         value: 's3://path/'
       - name: cutline # optional standardising cutline

--- a/workflows/raster/ascii-standardise-publish.yaml
+++ b/workflows/raster/ascii-standardise-publish.yaml
@@ -30,7 +30,7 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
-          - 'antartica'
+          - 'antarctica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'

--- a/workflows/raster/ascii-standardise-publish.yaml
+++ b/workflows/raster/ascii-standardise-publish.yaml
@@ -30,10 +30,12 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
+          - 'antartica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'
           - 'gisborne'
+          - 'global'
           - 'hawkes-bay'
           - 'manawatu-whanganui'
           - 'marlborough'
@@ -41,6 +43,7 @@ spec:
           - 'new-zealand'
           - 'northland'
           - 'otago'
+          - 'pacific-islands'
           - 'southland'
           - 'taranaki'
           - 'tasman'

--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -19,6 +19,8 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   arguments:
     parameters:
       - name: version-argo-tasks
@@ -26,6 +28,27 @@ spec:
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
       - name: source
         value: 's3://linz-imagery-staging/test/sample/'
       - name: target

--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -32,10 +32,12 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
+          - 'antartica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'
           - 'gisborne'
+          - 'global'
           - 'hawkes-bay'
           - 'manawatu-whanganui'
           - 'marlborough'
@@ -43,6 +45,7 @@ spec:
           - 'new-zealand'
           - 'northland'
           - 'otago'
+          - 'pacific-islands'
           - 'southland'
           - 'taranaki'
           - 'tasman'

--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -32,7 +32,7 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
-          - 'antartica'
+          - 'antarctica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -19,6 +19,8 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   arguments:
     parameters:
       - name: version-argo-tasks
@@ -26,6 +28,27 @@ spec:
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
       - name: source
         value: 's3://linz-imagery-staging/test/sample/'
       - name: target

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -32,10 +32,12 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
+          - 'antartica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'
           - 'gisborne'
+          - 'global'
           - 'hawkes-bay'
           - 'manawatu-whanganui'
           - 'marlborough'
@@ -43,6 +45,7 @@ spec:
           - 'new-zealand'
           - 'northland'
           - 'otago'
+          - 'pacific-islands'
           - 'southland'
           - 'taranaki'
           - 'tasman'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -32,7 +32,7 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
-          - 'antartica'
+          - 'antarctica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'

--- a/workflows/raster/standardising-publish-import.yaml
+++ b/workflows/raster/standardising-publish-import.yaml
@@ -19,9 +19,13 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   arguments:
     parameters:
       - name: ticket
+        value: ''
+      - name: region
         value: ''
       - name: source
         value: ''

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -37,7 +37,7 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
-          - 'antartica'
+          - 'antarctica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -37,10 +37,12 @@ spec:
         description: Region of the dataset
         value: 'new-zealand'
         enum:
+          - 'antartica'
           - 'auckland'
           - 'bay-of-plenty'
           - 'canterbury'
           - 'gisborne'
+          - 'global'
           - 'hawkes-bay'
           - 'manawatu-whanganui'
           - 'marlborough'
@@ -48,6 +50,7 @@ spec:
           - 'new-zealand'
           - 'northland'
           - 'otago'
+          - 'pacific-islands'
           - 'southland'
           - 'taranaki'
           - 'tasman'

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -19,6 +19,8 @@ spec:
     labelsFrom:
       linz.govt.nz/ticket:
         expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
   arguments:
     parameters:
       # FIXME: Should use camelCase or underscore?
@@ -31,6 +33,27 @@ spec:
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
       - name: source
         value: 's3://linz-imagery-staging/test/sample/'
       - name: include


### PR DESCRIPTION
#### Motivation

The region of the dataset is a useful information to be able to filter on.

#### Modification

`region` is passed as a parameter of the workflow to the `linz.govt.nz/region` label value. This is a mandatory field proposed as an enum to the user. Any modification of the `region` list will have to be applied at all the places it is used.
This change is also part of TDE-955 that will use this workflow parameter as an input of a task/step to build the dataset title.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - N/A
- [x] Docs updated
- [x] Issue linked in Title
