### PR TITLE
fix: invalid underscore for create-manifest group-size parameter TDE-959

### DIFF
--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -34,7 +34,7 @@ spec:
             description: A regular expression to match object path(s) or name(s) from within the source path to exclude in the copy
             default: ''
 
-          - name: copy-option
+          - name: copy_option
             description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.
             default: '--no-clobber'
             enum:
@@ -76,7 +76,7 @@ spec:
             '{{inputs.parameters.exclude}}',
             '--group',
             '{{=sprig.trim(inputs.parameters.group)}}',
-            '--group_size',
+            '--group-size',
             '{{=sprig.trim(inputs.parameters.group_size)}}',
             '--output',
             '/tmp/file_list.json',


### PR DESCRIPTION
#### Motivation

fixes a bug where workflows which run `create-manifest` would fail with an `^ Unknown arguments` message.

#### Modification
- `group_size` reverted to `group-size`
- `copy-option` changed to `copy_option` for consistency - although the copy option parameter is never used here?

#### Checklist

_If not applicable, provide explanation of why._

~~- [ ] Tests updated~~ no tests but tested in argo
~~- [ ] Docs updated~~ not required docs are correct
- [x] Issue linked in Title - linked to orginal ticket
