### PR TITLE
feat: change default value for exclude argument

### DIFF
--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -22,7 +22,7 @@ spec:
       - name: include
         value: ''
       - name: exclude
-        value: 'nz-satellite'
+        value: 'new-zealand'
   templateDefaults:
     container:
       imagePullPolicy: Always


### PR DESCRIPTION
The national 10m satellite imagery mosaic has had a name change since the source imagery was published to the ODR.
Previously it was named `nz_satellite_2021-2022_10m_RGB` in the basemaps aerial config
It is now named `new-zealand_2022-2023_10m`. This new name structure will continue going forward.
