### PR TITLE
feat: update publish-odr to remove copy and add new PR fields TDE-1100 TDE-1102

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -161,12 +161,16 @@ See https://github.com/linz/argo-tasks#stac-github-import
       - name: source
         value: '{{inputs.parameters.source}}'
       - name: target
-        value: '{{workflow.parameters.target}}'
+        value: '{{tasks.generate-path.outputs.parameters.target}}'
       - name: version_argo_tasks
         value: '{{workflow.parameters.version_argo_tasks}}'
       - name: repository
-        value: 'elevation'
-  depends: 'copy-with-github'
+        value: "{{=sprig.trimPrefix('nz-', workflow.parameters.target_bucket_name)}}"
+      - name: ticket
+        value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+      - name: copy_option
+        value: '{{workflow.parameters.copy_option}}'
+  depends: 'generate-path'
 ```
 
 ## argo-tasks/generate-path

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -32,8 +32,8 @@ spec:
         args:
           - 'generate-path'
           - '--target-bucket-name'
-          - '{{inputs.parameters.target_bucket_name}}'
-          - '{{inputs.parameters.source}}'
+          - '{{=sprig.trim(inputs.parameters.target_bucket_name)}}'
+          - '{{=sprig.trim(inputs.parameters.source)}}'
 
       outputs:
         parameters:

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -36,7 +36,7 @@ spec:
 
           - name: ticket
             description: Ticket ID e.g. 'AIP-55'
-            value: ''
+            default: ''
 
           - name: copy_option
             description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -29,7 +29,7 @@ spec:
 
           - name: repository
             description: Repository Name (only used when identified that push to GitHub is required)
-            default: 'elevation'
+            default: 'imagery'
             enum:
               - 'elevation'
               - 'imagery'
@@ -58,13 +58,13 @@ spec:
             'stac',
             'github-import',
             '--source',
-            '{{=sprig.trim(inputs.parameters.source)}}',
+            '{{inputs.parameters.source}}',
             '--target',
-            '{{=sprig.trim(inputs.parameters.target)}}',
+            '{{inputs.parameters.target}}',
             '--repo-name',
             'linz/{{=sprig.regexFind(inputs.parameters.repository, inputs.parameters.target)}}',
             '--ticket',
-            '{{=sprig.trim(inputs.parameters.target)}}',
+            '{{inputs.parameters.ticket}}',
             '--copy-option',
-            '{{=sprig.trim(inputs.parameters.copy_option)}}',
+            '{{inputs.parameters.copy_option}}',
           ]

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -34,6 +34,14 @@ spec:
               - 'elevation'
               - 'imagery'
 
+          - name: ticket
+            description: Ticket ID e.g. 'AIP-55'
+            value: ''
+
+          - name: copy_option
+            description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.
+            default: '--no-clobber'
+
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
         env:
@@ -55,4 +63,8 @@ spec:
             '{{=sprig.trim(inputs.parameters.target)}}',
             '--repo-name',
             'linz/{{=sprig.regexFind(inputs.parameters.repository, inputs.parameters.target)}}',
+            '--ticket',
+            '{{=sprig.trim(inputs.parameters.target)}}',
+            '--copy-option',
+            '{{=sprig.trim(inputs.parameters.copy_option)}}',
           ]

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -29,14 +29,12 @@ spec:
 
           - name: repository
             description: Repository Name
-            default: ''
             enum:
               - 'elevation'
               - 'imagery'
 
           - name: ticket
             description: Ticket ID e.g. 'AIP-55'
-            default: ''
 
           - name: copy_option
             description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -38,7 +38,6 @@ spec:
 
           - name: copy_option
             description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.
-            default: '--no-clobber'
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -29,9 +29,6 @@ spec:
 
           - name: repository
             description: Repository Name
-            enum:
-              - 'elevation'
-              - 'imagery'
 
           - name: ticket
             description: Ticket ID e.g. 'AIP-55'

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -28,7 +28,7 @@ spec:
             default: 'v3'
 
           - name: repository
-            description: Repository Name (only used when identified that push to GitHub is required)
+            description: Repository Name
             default: 'imagery'
             enum:
               - 'elevation'
@@ -58,7 +58,7 @@ spec:
             'stac',
             'github-import',
             '--source',
-            '{{inputs.parameters.source}}',
+            '{{=sprig.trim(inputs.parameters.source)}}',
             '--target',
             '{{inputs.parameters.target}}',
             '--repo-name',

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -29,7 +29,7 @@ spec:
 
           - name: repository
             description: Repository Name
-            default: 'imagery'
+            default: ''
             enum:
               - 'elevation'
               - 'imagery'

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -240,7 +240,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Description
 
-This workflow creates a GitHub Pull Request to be reviewed for publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registry of open data public S3 buckets). When the Pull Request is approved and merged, the files will be copied.
+This workflow creates a GitHub pull request to be reviewed for publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two AWS Registry of Open Data public S3 buckets). When the pull request is approved and merged, the files will be copied.
 
 
 ```mermaid

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -240,7 +240,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Description
 
