### PR TITLE
feat(basemaps): Move the create covering into spot instance to avoid exceeding memory

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -241,6 +241,8 @@ spec:
     - name: create-covering
       retryStrategy:
         limit: '2'
+      nodeSelector:
+        karpenter.sh/capacity-type: 'spot'
       inputs:
         parameters:
           - name: source
@@ -250,6 +252,9 @@ spec:
           - name: cutline_blend
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
+        resources:
+          requests:
+            memory: 2Gi
         command: [node, /app/node_modules/.bin/cogify]
         env:
           - name: AWS_ROLE_CONFIG_PATH


### PR DESCRIPTION
#### Motivation

Create covering using too much memory for both processing and caching. We will remove the caching the future feature, and move the task into spot node to avoid exceed the memory.

#### Modification

Use spot instance for the create-covering task.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
