### PR TITLE
feat: force fqdn dns request for cloudwatch resolution by fluentbit TDE-1093

### DIFF
--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -74,6 +74,8 @@ HC_Period 5
         cloudWatchLogs: {
           enabled: true,
           region: 'ap-southeast-2',
+          /** Specify Cloudwatch endpoint to add a trailing `.` to force FQDN DNS request */
+          endpoint: 'logs.ap-southeast-2.amazonaws.com.',
           autoCreateGroup: true,
           logRetentionDays: 30,
           logGroupName: `/aws/eks/${props.clusterName}/logs`,


### PR DESCRIPTION
#### Motivation

Inside kubernetes, DNS resolution uses ndots: 5 this means any dns requests that has less than 5 dots will go through all the search domains before looking up the actual domain. AWS Cloudwatch `logs.ap-southeast-2.amazonaws.com` has 3 dots.

#### Modification

Hardcode the Cloudwatch endpoint  to `logs.ap-southeast-2.amazonaws.com.` so DNS requests to Cloudwatch force the DNS lookup to be fully qualified.
This has been tested on a non prod cluster and we've seen a reduction of the DNS queries to the `coredns`

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
