### PR TITLE
feat(basemaps): Cron workflow for update nz roads addressing vector layer. BM-977

### DIFF
--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -14,7 +14,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: Version of the Argo Tasks CLI docker container to use
-        value: 'v2'
+        value: 'v3'
       
       - name: version_basemaps_etl
         description: Version of the Basemaps ETL eks container to use

--- a/workflows/cron/cron-vector-etl-roads-addressing.yaml
+++ b/workflows/cron/cron-vector-etl-roads-addressing.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4.13/api/jsonschema/schema.json
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: cron-vector-etl-roads-addressing
+  namespace: argo
+  labels:
+    linz.govt.nz/category: basemaps
+    linz.govt.nz/data-type: vector
+spec:
+  schedule: '0 06 * * 3' # 6 AM every Wednesday
+  timezone: 'NZ'
+  startingDeadlineSeconds: 3600 # Allow 1 hour delay if the workflow-controller clashes during the starting time.
+  concurrencyPolicy: 'Allow'
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  suspend: false
+  workflowSpec:
+    workflowTemplateRef:
+      name: basemaps-vector-etl
+    arguments:
+      parameters:
+        - filename:
+          value: '53382-nz-roads-addressing'
+        - name: 'retry'
+          value: '2'


### PR DESCRIPTION
#### Motivation

Another cron etl workflow for update the [53382-nz-roads-addressing](https://data.linz.govt.nz/layer/53382-nz-roads-addressing/) data.

#### Modification

- Add new cron workflow running 6am Wednesday for update nz road addressing vector data.
- Upgrade the argo task to v3 to support individual vector tileset in create-pr.

#### Checklist

- [ ] Tests updated - no tests
- [ ] Docs updated - no doc
- [x] Issue linked in Title
