### PR TITLE
fix: update secret name to linz-li-bot-pat TDE-940

### DIFF
--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -25,8 +25,8 @@ async function main(): Promise<void> {
     tunnelName: '/eks/cloudflared/argo/tunnelName',
     accountId: '/eks/cloudflared/argo/accountId',
 
-    // Personal access token to gain access to linz-basemaps github user
-    githubPat: '/eks/github/linz-basemaps/pat',
+    // Personal access token to gain access to linz-li-bot github user
+    githubPat: '/eks/github/linz-li-bot/pat',
 
     // Argo Database connection password
     argoDbPassword: '/eks/argo/postgres/password',
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
   new ArgoExtras(app, 'argo-extras', {
     namespace: 'argo',
     /** Argo workflows interacts with github give it access to github bot user*/
-    secrets: [{ name: 'github-linz-basemaps-pat', data: { pat: ssmConfig.githubPat } }],
+    secrets: [{ name: 'github-linz-li-bot-pat', data: { pat: ssmConfig.githubPat } }],
   });
 
   new Cloudflared(app, 'cloudflared', {


### PR DESCRIPTION
#### Motivation

All pushes to GitHub will now use the same PAT from user `linz-li-bot`, updating the secret names to reflect this.

#### Modification

Rename the GitHub secret generated from `github-linz-basemaps-pat` to `github-linz-li-bot-pat`. This will be deployed as a new secret. The old secret will be removed once the workflows have been updated (separate PR to follow).

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated (no tests)
- [ ] Docs updated (not in docs)
- [X] Issue linked in Title
