### PR TITLE
fix: argo controller disabling watch configmap wrong env var name TDE-1016

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -130,7 +130,7 @@ export class ArgoWorkflows extends Chart {
           workflowNamespaces: ['argo'],
           extraArgs: [],
           // FIXME: workaround for https://github.com/argoproj/argo-workflows/issues/11657
-          extraEnv: [{ name: 'WATCH_CONFIGMAPS', value: 'false' }],
+          extraEnv: [{ name: 'WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS', value: 'false' }],
           persistence,
           replicas: 2,
           workflowDefaults: {


### PR DESCRIPTION
#### Motivation

https://github.com/linz/topo-workflows/pull/498 has been using the wrong environment variable name to disable watching configmaps, so the issue is not fixed.

#### Modification

Use the correct [environment variable name](https://argo-workflows.readthedocs.io/en/stable/environment-variables/)

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
