### PR TITLE
fix: create-manifest should be create-manifest-github

### DIFF
--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -138,8 +138,8 @@ spec:
                   value: '{{workflow.parameters.version_argo_tasks}}'
                 - name: aws_role_config_path
                   value: 's3://linz-bucket-config/config-write.open-data-registry.json'
-            depends: 'create-manifest'
-            withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
+            depends: 'create-manifest-github'
+            withParam: '{{tasks.create-manifest-github.outputs.parameters.files}}'
 
           - name: push-to-github
             templateRef:


### PR DESCRIPTION
#### Motivation

bug in production

#### Modification

`create-manifest` should be `create-manifest-github`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - no tests will be tested asap 
- [ ] Docs updated - n/a
- [ ] Issue linked in Title - n/a quick bug fix no related ticket
