### PR TITLE
fix: parsing error

### DIFF
--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -97,7 +97,8 @@ spec:
                   value: '{{workflow.parameters.version-argo-tasks}}'
                 - name: path
                   value: '{{workflow.parameters.target}}'
-            when: '{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}}'
+            when: "{{=sprig.regexMatch('s3://nz-imagery/', workflow.parameters.target)}}"
+
           - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest


### PR DESCRIPTION
#### Motivation

Currently publish odr is not deploying in the github actions due to:
```
error: error parsing workflows/raster/publish-odr.yaml: error converting YAML to JSON: yaml: line 99: did not find expected key
Error: Process completed with exit code 1.
```
For example: https://github.com/linz/topo-workflows/actions/runs/7241106148/job/19724840294

#### Modification

upon investigation ' needs to be changed to " in when statement 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - not required
- [ ] Docs updated - not required
- [ ] Issue linked in Title - no ticket - can retrospectively make a bug if I must
