### PR TITLE
feat: publish-odr-specify-target TDE-1037

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -315,7 +315,7 @@ graph TD;
 
 **target_bucket_name:** `nz-imagery`
 
-**include:** Although only `.tiff` and `.json` files are required, there should not be any `.tfw` files in with the standardised imagery, so this option can be left at the default.
+**include:** Although only `.tiff` and `.json` files are required, there should not be any `.tfw` files in with the standardised imagery, so this option can be left as the default.
 
 **copy_option:** `--no-clobber`
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -204,17 +204,17 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Input Parameters
 
-| Parameter   | Type  | Default                                          | Description                                                                                                                                                      |
-| ----------- | ----- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ticket      | str   |                                                  | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
-| region      | enum  |                                                  | Region of the dataset                                                                                                                                            |
-| source      | str   | s3://linz-imagery-staging/test/sample/           | The URIs (paths) to the s3 source location                                                                                                                       |
-| target      | str   | s3://linz-imagery-staging/test/sample_target/    | The URIs (paths) to the s3 target location                                                                                                                       |
-| include     | regex | \\.tiff?\$\|\\.json\$\|\\.tfw$\|/capture-area\\.geojson$ | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                      |
-| copy_option | enum  | --no-clobber                                  | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
-| group       | int   | 1000                                             | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                          |
-| group_size  | str   | 100Gi                                            | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                      |
-| transform   | str   | `f`                                              | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
+| Parameter   | Type  | Default                                                  | Description                                                                                                                                                                                                                 |
+| ----------- | ----- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticket      | str   |                                                          | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
+| region      | enum  |                                                          | Region of the dataset                                                                                                                                                                                                       |
+| source      | str   | s3://linz-imagery-staging/test/sample/                   | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
+| target      | str   | s3://linz-imagery-staging/test/sample_target/            | The URIs (paths) to the s3 target location                                                                                                                                                                                  |
+| include     | regex | \\.tiff?\$\|\\.json\$\|\\.tfw$\|/capture-area\\.geojson$ | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                                                                                 |
+| copy_option | enum  | --no-clobber                                             | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
+| group       | int   | 1000                                                     | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                     |
+| group_size  | str   | 100Gi                                                    | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                 |
+| transform   | str   | `f`                                                      | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation.                                                            |
 
 ## Examples
 
@@ -249,22 +249,22 @@ This workflow replicates `copy` however it allows publishing to `s3://nz-imagery
 
 ```mermaid
 graph TD;
