### PR TITLE
fix(infra): disable coredns logs as it is too spammy TDE-1064

### DIFF
--- a/infra/charts/kube-system.coredns.ts
+++ b/infra/charts/kube-system.coredns.ts
@@ -36,7 +36,6 @@ export class CoreDns extends Chart {
         // FIXME: is there a better way of handling config files inside of cdk8s
         Corefile: `
 cluster.local:53 {
-    log
     errors
     health
     kubernetes cluster.local in-addr.arpa ip6.arpa {
@@ -52,7 +51,6 @@ cluster.local:53 {
 }
 
 .:53 {
-    log
     errors
     health
     template ANY AAAA {


### PR DESCRIPTION
#### Motivation

Our logs get forwarded out of EKS into cloudwatch then into elastic search, by logging every DNS query we are adding a lot of strain on the logging process.

#### Modification

Disable DNS query logs.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
