### PR TITLE
fix: use WATCH_CONFIGMAPS workaround TDE-1015

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -129,6 +129,7 @@ export class ArgoWorkflows extends Chart {
           nodeSelector: { ...DefaultNodeSelector },
           workflowNamespaces: ['argo'],
           extraArgs: [],
+          // FIXME: workaround for https://github.com/argoproj/argo-workflows/issues/11657
           extraEnv: [{ name: 'WATCH_CONFIGMAPS', value: 'false' }],
           persistence,
           replicas: 2,

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -43,14 +43,14 @@ export interface ArgoWorkflowsProps {
  *
  * (Do not mix up with Argo Workflows application version)
  */
-const chartVersion = '0.34.0';
+const chartVersion = '0.41.0';
 
 /**
  * This is the version of Argo Workflows for the `chartVersion` we're using
  * https://github.com/argoproj/argo-helm/blob/2730dc24c7ad69b98d3206705a5ebf5cb34dd96b/charts/argo-workflows/Chart.yaml#L2
  *
  */
-const appVersion = 'v3.4.11';
+const appVersion = 'v3.5.5';
 
 export class ArgoWorkflows extends Chart {
   constructor(scope: Construct, id: string, props: ArgoWorkflowsProps & ChartProps) {
@@ -129,6 +129,7 @@ export class ArgoWorkflows extends Chart {
           nodeSelector: { ...DefaultNodeSelector },
           workflowNamespaces: ['argo'],
           extraArgs: [],
+          extraEnv: [{ name: 'WATCH_CONFIGMAPS', value: 'false' }],
           persistence,
           replicas: 2,
           workflowDefaults: {


### PR DESCRIPTION
#### Motivation

In order to reduce the Argo controller logs due to [this issue](https://github.com/argoproj/argo-workflows/issues/11657), we can use [this workaround](https://github.com/argoproj/argo-workflows/pull/12622) for now.

#### Modification

Using `WATCH_CONFIGMAPS=false` workaround implies upgrading Argo Workflows:
- upgrade Argo Workflows to `3.5.5`
- set `WATCH_CONFIGMAPS` to Argo Controller environment variable to `false`

Non regression tested on a NonProd cluster.

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
