### PR TITLE
ci: fix delete test namespace empty value TDE-899

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,8 +96,7 @@ jobs:
         if: github.ref != 'refs/heads/master'
         run: |
           # Create test namespace
-          TEST_NAMESPACE=$GITHUB_SHA
-          kubectl create namespace "$TEST_NAMESPACE"
+          kubectl create namespace "$GITHUB_SHA"
 
           # Create copy of Workflows files to change their namespaces
           mkdir test
@@ -105,20 +104,20 @@ jobs:
 
           # Deploy templates in the test namespace
           # Note: the templates have no default namespace so no need to modify them
-          kubectl apply -f templates/argo-tasks/ --namespace "$TEST_NAMESPACE"
+          kubectl apply -f templates/argo-tasks/ --namespace "$GITHUB_SHA"
 
           # Find all workflows that have kind "WorkflowTemplate"
           WORKFLOWS=$(grep -R -H '^kind: WorkflowTemplate$' test/workflows/ | cut -d ':' -f1)
           # For each workflow attempt to deploy it using kubectl
           for wf in $WORKFLOWS; do
               # Change namespace in files
-              sed -i "/^\([[:space:]]*namespace: \).*/s//\1$TEST_NAMESPACE/" "$wf"
-              kubectl apply -f "$wf" --namespace "$TEST_NAMESPACE"
+              sed -i "/^\([[:space:]]*namespace: \).*/s//\1$GITHUB_SHA/" "$wf"
+              kubectl apply -f "$wf" --namespace "$GITHUB_SHA"
           done
 
           # Finally lint the templates
-          ./argo-linux-amd64 lint templates/ -n "$TEST_NAMESPACE"
-          ./argo-linux-amd64 lint test/workflows/ -n "$TEST_NAMESPACE"
+          ./argo-linux-amd64 lint templates/ -n "$GITHUB_SHA"
+          ./argo-linux-amd64 lint test/workflows/ -n "$GITHUB_SHA"
 
       - name: Delete Test namespace
         if: always()


### PR DESCRIPTION
#### Motivation

A non expected error happens when trying to delete the test namespace on Kubernetes. The workflow is using the wrong environment variable: https://github.com/linz/topo-workflows/actions/runs/7079026717/job/19265196098

#### Modification

Use `GITHUB_SHA` instead of `TEST_NAMESPACE` 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
