### PR TITLE
docs: troubleshooting Fluent Bit broken connection TDE-994

### DIFF
--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -44,6 +44,8 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
 
 [Guide to Debugging Fluent Bit issues](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md)
 
+### Basic checks
+
 1. Verify Fluent Bit is deployed and available in the K8s cluster
 
    ```shell
@@ -76,3 +78,16 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
    ```
 
    - Check configuration that might have been deployed by running `cdk8s synth` and look at the `fluentbit` yaml file.
+
+### `broken connection to logs.ap-southeast-2.amazonaws.com:443`
+
+We can see this error happening time to time. It is OK as long as the connection retry succeed:
+
+```shell
+[2023/12/19 11:31:00] [ warn] [engine] failed to flush chunk '1-1702985459.558236192.flb', retry in 10 seconds: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)
+[2023/12/19 11:31:10] [ info] [engine] flush chunk '1-1702985459.558236192.flb' succeeded at retry 1: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)
+```
+
+However, this issue could potentially cause [a delay for the log](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#log-delay) to come into CloudWatch (the time to retry).
+
+If the retry fails, that could mean logs being lost. In that case it would need investigation. [More information here](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#how-do-i-tell-if-fluent-bit-is-losing-logs).

--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -84,8 +84,8 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
 We can see this error happening from time to time. It is OK as long as the connection retry succeed:
 
 ```console
-[2023/12/19 11:31:00] [ warn] [engine] failed to flush chunk '1-1702985459.558236192.flb', retry in 10 seconds: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)
-[2023/12/19 11:31:10] [ info] [engine] flush chunk '1-1702985459.558236192.flb' succeeded at retry 1: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)
+[2023/12/19 11:31:00] [ warn] [engine] failed to flush chunk [...] retry in 10 seconds: task_id=0, [...]
+[2023/12/19 11:31:10] [ info] [engine] flush chunk [...] succeeded at retry 1: task_id=0, [...]
 ```
 
 However, this issue could potentially cause [a delay for the log](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#log-delay) to come into CloudWatch (the time to retry).

--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -42,6 +42,8 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
 
 ## Troubleshooting
 
+[Guide to Debugging Fluent Bit issues](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md)
+
 1. Verify Fluent Bit is deployed and available in the K8s cluster
 
    ```shell

--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -81,7 +81,7 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
 
 ### `broken connection to logs.ap-southeast-2.amazonaws.com:443`
 
-We can see this error happening time to time. It is OK as long as the connection retry succeed:
+We can see this error happening from time to time. It is OK as long as the connection retry succeed:
 
 ```shell
 [2023/12/19 11:31:00] [ warn] [engine] failed to flush chunk '1-1702985459.558236192.flb', retry in 10 seconds: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)

--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -83,7 +83,7 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
 
 We can see this error happening from time to time. It is OK as long as the connection retry succeed:
 
-```shell
+```console
 [2023/12/19 11:31:00] [ warn] [engine] failed to flush chunk '1-1702985459.558236192.flb', retry in 10 seconds: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)
 [2023/12/19 11:31:10] [ info] [engine] flush chunk '1-1702985459.558236192.flb' succeeded at retry 1: task_id=0, input=tail.0 > output=cloudwatch_logs.0 (out_id=0)
 ```


### PR DESCRIPTION
#### Motivation

We are seeing some errors in the Fluent Bit pods logs that are not harmful as the logs a finally get sent to CloudWatch.

#### Modification

Adding information about this error logs to inform the cluster maintainer if it needs to be ignored or investigated further. 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] _Tests updated - N/A_
- [x] Docs updated
- [x] Issue linked in Title
