### PR TITLE
fix: coredns readiness changed from health to ready check

### DIFF
--- a/infra/charts/kube-system.coredns.ts
+++ b/infra/charts/kube-system.coredns.ts
@@ -44,6 +44,7 @@ cluster.local:53 {
         fallthrough in-addr.arpa ip6.arpa
     }
     prometheus :9153
+    ready :8181
     forward . /etc/resolv.conf
     cache 30
     loop
@@ -59,6 +60,7 @@ cluster.local:53 {
       rcode NOERROR
     }
     prometheus :9153
+    ready :8181
     forward . /etc/resolv.conf
     cache 30
     loop


### PR DESCRIPTION
#### Motivation

AWS changed the way to check the readiness of CoreDNS. See https://aws.amazon.com/blogs/containers/recent-changes-to-the-coredns-add-on/ and https://github.com/aws/containers-roadmap/issues/941

#### Modification

Add the ready plugin in the corefile config.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
