### PR TITLE
fix: publish-copy parameter hyphens TDE-826

### DIFF
--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -173,7 +173,7 @@ spec:
                   value: '{{item}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: aws-role-config-path
+                - name: aws_role_config_path
                   value: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -156,7 +156,7 @@ spec:
                   value: '{{item}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: aws-role-config-path
+                - name: aws_role_config_path
                   value: 's3://linz-bucket-config/config-write.open-data-registry.json,s3://linz-bucket-config/config.json'
             depends: 'create-manifest-github.Succeeded'
             withParam: '{{tasks.create-manifest-github.outputs.parameters.files}}'
@@ -173,7 +173,7 @@ spec:
                   value: '{{item}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: aws-role-config-path
+                - name: aws_role_config_path
                   value: 's3://linz-bucket-config/config-write.open-data-registry.json'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'


### PR DESCRIPTION
#### Motivation

Align the `publish-copy` and `publish-odr` workflowtemplates with the downstream sub-templates.

#### Modification

Replace `aws-role-config-path` with `aws_role_config_path`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [X] Issue linked in Title
