### PR TITLE
chore: update container versions TDE-961 TDE-1014

### DIFF
--- a/workflows/raster/ascii-standardise-publish.yaml
+++ b/workflows/raster/ascii-standardise-publish.yaml
@@ -87,11 +87,11 @@ spec:
       - name: lifecycle
         value: 'completed'
       - name: version_argo_tasks
-        value: 'v2'
+        value: 'v3'
       - name: version_basemaps_cli
         value: 'v6'
       - name: version_topo_imagery
-        value: 'v3'
+        value: 'v4'
   templateDefaults:
     container:
       imagePullPolicy: Always

--- a/workflows/raster/ascii-standardise-publish.yaml
+++ b/workflows/raster/ascii-standardise-publish.yaml
@@ -87,11 +87,11 @@ spec:
       - name: lifecycle
         value: 'completed'
       - name: version_argo_tasks
-        value: 'v3'
+        value: 'v2'
       - name: version_basemaps_cli
         value: 'v6'
       - name: version_topo_imagery
-        value: 'v4'
+        value: 'v3'
   templateDefaults:
     container:
       imagePullPolicy: Always

--- a/workflows/raster/publish-copy.yaml
+++ b/workflows/raster/publish-copy.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v2'
+        value: 'v3'
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v2'
+        value: 'v3'
       - name: ticket
         description: Ticket ID e.g. 'AIP-55'
         value: ''

--- a/workflows/raster/standardising-publish-import.yaml
+++ b/workflows/raster/standardising-publish-import.yaml
@@ -63,11 +63,11 @@ spec:
       - name: lifecycle
         value: 'completed'
       - name: version_argo_tasks
-        value: 'v2'
+        value: 'v3'
       - name: version_basemaps_cli
         value: 'v6'
       - name: version_topo_imagery
-        value: 'v3'
+        value: 'v4'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -104,7 +104,7 @@ spec:
         #     arguments:
         #       parameters:
         #         - name: version_argo_tasks
-        #           value: 'v2'
+        #           value: 'v3'
         #         - name: version_basemaps_cli
         #           value: 'v6'
         #         - name: source

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v2'
+        value: 'v3'
       - name: version_basemaps_cli
         value: 'v6'
       - name: version_topo_imagery

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -14,7 +14,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v2'
+        value: 'v3'
       - name: uri
         description: 'Path(s) to the STAC file(s).'
         value: 's3://linz-imagery-staging/test/stac-validate/'

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -17,9 +17,9 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v2'
-      - name: version_topo_imagery
         value: 'v3'
+      - name: version_topo_imagery
+        value: 'v4'
       - name: source
         value: 's3://linz-topographic-upload/maps/topo50/'
       - name: include


### PR DESCRIPTION
#### Motivation

Bump the container version of argo-tasks (and a few of topo-imagery) to use [new features](https://github.com/linz/argo-tasks/releases/tag/v3.0.0).

#### Modification

Update container version.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated N/A
- [ ] Docs updated N/A - already done
- [X] Issue linked in Title
