### PR TITLE
fix: rename node-cache to node-local-dns

### DIFF
--- a/infra/charts/kube-system.node.local.dns.ts
+++ b/infra/charts/kube-system.node.local.dns.ts
@@ -72,7 +72,7 @@ export class NodeLocalDns extends Chart {
       podMetadata: {},
       containers: [
         {
-          name: 'node-cache',
+          name: 'node-local-dns',
           securityContext: {
             ensureNonRoot: false,
             allowPrivilegeEscalation: true,


### PR DESCRIPTION
#### Motivation

Our analytics use the container name for DNS query logs, `node-cache` is not easily mappable to `node-local-dns`

#### Modification

Switches the container name of node-local-dns to "node-local-dns" 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
