### PR TITLE
fix: publish-odr should not copy TFW files

### DIFF
--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -60,7 +60,7 @@ spec:
       - name: target
         value: 's3://linz-imagery-staging/test/sample_target/'
       - name: include
-        value: '.tiff?$|.json$|.tfw$'
+        value: '.tiff?$|.json$'
       - name: copy_option
         value: '--no-clobber'
         enum:


### PR DESCRIPTION
#### Motivation

The ODR bucket should not contain TFW files. The TFW files are sometimes provided by the data supplier (also sometimes other sidecar files like `.proj`). We use these sidecar files to get extra information while standardising the data, but would not want to distribute them with the standardised data: all datasets don't have them.

#### Modification

Remove the TFW files from the `include` parameter default value.
The existing data should not be impacted, as the standardised files folder (`flat/` directory) was not including any other files than `tiff` and `json`.

#### Checklist

- [ ] Tests updated NA
- [ ] Docs updated NA
- [ ] Issue linked in Title NA
