### PR TITLE
fix: scanned aerial imagery does not exist in topo-imagery TDE-955

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -107,7 +107,7 @@ spec:
           - 'Aerial Photos'
           - 'Urban Aerial Photos'
           - 'Rural Aerial Photos'
-          - 'Scanned Aerial Imagery'
+          - 'Scanned Aerial Photos'
           - 'DEM'
           - 'DSM'
           - 'Satellite Imagery'


### PR DESCRIPTION
#### Motivation

Align `topo-imagery` [categories](https://github.com/linz/topo-imagery/blob/cde875dc730011165b73848338a700394eccdb4b/scripts/stac/imagery/metadata_constants.py#L40)

#### Modification

`Scanned Aerial Imagery` -> `Scanned Aerial Photos`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
