### PR TITLE
fix: revert "fix(infra): disable coredns logs as it is too spammy TDE-1064 (#472)" TDE-1084

### DIFF
--- a/infra/charts/kube-system.coredns.ts
+++ b/infra/charts/kube-system.coredns.ts
@@ -36,6 +36,7 @@ export class CoreDns extends Chart {
         // FIXME: is there a better way of handling config files inside of cdk8s
         Corefile: `
 cluster.local:53 {
+    log
     errors
     health
     kubernetes cluster.local in-addr.arpa ip6.arpa {
@@ -51,6 +52,7 @@ cluster.local:53 {
 }
 
 .:53 {
+    log
     errors
     health
     template ANY AAAA {


### PR DESCRIPTION
#### Motivation

We are investigating some DNS related issues, would be nice to see the logs of DNS queries so we can have more information.

#### Modification

This reverts commit 942f297df9609d68a08d86bcd9b1017394d0088a.
