### PR TITLE
feat: enable publish to elevation TDE-1037

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -244,7 +244,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Description
 
-This workflow replicates `copy` however it allows publishing to `s3://nz-imagery` (the registry of open data).
+This workflow replicates `copy` however it allows publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registries of open data).
 **This workflow should not be run using the Argo UI, instead follow the instruction [here](https://github.com/linz/imagery/tree/master/publish-odr-parameters/README.md)**
 
 ```mermaid

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -191,14 +191,10 @@ Copy files from one S3 location to another. This workflow is intended to be used
 
 ```mermaid
 graph TD;
-  create-manifest-->copy-.->push-to-github;
+  create-manifest-->copy;
 ```
 
-\* `push-to-github` is an optional task run only for `s3://linz-imagery/`
-
 This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks#create-manifest) container `create-manifest` (list of source and target file paths) and `copy` (the actual file copy) commands.
-
-If the target destination is `linz-imagery` there is an extra step carried out that pushes the `collection.json` to the `linz/imagery` GitHub repository, which is where the STAC Catalog and Collection metadata files for the `s3://linz-imagery` bucket are managed. This step uses the argo-tasks container `stac-github-import` command.
 
 Access permissions are controlled by the [Bucket Sharing Config](https://github.com/linz/topo-aws-infrastructure/blob/master/src/stacks/bucket.sharing.ts) which gives Argo Workflows access to the S3 buckets we use.
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -240,7 +240,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Description
 
-This workflow replicates `copy` however it allows publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registries of open data).
+This workflow replicates `copy` however it allows publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registry of open data public S3 buckets).
 **This workflow should not be run using the Argo UI, instead follow the instruction [here](https://github.com/linz/imagery/tree/master/publish-odr-parameters/README.md)**
 
 ```mermaid

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -108,7 +108,6 @@ spec:
                   value: '{{inputs.parameters.group_size}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
-            depends: 'create-manifest-github.Skipped'
 
           - name: copy
             templateRef:

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -88,28 +88,6 @@ spec:
           - name: group_size
       dag:
         tasks:
-          - name: create-manifest-github
-            templateRef:
-              name: tpl-create-manifest
-              template: main
-            arguments:
-              parameters:
-                - name: source
-                  value: '{{inputs.parameters.source}}'
-                - name: target
-                  value: '{{workflow.parameters.target}}'
-                - name: include
-                  value: '{{inputs.parameters.include}}'
-                - name: exclude
-                  value: 'collection.json$'
-                - name: group
-                  value: '{{inputs.parameters.group}}'
-                - name: group_size
-                  value: '{{inputs.parameters.group_size}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-            when: "{{=sprig.regexMatch('s3://linz-elevation/', workflow.parameters.target)}}"
-
           - name: create-manifest
             templateRef:
               name: tpl-create-manifest
@@ -132,21 +110,6 @@ spec:
                   value: '{{workflow.parameters.version_argo_tasks}}'
             depends: 'create-manifest-github.Skipped'
 
-          - name: copy-with-github
-            templateRef:
-              name: tpl-copy
-              template: main
-            arguments:
-              parameters:
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
-                - name: file
-                  value: '{{item}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-            depends: 'create-manifest-github.Succeeded'
-            withParam: '{{tasks.create-manifest-github.outputs.parameters.files}}'
-
           - name: copy
             templateRef:
               name: tpl-copy
@@ -163,19 +126,3 @@ spec:
                   value: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
-
-          - name: push-to-github
-            templateRef:
-              name: tpl-push-to-github
-              template: main
-            arguments:
-              parameters:
-                - name: source
-                  value: '{{inputs.parameters.source}}'
-                - name: target
-                  value: '{{workflow.parameters.target}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: repository
-                  value: 'elevation'
-            depends: 'copy-with-github'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -121,7 +121,7 @@ spec:
                   value: '{{inputs.parameters.group_size}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
-            when: "{{=sprig.regexMatch('nz-imagery', workflow.parameters.target_bucket_name)}}"
+            when: "{{=sprig.regexMatch('nz-imagery|nz-elevation', workflow.parameters.target_bucket_name)}}"
             depends: 'generate-path'
 
           - name: create-manifest
@@ -193,5 +193,5 @@ spec:
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
                 - name: repository
-                  value: 'imagery'
+                  value: "{{=sprig.trimPrefix('nz-', workflow.parameters.target_bucket_name)}}"
             depends: 'copy-with-github'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -101,7 +101,7 @@ spec:
                 - name: source
                   value: '{{inputs.parameters.source}}'
 
-          - name: create-manifest
+          - name: create-manifest-github
             templateRef:
               name: tpl-create-manifest
               template: main
@@ -124,7 +124,7 @@ spec:
             when: "{{=sprig.regexMatch('nz-imagery|nz-elevation', workflow.parameters.target_bucket_name)}}"
             depends: 'generate-path'
 
-          - name: copy
+          - name: copy-with-github
             templateRef:
               name: tpl-copy
               template: main

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -101,7 +101,7 @@ spec:
                 - name: source
                   value: '{{inputs.parameters.source}}'
 
-          - name: create-manifest-github
+          - name: create-manifest
             templateRef:
               name: tpl-create-manifest
               template: main
@@ -123,45 +123,6 @@ spec:
                   value: '{{workflow.parameters.version_argo_tasks}}'
             when: "{{=sprig.regexMatch('nz-imagery|nz-elevation', workflow.parameters.target_bucket_name)}}"
             depends: 'generate-path'
-
-          - name: create-manifest
-            templateRef:
-              name: tpl-create-manifest
-              template: main
-            arguments:
-              parameters:
-                - name: source
-                  value: '{{inputs.parameters.source}}'
-                - name: target
-                  value: '{{tasks.generate-path.outputs.parameters.target}}'
-                - name: include
-                  value: '{{inputs.parameters.include}}'
-                - name: exclude
-                  value: ''
-                - name: group
-                  value: '{{inputs.parameters.group}}'
-                - name: group_size
-                  value: '{{inputs.parameters.group_size}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-            depends: 'create-manifest-github.Skipped && generate-path'
-
-          - name: copy-with-github
-            templateRef:
-              name: tpl-copy
-              template: main
-            arguments:
-              parameters:
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
-                - name: file
-                  value: '{{item}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: aws_role_config_path
-                  value: 's3://linz-bucket-config/config-write.open-data-registry.json,s3://linz-bucket-config/config.json'
-            depends: 'create-manifest-github.Succeeded'
-            withParam: '{{tasks.create-manifest-github.outputs.parameters.files}}'
 
           - name: copy
             templateRef:

--- a/workflows/test/generate-path.yaml
+++ b/workflows/test/generate-path.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: test-generate-target
+  namespace: argo
+  labels:
+    linz.govt.nz/category: test
+spec:
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        value: 'v3'
+      - name: source
+        value: 's3://linz-imagery-staging/test/sample/'
+      - name: target_bucket_name
+        value: 'nz-imagery'
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: source
+          - name: target_bucket_name
+      dag:
+        tasks:
+          - name: generate-path
+            templateRef:
+              name: tpl-at-generate-path
+              template: main
+            arguments:
+              parameters:
+                - name: version
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+                - name: target_bucket_name
+                  value: '{{inputs.parameters.target_bucket_name}}'
+                - name: source
+                  value: '{{inputs.parameters.source}}'


### PR DESCRIPTION
#### Motivation

Enable publish-odr to also push to linz/elevation 

#### Modification

**publish-odr:**
- Will always use a generated-target-path
- Will always publish to github
- Can publish to linz/imagery or linz/elevation

_nb: I will create a separate PR with a workflow that can be run in the event someone needs to publish to the odr and specifiy the target rather than automatically generating it (a backup workaround for any difficult datasets)_

**Copy**
- Will always require a target path (can use test-generate-path to build target)
- Will never publish to github
- Cannot publish to ODR

**test-generate-path**
New test workflow template for use to check the generated target path (superceding: https://github.com/linz/argo-tasks/blob/docs/tmp-generate-path/src/commands/path/TMP_DOC.md) 


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - unable to test publish-odr changes not in production?
- [x] Docs updated
- [x] Issue linked in Title
