### PR TITLE
feat: give Argo Workflows read access to ODR buckets TDE-1065

### DIFF
--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -289,5 +289,7 @@ export class LinzEksCluster extends Stack {
     this.tempBucket.grantReadWrite(argoRunnerSa.role);
     // give permission to the sa to assume a role
     argoRunnerSa.role.addToPrincipalPolicy(new PolicyStatement({ actions: ['sts:AssumeRole'], resources: ['*'] }));
+    // give read on ODR public bucket
+    Bucket.fromBucketName(this, 'OdrNzImagery', 'nz-imagery').grantRead(argoRunnerSa.role);
   }
 }

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -289,7 +289,12 @@ export class LinzEksCluster extends Stack {
     this.tempBucket.grantReadWrite(argoRunnerSa.role);
     // give permission to the sa to assume a role
     argoRunnerSa.role.addToPrincipalPolicy(new PolicyStatement({ actions: ['sts:AssumeRole'], resources: ['*'] }));
-    // give read on ODR public bucket
+
+    /* Gives read access on ODR public buckets.
+     * While those are public buckets, we still need to give permission to Argo
+     * as the `--no-sign-request` is not handled in the code.
+     */
     Bucket.fromBucketName(this, 'OdrNzImagery', 'nz-imagery').grantRead(argoRunnerSa.role);
+    Bucket.fromBucketName(this, 'OdrNzElevation', 'nz-elevation').grantRead(argoRunnerSa.role);
   }
 }


### PR DESCRIPTION
#### Motivation

Argo Workflows needs read access to the public ODR buckets in order to achieve tasks that needs reading published files such as [`stac-validate`](https://github.com/linz/topo-workflows/tree/master/workflows/stac).

#### Modification

Grant read access to `s3://nz-elevation` and `s3://nz-imagery` to the Argo Runner service account.

**The change has been deployed and tested on `nz-imagery` with [a `stac-validate` workflow](https://argo.linzaccess.com/workflows/argo/stac-validate-8l4qv?tab=workflow).**

#### Checklist

- [ ] Tests updated N/A
- [x] Docs updated
- [x] Issue linked in Title