-  generate-path-->create-manifest-->copy-.->push-to-github;
+  generate-path-->create-manifest-->copy-->push-to-github;
 ```
 
 ## Workflow Input Parameters
 
-| Parameter          | Type  | Default                                   | Description                                                                                                                                                      |
-| ------------------ | ----- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ticket             | str   |                                           | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
-| region             | enum  |                                           | Region of the dataset                                                                                                                                            |
-| source             | str   | s3://linz-imagery-staging/test/sample/    | The URIs (paths) to the s3 source location                                                                                                                       |
-| target_bucket_name | str   | nz-imagery                                | The bucket name of the target location location                                                                                                                  |
-| include            | regex | \\.tiff?\$\|\\.json\$\|/capture-area\\.geojson$ | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                      |
-| copy_option        | enum  | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
-| group              | int   | 1000                                      | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                          |
-| group_size         | str   | 100Gi                                     | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                      |
-| transform          | str   | `f`                                       | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
+| Parameter          | Type  | Default                                         | Description                                                                                                                                                                                                                 |
+| ------------------ | ----- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticket             | str   |                                                 | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
+| region             | enum  |                                                 | Region of the dataset                                                                                                                                                                                                       |
+| source             | str   | s3://linz-imagery-staging/test/sample/          | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
+| target_bucket_name | str   | nz-imagery                                      | The bucket name of the target location location                                                                                                                                                                             |
+| include            | regex | \\.tiff?\$\|\\.json\$\|/capture-area\\.geojson$ | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                                                                                 |
+| copy_option        | enum  | --no-clobber                                    | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
+| group              | int   | 1000                                            | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                     |
+| group_size         | str   | 100Gi                                           | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                 |
+| transform          | str   | `f`                                             | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation.                                                            |
 
 ## Examples
 
@@ -279,6 +279,49 @@ graph TD;
 **copy_option:** `--no-clobber`
 
 See the [copy template](#copy) for more information.
+
+# Publish-odr-specify-target
+
+## Workflow Description
+
+This workflow replicates `publish-odr` however it allows the user to specify the target path in the registry of open data.
+**This workflow should not be run unless generate-path does not produce the desired target, for example sometimes datasets have non-standard names during emergency response work**
+
+```mermaid
+graph TD;
+  create-manifest-->copy-->push-to-github;
+```
+
+## Workflow Input Parameters
+
+| Parameter          | Type  | Default                                         | Description                                                                                                                                                                                                                 |
+| ------------------ | ----- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticket             | str   |                                                 | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
+| region             | enum  |                                                 | Region of the dataset                                                                                                                                                                                                       |
+| source             | str   | s3://linz-imagery-staging/test/sample/          | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
+| target_bucket_name | str   | nz-imagery                                      | The bucket name of the target location location                                                                                                                                                                             |
+| include            | regex | \\.tiff?\$\|\\.json\$\|/capture-area\\.geojson$ | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                                                                                 |
+| copy_option        | enum  | --no-clobber                                    | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
+| group              | int   | 1000                                            | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                     |
+| group_size         | str   | 100Gi                                           | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                 |
+| transform          | str   | `f`                                             | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation.                                                            |
+| target_path        | str   | `s3://nz-imagery/test/sample`                   | The target ODR path                                                                                                                                                                                                         |
+
+## Examples
+
+### Publish:
+
+**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+
+**target_bucket_name:** `nz-imagery`
+
+**include:** Although only `.tiff` and `.json` files are required, there should not be any `.tfw` files in with the standardised imagery, so this option can be left at the default.
+
+**copy_option:** `--no-clobber`
+
+See the [copy template](#copy) for more information.
+
+**target_path:** `s3://nz-imagery/auckland/auckland_2010-2011_0.125m/rgb/2193/`
 
 # Standardising-publish-import
 
@@ -330,8 +373,8 @@ This workflow carries out the steps in the [Standardising](#Standardising) workf
 
 These are hardcoded due to parameter naming collisions in the downstream WorkflowTemplates and will likely not need to be changed.
 
-| Parameter | Type  | Default                                  | Description                                                                                                                                         |
-| --------- | ----- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter | Type  | Default                                        | Description                                                                                                                                         |
+| --------- | ----- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | include   | regex | \\.tiff?\$\|\\.json$\|/capture-area\\.geojson$ | Applies to the publishing workflow. A regular expression to match object path(s) or name(s) from within the source path to include in publishing\*. |
 
 \* This regex can be used to exclude paths as well, e.g. if there are RBG and RGBI directories, the following regex will only include TIFF files in the RGB directory: `RGB(?!I).*.tiff?$`.

--- a/workflows/raster/publish-odr-specify-target.yaml
+++ b/workflows/raster/publish-odr-specify-target.yaml
@@ -1,0 +1,145 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: publish-odr-specify-target
+  namespace: argo
+  labels:
+    linz.govt.nz/category: raster
+    linz.govt.nz/data-type: raster
+spec:
+  parallelism: 50
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  synchronization:
+    semaphore:
+      configMapKeyRef:
+        name: semaphores
+        key: bulkcopy
+  workflowMetadata:
+    labelsFrom:
+      linz.govt.nz/ticket:
+        expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        value: 'v3'
+      - name: ticket
+        description: Ticket ID e.g. 'AIP-55'
+        value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'antarctica'
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'global'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'pacific-islands'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
+      - name: source
+        value: 's3://linz-imagery-staging/test/sample/'
+      - name: target_bucket_name
+        value: 'nz-imagery'
+      - name: include
+        value: '\.tiff?$|\.json$|/capture-area\.geojson$'
+      - name: copy_option
+        value: '--no-clobber'
+        enum:
+          - '--no-clobber'
+          - '--force'
+          - '--force-no-clobber'
+      - name: group
+        value: '1000'
+      - name: group_size
+        value: '100Gi'
+      - name: transform
+        value: 'f'
+      - name: target_path
+        value: 's3://nz-imagery/test/sample/'
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: source
+          - name: target_bucket_name
+          - name: include
+          - name: group
+          - name: group_size
+      dag:
+        tasks:
+          - name: create-manifest-github
+            templateRef:
+              name: tpl-create-manifest
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{inputs.parameters.source}}'
+                - name: target
+                  value: '{{workflow.parameters.target_path}}'
+                - name: include
+                  value: '{{inputs.parameters.include}}'
+                - name: exclude
+                  value: 'collection.json$'
+                - name: group
+                  value: '{{inputs.parameters.group}}'
+                - name: group_size
+                  value: '{{inputs.parameters.group_size}}'
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+            when: "{{=sprig.regexMatch('nz-imagery|nz-elevation', workflow.parameters.target_bucket_name)}}"
+
+          - name: copy-with-github
+            templateRef:
+              name: tpl-copy
+              template: main
+            arguments:
+              parameters:
+                - name: copy_option
+                  value: '{{workflow.parameters.copy_option}}'
+                - name: file
+                  value: '{{item}}'
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+                - name: aws_role_config_path
+                  value: 's3://linz-bucket-config/config-write.open-data-registry.json'
+            depends: 'create-manifest-input-target'
+            withParam: '{{tasks.create-manifest-github.outputs.parameters.files}}'
+
+          - name: push-to-github
+            templateRef:
+              name: tpl-push-to-github
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{inputs.parameters.source}}'
+                - name: target
+                  value: '{{workflow.parameters.target_path}}'
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+                - name: repository
+                  value: "{{=sprig.trimPrefix('nz-', workflow.parameters.target_bucket_name)}}"


### PR DESCRIPTION
#### Motivation

In some situations the target path automatically generated might be incorrect. The most likely scenario for this is imagery flown during emergency response. Therefore a workaround needs to exist that will allow the imagery data maintainers to quickly publish data to the ODR.

#### Modification

copy of `publish-odr` workflow with added parameter that allows the user to publish to the odr with a specified target path


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - unable to test publish to odr (tested up untill create-manifest)
- [x] Docs updated
- [x] Issue linked in Title
