### PR TITLE
fix: pin tileindex-validate argo-tasks version to 3.1.0 TDE-1013

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v3'
+        value: 'v3.1.0'
       - name: version_basemaps_cli
         value: 'v6'
       - name: version_topo_imagery


### PR DESCRIPTION
#### Motivation

There might be a bug introduced by v3.1.1. While investigating/fixing, pinning tileindex-validate to previous argo-tasks version is safer.

#### Modification

Pin argo-tasks version to v3.1.0 for tileindex-validate.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
