### PR TITLE
feat: expose capture-area.geojson TDE-1045

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -466,7 +466,7 @@ spec:
       outputs:
         artifacts:
           - name: capture-area
-            path: 'tmp/capture-area.geojson'
+            path: '/tmp/capture-area.geojson'
             archive:
               none: {}
       container:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -463,6 +463,12 @@ spec:
         parameters:
           - name: collection-id
           - name: location
+      outputs:
+        artifacts:
+          - name: capture-area
+            path: 'tmp/capture-area.geojson'
+            archive:
+              none: {}
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(workflow.parameters.version_topo_imagery)}}'
         resources:


### PR DESCRIPTION
#### Motivation

A direct access to the `capture-area.geojson` file from the workflow UI can be useful for the user to verify data. https://github.com/linz/topo-imagery/pull/860

#### Modification

Add a workflow artifact containing the local copy of `capture-area.geojson`

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [x] Issue linked in Title
