### PR TITLE
fix: temporary stop sending Argo controller logs TDE-1016

### DIFF
--- a/docs/infrastructure/components/fluentbit.md
+++ b/docs/infrastructure/components/fluentbit.md
@@ -31,6 +31,10 @@ Elasticsearch forwarder should not be enabled. Our logs are shipped into Elastic
 
 Fluent Bit application logs are sent by default to CloudWatch.
 
+### Exclude a pod
+
+You can exclude a pod logs to be treated by Fluent Bit by adding the annotation `'fluentbit.io/exclude': 'true'`.
+
 ## Upgrade
 
 To upgrade the Fluent Bit version, as per the installation, you need to do it via upgrading `aws-for-fluent-bit`.
@@ -91,5 +95,3 @@ We can see this error happening a lot. It is OK as long as the connection retry 
 However, this issue could potentially cause [a delay for the log](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#log-delay) to come into CloudWatch (the time to retry).
 
 If the retry fails, that could mean logs being lost. In that case it would need investigation. [More information here](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#how-do-i-tell-if-fluent-bit-is-losing-logs).
-
-> **_NOTE:_** One of the consequences of this error is that it increases considerably the amount of the Fluent Bit application pods logs. We had to exclude these logs from being sent to CloudWatch to avoid an increase of our AWS S3 storage cost (as CloudWatch logs are shipped to AWS S3 in our system).

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -121,6 +121,7 @@ export class ArgoWorkflows extends Chart {
         },
         artifactRepository,
         controller: {
+          podAnnotations: { 'fluentbit.io/exclude': 'true' },
           nodeSelector: { ...DefaultNodeSelector },
           workflowNamespaces: ['argo'],
           extraArgs: [],

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -121,6 +121,10 @@ export class ArgoWorkflows extends Chart {
         },
         artifactRepository,
         controller: {
+          /* Tells Fluent Bit to not send Argo Controller log to CloudWatch
+            https://github.com/argoproj/argo-workflows/issues/11657 is spamming the logs
+            and increase our logs storage cost.
+          */
           podAnnotations: { 'fluentbit.io/exclude': 'true' },
           nodeSelector: { ...DefaultNodeSelector },
           workflowNamespaces: ['argo'],

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -122,9 +122,9 @@ export class ArgoWorkflows extends Chart {
         artifactRepository,
         controller: {
           /* Tells Fluent Bit to not send Argo Controller log to CloudWatch
-            https://github.com/argoproj/argo-workflows/issues/11657 is spamming the logs
-            and increase our logs storage cost.
-          */
+           *  https://github.com/argoproj/argo-workflows/issues/11657 is spamming the logs
+           *  and increase our logs storage cost.
+           */
           podAnnotations: { 'fluentbit.io/exclude': 'true' },
           nodeSelector: { ...DefaultNodeSelector },
           workflowNamespaces: ['argo'],


### PR DESCRIPTION
#### Motivation

The Argo Controller pod are having this issue https://github.com/argoproj/argo-workflows/issues/11657. This issue is increasing our storage log cost.

#### Modification

Excluding the controller pods so Fluent Bit is not sending their logs to CloudWatch.
Extract of the Deployment with the change:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/component: workflow-controller
    app.kubernetes.io/instance: argo-workflows
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: argo-workflows-workflow-controller
    app.kubernetes.io/part-of: argo-workflows
    app.kubernetes.io/version: v3.4.11
    helm.sh/chart: argo-workflows-0.34.0
    linz.govt.nz/build-id: ""
    linz.govt.nz/git-hash: 628900c56465bd942d68dac4f29faa35c9667b48
    linz.govt.nz/git-repository: linz__topo-workflows
    linz.govt.nz/git-version: v0.0.2-28-g628900c
  name: argo-workflows-workflow-controller
  namespace: argo
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/instance: argo-workflows
      app.kubernetes.io/name: argo-workflows-workflow-controller
  template:
    metadata:
      annotations:
        fluentbit.io/exclude: "true"
      labels:
        app.kubernetes.io/component: workflow-controller
        app.kubernetes.io/instance: argo-workflows
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: argo-workflows-workflow-controller
        app.kubernetes.io/part-of: argo-workflows
        app.kubernetes.io/version: v3.4.11
        helm.sh/chart: argo-workflows-0.34.0
[...]
```

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
