### PR TITLE
fix: create-manifest copy regex needs to match full stop

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -133,7 +133,7 @@ Create a manifest file for a user specified source and target that includes `.ti
       - name: target
         value: '{{workflow.parameters.target}}'
       - name: include
-        value: '.tiff?$|.json$|.tfw$'
+        value: '\.tiff?$|\.json$|\.tfw$'
       - name: exclude
         value: ''
       - name: group

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -5,7 +5,7 @@ kind: WorkflowTemplate
 metadata:
   # Template for creating a manifest to be copied and their target path
   # See https://github.com/linz/argo-tasks#create-manifest
-  name: tpl-afage-create-manifest
+  name: tpl-create-manifest
 spec:
   templateDefaults:
     container:

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -5,7 +5,7 @@ kind: WorkflowTemplate
 metadata:
   # Template for creating a manifest to be copied and their target path
   # See https://github.com/linz/argo-tasks#create-manifest
-  name: tpl-create-manifest
+  name: tpl-afage-create-manifest
 spec:
   templateDefaults:
     container:
@@ -28,7 +28,7 @@ spec:
 
           - name: include
             description: A regular expression to match object path(s) or name(s) from within the source path to include in the copy
-            default: '.tiff?$|.json$|.tfw$'
+            default: '\.tiff?$|\.json$|\.tfw$'
 
           - name: exclude
             description: A regular expression to match object path(s) or name(s) from within the source path to exclude in the copy

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -332,7 +332,7 @@ These are hardcoded due to parameter naming collisions in the downstream Workflo
 
 | Parameter | Type  | Default                                  | Description                                                                                                                                         |
 | --------- | ----- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| include   | regex | .tiff?\$\|.json$\|^capture-area.geojson$ | Applies to the publishing workflow. A regular expression to match object path(s) or name(s) from within the source path to include in publishing\*. |
+| include   | regex | \\.tiff?\$\|\\.json$\|^capture-area.geojson$ | Applies to the publishing workflow. A regular expression to match object path(s) or name(s) from within the source path to include in publishing\*. |
 
 \* This regex can be used to exclude paths as well, e.g. if there are RBG and RGBI directories, the following regex will only include TIFF files in the RGB directory: `RGB(?!I).*.tiff?$`.
 

--- a/workflows/raster/ascii-standardise-publish.yaml
+++ b/workflows/raster/ascii-standardise-publish.yaml
@@ -136,7 +136,7 @@ spec:
                 - name: source
                   value: '{{tasks.get-location.outputs.parameters.location}}flat/'
                 - name: include
-                  value: '.tiff?$|.json$'
+                  value: '\.tiff?$|\.json$'
                 - name: group
                   value: '1000'
                 - name: group_size

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: copy
+  name: test-afage-copy
   namespace: argo
   labels:
     linz.govt.nz/category: raster
@@ -60,7 +60,7 @@ spec:
       - name: target
         value: 's3://linz-imagery-staging/test/sample_target/'
       - name: include
-        value: '.tiff?$|.json$|.tfw$|^capture-area.geojson$'
+        value: '\.tiff?$|\.json$|\.tfw$|^capture-area.geojson$'
       - name: copy_option
         value: '--no-clobber'
         enum:

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-afage-copy
+  name: copy
   namespace: argo
   labels:
     linz.govt.nz/category: raster

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -60,7 +60,7 @@ spec:
       - name: target_bucket_name
         value: 'nz-imagery'
       - name: include
-        value: '.tiff?$|.json$|^capture-area.geojson$'
+        value: '\.tiff?$|\.json$|^capture-area.geojson$'
       - name: copy_option
         value: '--no-clobber'
         enum:

--- a/workflows/raster/standardising-publish-import.yaml
+++ b/workflows/raster/standardising-publish-import.yaml
@@ -92,7 +92,7 @@ spec:
                 - name: source
                   value: '{{steps.standardise.outputs.parameters.target}}flat/'
                 - name: include
-                  value: '.tiff?$|.json$|^capture-area.geojson$'
+                  value: '\.tiff?$|\.json$|^capture-area.geojson$'
                 - name: group
                   value: '1000'
                 - name: group_size

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -18,7 +18,7 @@ spec:
       - name: uri
         value: ''
       - name: filter
-        value: '.tiff?$|.json$'
+        value: '\.tiff?$|\.json$'
       - name: copy_option
         value: '--no-clobber'
         enum:


### PR DESCRIPTION
#### Motivation

To prevent copy of the `.geojson` footprint files.

#### Modification

Escape the `.` in the `.json$` in the regex so we don't copy all `.geojson` files that get matched.

#### Checklist

_If not applicable, provide explanation of why._

N/A

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
