### PR TITLE
fix: argo-workflows kubernetes compoenent label is wrong

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -54,7 +54,7 @@ const appVersion = 'v3.4.11';
 
 export class ArgoWorkflows extends Chart {
   constructor(scope: Construct, id: string, props: ArgoWorkflowsProps & ChartProps) {
-    super(scope, id, applyDefaultLabels(props, 'argo-workflows', appVersion, 'logs', 'workflows'));
+    super(scope, id, applyDefaultLabels(props, 'argo', appVersion, 'argo-workflows', 'workflows'));
 
     const artifactRepository = {
       archiveLogs: true,


### PR DESCRIPTION
#### Motivation

`app.kubernetes.io/component` seems that it has been copy-pasted from the `fluentbit` one.

#### Modification

Use `argo-workflows` as `app.kubernetes.io/component`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
