### PR TITLE
fix: reinstate Sinergise as a licensor

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -206,6 +206,7 @@ spec:
             'Rotorua District Council',
             'Ruapehu District Council',
             'Selwyn District Council',
+            'Sinergise',
             'South Taranaki District Council',
             'South Waikato District Council',
             'South Wairarapa District Council',


### PR DESCRIPTION
We may reprocess imagery in the future so we should keep all licensors that have been used.

See https://linz.slack.com/archives/C01BWPHA1EU/p1703040633399969