### PR TITLE
refactor: store default region in const

### DIFF
--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -1,6 +1,6 @@
 import { App } from 'aws-cdk-lib';
 
-import { ClusterName } from './constants.js';
+import { ClusterName, DefaultRegion } from './constants.js';
 import { tryGetContextArns } from './eks/arn.js';
 import { LinzEksCluster } from './eks/cluster.js';
 import { fetchSsmParameters } from './util/ssm.js';
@@ -22,7 +22,7 @@ async function main(): Promise<void> {
   }
 
   new LinzEksCluster(app, ClusterName, {
-    env: { region: 'ap-southeast-2', account: accountId },
+    env: { region: DefaultRegion, account: accountId },
     maintainerRoleArns,
     slackChannelConfigurationName: slackSsmConfig.slackChannelConfigurationName,
     slackWorkspaceId: slackSsmConfig.slackWorkspaceId,

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -2,7 +2,7 @@ import { Chart, ChartProps, Duration, Helm } from 'cdk8s';
 import { Secret } from 'cdk8s-plus-27';
 import { Construct } from 'constructs';
 
-import { ArgoDbName, ArgoDbUser } from '../constants.js';
+import { ArgoDbName, ArgoDbUser, DefaultRegion } from '../constants.js';
 import { applyDefaultLabels } from '../util/labels.js';
 
 export interface ArgoWorkflowsProps {
@@ -65,7 +65,7 @@ export class ArgoWorkflows extends Chart {
         bucket: props.tempBucketName,
         keyFormat:
           '{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}-{{workflow.name}}/{{pod.name}}',
-        region: 'ap-southeast-2',
+        region: DefaultRegion,
         endpoint: 's3.amazonaws.com',
         useSDKCreds: true,
         insecure: false,

--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -1,6 +1,7 @@
 import { Chart, ChartProps, Helm } from 'cdk8s';
 import { Construct } from 'constructs';
 
+import { DefaultRegion } from '../constants.js';
 import { applyDefaultLabels } from '../util/labels.js';
 
 /**
@@ -73,9 +74,9 @@ HC_Period 5
         serviceAccount: { name: props.saName, create: false },
         cloudWatchLogs: {
           enabled: true,
-          region: 'ap-southeast-2',
+          region: DefaultRegion,
           /** Specify Cloudwatch endpoint to add a trailing `.` to force FQDN DNS request */
-          endpoint: 'logs.ap-southeast-2.amazonaws.com.',
+          endpoint: `logs.${DefaultRegion}.amazonaws.com.`,
           autoCreateGroup: true,
           logRetentionDays: 30,
           logGroupName: `/aws/eks/${props.clusterName}/logs`,

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,15 +1,17 @@
-/* Cluster name */
+/** Cluster name */
 export const ClusterName = 'Workflows';
-/* LINZ conventional name for Argo Workflows artifact bucket */
+/** LINZ conventional name for Argo Workflows artifact bucket */
 export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
-/* Argo Database Instance name */
+/** Argo Database Instance name */
 export const ArgoDbInstanceName = 'ArgoDb';
-/* Argo Database name */
+/** Argo Database name */
 export const ArgoDbName = 'argo';
-/* Argo Database user */
+/** Argo Database user */
 export const ArgoDbUser = 'argo_user';
+/** AWS default region for our stack */
+export const DefaultRegion = 'ap-southeast-2';
 
-/* CloudFormation Output to access from CDK8s */
+/** CloudFormation Output to access from CDK8s */
 export const CfnOutputKeys = {
   ClusterEndpoint: 'ClusterEndpoint',
 


### PR DESCRIPTION
#### Motivation

It is easier to maintain the region of our AWS stack if we have to modify it in a single place.

#### Modification

Store the region in a constant.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated N/A
- [x] Docs updated
- [ ] Issue linked in Title N/A
