### PR TITLE
feat(basemaps): Downgrade to the create-overview tasks to v6.

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -353,7 +353,7 @@ spec:
           requests:
             memory: 7.8Gi
             cpu: 15000m
-        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
+        image: ghcr.io/linz/basemaps/cli:v6
         command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH


### PR DESCRIPTION
#### Motivation

We need to downgrade the create-overview to basemaps cli v6. As this is currently removed in v7 when we doing upgrade of AWS CDK and chunkd in [basemaps](https://github.com/linz/basemaps/commit/6b6e409553b74a10b7c79b077c1a89797747d5d3). 

So we will fix the create-overview task to cli v6 for now until we got a new one in the basemaps cogify in future.

#### Modification

Fix the basemaps cli version to v6 for the create-overview tasks.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
