### PR TITLE
fix: add missing depends arguments TDE-987

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -183,7 +183,7 @@ Copy files from one S3 location to another. This workflow is intended to be used
 
 ```mermaid
 graph TD;
-    lint-inputs-->create-manifest-->copy-.->push-to-github;
+    lint-inputs-.->create-manifest-->copy-.->push-to-github;
 ```
 
 \* `push-to-github` is an optional task run only for `s3://linz-imagery/`
@@ -207,7 +207,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 | group       | int   | 1000                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group-size` that is reached first).                                          |
 | group-size  | str   | 100Gi                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group-size` that is reached first).                                      |
 | transform   | str   | `f`                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
-| lint        | str   | `true`                                        | true: lint the target path; false: skip linting of target path - to be used when publishing to a location other than `linz-imagery` or using a non-standard path |
+| lint        | str   | `false`                                       | true: lint the target path; false: skip linting of target path - to be used when publishing to a location other than `linz-imagery` or using a non-standard path |
 
 ## Examples
 
@@ -221,6 +221,8 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 **copy-option:** `--no-clobber`
 
+**lint:** `true`
+
 **Target path naming convention:** `s3://linz-imagery/<region>/<city-or-sub-region>_<year>_<resolution>/<product>/<crs>/`
 
 ### Backup RGBI:
@@ -232,8 +234,6 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 **include:** Although only `.tif(f)` and `.tfw` files are required, there should not be any `.json` files in with the uploaded imagery, so this option can be left at the default.
 
 **copy-option:** `--no-clobber`
-
-**lint:** `true`
 
 # Publish-odr
 

--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -121,7 +121,8 @@ spec:
                   value: '{{inputs.parameters.group-size}}'
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
-            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}} && lint-inputs"
+            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}"
+            depends: 'lint-inputs'
 
           - name: create-manifest
             templateRef:

--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -74,7 +74,7 @@ spec:
       - name: transform
         value: 'f'
       - name: 'lint'
-        value: 'true'
+        value: 'false'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -121,7 +121,7 @@ spec:
                   value: '{{inputs.parameters.group-size}}'
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
-            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}"
+            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}} && lint-inputs"
 
           - name: create-manifest
             templateRef:
@@ -143,7 +143,7 @@ spec:
                   value: '{{inputs.parameters.group-size}}'
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
-            depends: 'create-manifest-github.Skipped'
+            depends: 'create-manifest-github.Skipped && lint-inputs'
 
           - name: copy-with-github
             templateRef:

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -118,7 +118,8 @@ spec:
                   value: '{{inputs.parameters.group-size}}'
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
-            when: "{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}} && lint-inputs"
+            when: "{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}}"
+            depends: 'lint-inputs'
 
           - name: create-manifest
             templateRef:

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -73,8 +73,6 @@ spec:
         value: '100Gi'
       - name: transform
         value: 'f'
-      - name: lint
-        value: 'false'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -99,7 +97,7 @@ spec:
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: path
                   value: '{{workflow.parameters.target}}'
-            when: '{{workflow.parameters.lint}}'
+            when: '{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}}'
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest
@@ -120,7 +118,7 @@ spec:
                   value: '{{inputs.parameters.group-size}}'
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
-            when: "{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}}"
+            when: "{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}} && lint-inputs"
 
           - name: create-manifest
             templateRef:
@@ -142,7 +140,7 @@ spec:
                   value: '{{inputs.parameters.group-size}}'
                 - name: version-argo-tasks
                   value: '{{workflow.parameters.version-argo-tasks}}'
-            depends: 'create-manifest-github.Skipped'
+            depends: 'create-manifest-github.Skipped && lint-inputs'
 
           - name: copy-with-github
             templateRef:


### PR DESCRIPTION
#### Motivation

the linting steps were not working as expected for the imagery team:
- even when linting fails the copy still occurs as the `depends: lint-inputs` step is missing
- preference to default lint to false in publish-copy
- preference to not specify in publish-odr - use nz-imagery bucket name to determine if should lint

#### Modification

_publish-copy_
- `lint` now defaults to `false`
- Only copies/continues if lint-inputs succeeds or is skipped 

_publish-odr_
- remove `lint` parameter
- only lints if target bucket = nz-imagery
- Only copies if lint-inputs succeeds or is skipped

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated - tested manually 
- [x] Docs updated
- [x] Issue linked in Title
