### PR TITLE
chore: update templates with Argo Tasks v3

### DIFF
--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -23,7 +23,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v2'
+            default: 'v3'
 
           - name: copy_option
             description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -24,7 +24,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v2'
+            default: 'v3'
 
           - name: include
             description: A regular expression to match object path(s) or name(s) from within the source path to include in the copy

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -21,7 +21,7 @@ spec:
             description: target bucket name e.g. 'nz-imagery'
           - name: version
             description: argo-task Container version to use
-            default: 'v2'
+            default: 'v3'
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{= inputs.parameters.version }}'

--- a/templates/argo-tasks/group.yml
+++ b/templates/argo-tasks/group.yml
@@ -32,7 +32,7 @@ spec:
 
           - name: version
             description: argo-task Container version to use
-            default: 'v2'
+            default: 'v3'
 
       outputs:
         parameters:

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -25,7 +25,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v2'
+            default: 'v3'
 
           - name: repository
             description: Repository Name (only used when identified that push to GitHub is required)

--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -41,7 +41,7 @@ spec:
 
           - name: version
             description: container version to use
-            default: 'v2'
+            default: 'v3'
 
       outputs:
         artifacts:


### PR DESCRIPTION
#### Motivation

Bring the templates into line with the workflows and workflowtemplates to be consistent. It should have no functional effect as the upstream workflows specify Argo Tasks `v3` which will override the templates, but there is always the possibility that this might not be specified upstream.

#### Modification

Change `version_argo_tasks` to `v3` in templates.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
