### PR TITLE
feat: do not send Fluent Bit application logs to CloudWatch TDE-1016

### DIFF
--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -81,7 +81,7 @@ The Fluent Bit application version is stored in `appVersion` but this is only he
 
 ### `broken connection to logs.ap-southeast-2.amazonaws.com:443`
 
-We can see this error happening from time to time. It is OK as long as the connection retry succeed:
+We can see this error happening a lot. It is OK as long as the connection retry succeed:
 
 ```console
 [2023/12/19 11:31:00] [ warn] [engine] failed to flush chunk [...] retry in 10 seconds: task_id=0, [...]
@@ -91,3 +91,5 @@ We can see this error happening from time to time. It is OK as long as the conne
 However, this issue could potentially cause [a delay for the log](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#log-delay) to come into CloudWatch (the time to retry).
 
 If the retry fails, that could mean logs being lost. In that case it would need investigation. [More information here](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#how-do-i-tell-if-fluent-bit-is-losing-logs).
+
+> **_NOTE:_** One of the consequences of this error is that it increases considerably the amount of the Fluent Bit application pods logs. We had to exclude these logs from being sent to CloudWatch to avoid an increase of our AWS S3 storage cost (as CloudWatch logs are shipped to AWS S3 in our system).

--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -91,6 +91,11 @@ HC_Period 5
           { key: 'karpenter.sh/capacity-type', operator: 'Equal', value: 'spot', effect: 'NoSchedule' },
           { key: 'kubernetes.io/arch', operator: 'Equal', value: 'arm64', effect: 'NoSchedule' },
         ],
+        /* To reduce the log volume being sent to CloudWatch (shipped to AWS s3 => storage cost),
+         tells Fluent Bit to not send the logs from the Fluent Bit application pods.
+         The Fluent Bit application pods have some (a lot!) network errors that are being logged.
+        */
+        annotations: { 'fluentbit.io/exclude': 'true' },
       },
     });
   }


### PR DESCRIPTION
#### Motivation

Due to some managed network issues dealt by Fluent Bit application pods, the amount of logs increased dramatically which has a considerable impact on our cloud storage cost. A solution (that could be temporary until this network errors stop/slow down if we find a way to fix them?) is to stop sending the Fluent Bit application pod logs to CloudWatch.

#### Modification

Telling Fluent Bit to ignore its own logs using the [exclude annotation](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#request-to-exclude-logs).
Consequences are that these logs won't be shipped through our system (not being seen in Elasticsearch). We are still able to view them from the EKS Cluster that we have hands on.

#### Checklist

- [ ] Tests updated - N/A
- [x] Docs updated
- [x] Issue linked in Title
