### PR TITLE
fix: add write config to publish-copy workflow for elevation and topographic buckets

### DIFF
--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -147,7 +147,7 @@ spec:
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: aws-role-config-path
-                  value: 's3://linz-bucket-config/config-write.imagery.json'
+                  value: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
 


### PR DESCRIPTION
#### Motivation

The publish-copy script does not have permission to write to the `linz-topographic` or `linz-elevation` buckets.

#### Modification

Add in the write config paths for these buckets.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
