### PR TITLE
fix: allocate more CPU resources to the create-collection workflow task TDE-988

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -475,7 +475,7 @@ spec:
         resources:
           requests:
             memory: 7.8Gi
-            cpu: 2000m
+            cpu: 15000m
         command:
           - python
           - '/app/scripts/collection_from_items.py'


### PR DESCRIPTION
#### Motivation

The create-collection standardising workflow step has changed to also create the `capture-area.geojson` file, which is a more computationally intensive task and can take a long time.

#### Modification

Change the CPU from `2000m` to `15000m`.

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [X] Issue linked in Title N/A
