### PR TITLE
fix(cron): Add the missing parameter name for the cron workflow

### DIFF
--- a/workflows/cron/cron-vector-etl-roads-addressing.yaml
+++ b/workflows/cron/cron-vector-etl-roads-addressing.yaml
@@ -20,7 +20,7 @@ spec:
       name: basemaps-vector-etl
     arguments:
       parameters:
-        - filename:
+        - name: 'filename'
           value: '53382-nz-roads-addressing'
         - name: 'retry'
           value: '2'

--- a/workflows/cron/cron-vector-etl.yaml
+++ b/workflows/cron/cron-vector-etl.yaml
@@ -20,7 +20,7 @@ spec:
       name: basemaps-vector-etl
     arguments:
       parameters:
-        - filename:
+        - name: 'filename'
           value: 'topographic'
         - name: 'retry'
           value: '2'


### PR DESCRIPTION
#### Motivation

Parameter name is defined incorrectly in the cron workflow.

#### Modification

fix the name in two cron workflow

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - no test
- [ ] Docs updated - no doc
- [ ] Issue linked in Title - no ticket