-This workflow creates a Pull Request to be reviewed for publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registry of open data public S3 buckets). When the Pull Request is approved and merged, the files will be copied.
+This workflow creates a GitHub Pull Request to be reviewed for publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registry of open data public S3 buckets). When the Pull Request is approved and merged, the files will be copied.
 
 
 ```mermaid

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -245,7 +245,7 @@ This workflow replicates `copy` however it allows publishing to `s3://nz-imagery
 
 ```mermaid
 graph TD;
-  generate-path-->create-manifest-->copy-.->push-to-github;
+  generate-path-->push-to-github;
 ```
 
 ## Workflow Input Parameters
@@ -255,12 +255,9 @@ graph TD;
 | ticket             | str   |                                           | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
 | region             | enum  |                                           | Region of the dataset                                                                                                                                            |
 | source             | str   | s3://linz-imagery-staging/test/sample/    | The URIs (paths) to the s3 source location                                                                                                                       |
-| target_bucket_name | str   | nz-imagery                                | The bucket name of the target location location                                                                                                                  |
-| include            | regex | \\.tiff?\$\|\\.json\$\|/capture-area\\.geojson$ | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                      |
+| target_bucket_name | enum   | nz-imagery                                | The bucket name of the target location location                                                                                                                  |                                                  |
 | copy_option        | enum  | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
-| group              | int   | 1000                                      | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                          |
-| group_size         | str   | 100Gi                                     | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                      |
-| transform          | str   | `f`                                       | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
+
 
 ## Examples
 
@@ -269,8 +266,6 @@ graph TD;
 **source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
 
 **target_bucket_name:** `nz-imagery`
-
-**include:** Although only `.tiff` and `.json` files are required, there should not be any `.tfw` files in with the standardised imagery, so this option can be left at the default.
 
 **copy_option:** `--no-clobber`
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -240,8 +240,8 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ## Workflow Description
 
