### PR TITLE
feat: default retryStrategy TDE-1112

### DIFF
--- a/docs/retry.md
+++ b/docs/retry.md
@@ -1,0 +1,29 @@
+# Default retryStrategy
+
+The default [`retryStrategy`](https://argo-workflows.readthedocs.io/en/stable/fields/#retrystrategy) is defined at the `workflowDefaults` level in the [Argo Workflow chart configuration](https://github.com/linz/topo-workflows/blob/master/infra/charts/argo.workflows.ts). This will be apply to every step/tasks by default.
+
+## Overriding
+
+To override the default `retryStrategy`, it can be done at the workflow or template level by defining a specific `retryStrategy`.
+
+## Avoiding retry
+
+For example, to avoid the default `retryStrategy` and make sure the task does not retry:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: my-wf-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        expression: 'false'
+      container:
+        image: python:alpine3.6
+        command: ['python']
+        source: |
+          # Do something that fails ...
+```

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -147,6 +147,8 @@ export class ArgoWorkflows extends Chart {
                 },
               ],
               parallelism: 3,
+              // FIXME: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
+              retryStrategy: { limit: 2, affinity: { nodeAntiAffinity: {} } },
             },
           },
         },

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -14,8 +14,6 @@ spec:
   entrypoint: main
   templates:
     - name: main
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: file

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -13,8 +13,6 @@ spec:
   entrypoint: main
   templates:
     - name: main
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: source

--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -30,8 +30,6 @@ spec:
                 - name: location
                   value: '{{workflow.parameters.location}}'
     - name: create-config
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: location

--- a/workflows/basemaps/create-overview-all.yaml
+++ b/workflows/basemaps/create-overview-all.yaml
@@ -51,8 +51,6 @@ spec:
               path: '/tmp/imagery.json'
 
     - name: create-overview
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: source

--- a/workflows/basemaps/create-overview.yaml
+++ b/workflows/basemaps/create-overview.yaml
@@ -35,8 +35,6 @@ spec:
                 - name: output
                   value: '{{workflow.parameters.output}}'
     - name: create-overview
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: source

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -239,8 +239,6 @@ spec:
 
     # Generate a tile covering for input imagery
     - name: create-covering
-      retryStrategy:
-        limit: '2'
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       inputs:
@@ -284,8 +282,6 @@ spec:
 
     # Actually create COGs using gdal_translate on a large spot instances
     - name: create-cog
-      retryStrategy:
-        limit: '2'
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       inputs:
@@ -312,8 +308,6 @@ spec:
 
     # Create a basemaps configuration file to view the imagery
     - name: create-config
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: path
@@ -340,8 +334,6 @@ spec:
 
     # create additional overviews for any COGs found in the path
     - name: create-overview
-      retryStrategy:
-        limit: '2'
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       inputs:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -441,8 +441,6 @@ spec:
               path: '/tmp/collection-id'
 
     - name: standardise-validate
-      retryStrategy:
-        limit: '2'
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       inputs:
@@ -489,8 +487,6 @@ spec:
           - '{{=sprig.trim(workflow.parameters.gsd)}}'
 
     - name: create-collection
-      retryStrategy:
-        limit: '2'
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       inputs:
@@ -582,8 +578,6 @@ spec:
               path: '/tmp/key'
 
     - name: create-overview
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: location
@@ -608,8 +602,6 @@ spec:
           ]
 
     - name: create-config
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: location

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -68,8 +68,6 @@ spec:
             valueFrom:
               path: /tmp/file_list.json
     - name: stac-validate-collections
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: file

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -80,8 +80,6 @@ spec:
             valueFrom:
               path: /tmp/file_list.json
     - name: flatten-copy
-      retryStrategy:
-        limit: '2'
       inputs:
         parameters:
           - name: file

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -75,8 +75,6 @@ spec:
             path: /tmp/file_list.json
 
     - name: thumbnails
-      retryStrategy:
-        limit: '2'
       nodeSelector:
         karpenter.sh/capacity-type: 'spot'
       inputs:


### PR DESCRIPTION
#### Motivation

We want every task within our workflows to retry (twice) automatically and on a different node/host (network issues) when they fail.

#### Modification

Configure the `retryStrategy` at the `workflowDefaults` level.
Notes: 

- the `nodeAntiAffinity` to prioritize retrying on a different node/host is not working due to an issue in the Argo Workflows system. A [PR is opened](https://github.com/argoproj/argo-workflows/pull/12701) in the Argo repo
- this change will make every task retrying on failure. Some of our tasks (for example, `stac-validate`, `tileindex-validate`) are expected to fail if the system invalidate something. They will still retry twice in that case. This would be handle in a separate PR.

#### Checklist

- [ ] Tests updated NA
- [x] Docs updated 
- [x] Issue linked in Title
