### PR TITLE
feat(basemaps): Lock Vector Map ETL container to the latest stable version.

### DIFF
--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -13,8 +13,12 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        description: Version of the basemaps CLI docker container to use
+        description: Version of the Argo Tasks CLI docker container to use
         value: v2
+      
+      - name: version_basemaps_etl
+        description: Version of the Basemaps ETL eks container to use
+        value: d099b18
 
       - name: target
         description: S3 Bucket to use for storing the output
@@ -62,7 +66,7 @@ spec:
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       container:
-        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:bm-etl-latest
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/eks:{{ workflow.parameters.version_basemaps_etl }}
         resources:
           requests:
             memory: 7.8Gi


### PR DESCRIPTION
#### Motivation

We are about the productionise and refactoring the Vector map ETL process, before we adding new breaking changes, we want to lock the ETL to the [latest stable version](https://github.com/linz/basemaps-team/commit/d099b18454b21e7e7fe8943d216e107f170b7d45) in Argo.

#### Modification

Update the ETL workflow to use latest stable [version](https://github.com/linz/basemaps-team/commit/d099b18454b21e7e7fe8943d216e107f170b7d45). 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