-This workflow replicates `copy` however it allows publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registry of open data public S3 buckets).
-**This workflow should not be run using the Argo UI, instead follow the instruction [here](https://github.com/linz/imagery/tree/master/publish-odr-parameters/README.md)**
+This workflow creates a Pull Request to be reviewed for publishing to `s3://nz-imagery` and `s3://nz-elevation` (the two registry of open data public S3 buckets). When the Pull Request is approved and merged, the files will be copied.
+
 
 ```mermaid
 graph TD;

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -255,7 +255,7 @@ graph TD;
 | ticket             | str   |                                           | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
 | region             | enum  |                                           | Region of the dataset                                                                                                                                            |
 | source             | str   | s3://linz-imagery-staging/test/sample/    | The URIs (paths) to the s3 source location                                                                                                                       |
-| target_bucket_name | enum   | nz-imagery                                | The bucket name of the target location location                                                                                                                  |                                                  |
+| target_bucket_name | enum   | nz-imagery                                | The bucket name of the target location                                                                                                                  |                                                  |
 | copy_option        | enum  | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
 
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -258,7 +258,6 @@ graph TD;
 | target_bucket_name | enum   | nz-imagery                                | The bucket name of the target location                                                                                                                  |                                                  |
 | copy_option        | enum  | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
 
-
 ## Examples
 
 ### Publish:

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -59,20 +59,15 @@ spec:
         value: 's3://linz-imagery-staging/test/sample/'
       - name: target_bucket_name
         value: 'nz-imagery'
-      - name: include
-        value: '\.tiff?$|\.json$|/capture-area\.geojson$'
+        enum:
+          - 'nz-imagery'
+          - 'nz-elevation'
       - name: copy_option
         value: '--no-clobber'
         enum:
           - '--no-clobber'
           - '--force'
           - '--force-no-clobber'
-      - name: group
-        value: '1000'
-      - name: group_size
-        value: '100Gi'
-      - name: transform
-        value: 'f'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -101,46 +96,6 @@ spec:
                 - name: source
                   value: '{{inputs.parameters.source}}'
 
-          - name: create-manifest-github
-            templateRef:
-              name: tpl-create-manifest
-              template: main
-            arguments:
-              parameters:
-                - name: source
-                  value: '{{inputs.parameters.source}}'
-                - name: target
-                  value: '{{tasks.generate-path.outputs.parameters.target}}'
-                - name: include
-                  value: '{{inputs.parameters.include}}'
-                - name: exclude
-                  value: 'collection.json$'
-                - name: group
-                  value: '{{inputs.parameters.group}}'
-                - name: group_size
-                  value: '{{inputs.parameters.group_size}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-            when: "{{=sprig.regexMatch('nz-imagery|nz-elevation', workflow.parameters.target_bucket_name)}}"
-            depends: 'generate-path'
-
-          - name: copy-with-github
-            templateRef:
-              name: tpl-copy
-              template: main
-            arguments:
-              parameters:
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
-                - name: file
-                  value: '{{item}}'
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: aws_role_config_path
-                  value: 's3://linz-bucket-config/config-write.open-data-registry.json'
-            depends: 'create-manifest-github'
-            withParam: '{{tasks.create-manifest-github.outputs.parameters.files}}'
-
           - name: push-to-github
             templateRef:
               name: tpl-push-to-github
@@ -148,11 +103,15 @@ spec:
             arguments:
               parameters:
                 - name: source
-                  value: '{{inputs.parameters.source}}'
+                  value: '{{=sprig.trim(inputs.parameters.source)}}'
                 - name: target
                   value: '{{tasks.generate-path.outputs.parameters.target}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
                 - name: repository
                   value: "{{=sprig.trimPrefix('nz-', workflow.parameters.target_bucket_name)}}"
-            depends: 'copy-with-github'
+                - name: ticket
+                  value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+                - name: copy_option
+                  value: '{{workflow.parameters.copy_option}}'
+            depends: 'generate-path'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -78,9 +78,6 @@ spec:
         parameters:
           - name: source
           - name: target_bucket_name
-          - name: include
-          - name: group
-          - name: group_size
       dag:
         tasks:
           - name: generate-path
@@ -103,7 +100,7 @@ spec:
             arguments:
               parameters:
                 - name: source
-                  value: '{{=sprig.trim(inputs.parameters.source)}}'
+                  value: '{{inputs.parameters.source}}'
                 - name: target
                   value: '{{tasks.generate-path.outputs.parameters.target}}'
                 - name: version_argo_tasks

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -58,10 +58,10 @@ spec:
       - name: source
         value: 's3://linz-imagery-staging/test/sample/'
       - name: target_bucket_name
-        value: 'nz-imagery'
+        value: ''
         enum:
-          - 'nz-imagery'
           - 'nz-elevation'
+          - 'nz-imagery'
       - name: copy_option
         value: '--no-clobber'
         enum:

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -76,8 +76,10 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: copy_option
           - name: source
           - name: target_bucket_name
+          - name: ticket
       dag:
         tasks:
           - name: generate-path
@@ -106,9 +108,9 @@ spec:
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
                 - name: repository
-                  value: "{{=sprig.trimPrefix('nz-', workflow.parameters.target_bucket_name)}}"
+                  value: "{{=sprig.trimPrefix('nz-', inputs.parameters.target_bucket_name)}}"
                 - name: ticket
-                  value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+                  value: '{{=sprig.trim(inputs.parameters.ticket)}}'
                 - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
+                  value: '{{inputs.parameters.copy_option}}'
             depends: 'generate-path'


### PR DESCRIPTION
#### Motivation

Provide more info for imagery and elevation PR reviews and copy the item TIFFs and STAC files only after the PR is approved and merged.

#### Modification

The ticket and copy-option need to be part of the Pull Request.
The `create-manifest` and `copy` tasks are removed from the `publish-odr` workflowtemplate.
The `publish-to-github` workflowtemplate is updated for the new fields in Argo Tasks that are to be passed through to the Pull Request.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
