### PR TITLE
fix: input parameters for consistency in copy create-manifest step

### DIFF
--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -88,6 +88,7 @@ spec:
       inputs:
         parameters:
           - name: source
+          - name: target
           - name: include
           - name: exclude
           - name: group
@@ -103,7 +104,7 @@ spec:
                 - name: source
                   value: '{{inputs.parameters.source}}'
                 - name: target
-                  value: '{{workflow.parameters.target}}'
+                  value: '{{inputs.parameters.target}}'
                 - name: include
                   value: '{{inputs.parameters.include}}'
                 - name: exclude


### PR DESCRIPTION
#### Motivation

Make the `create-manifest` step have consistent inputs.

#### Modification

Add `target` as an input to `create-manifest` in the same way as `source`.

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A already correct
- [ ] Issue linked in Title N/A
