### PR TITLE
fix: workflow-controller is not picking up ConfigMap changes TDE-1016 TDE-1112

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,9 @@ jobs:
         if: steps.get-infra-changes.outputs.run_infra == 'true'
         run: |
           kubectl apply -f dist/
+          # FIXME since `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS=false` we need to restart argo-workflow-controller
+          # to make sure ConfigMap changes are taken into account
+          kubectl rollout restart deployment argo-workflows-workflow-controller -n argo
 
       - name: Install Argo
         run: |


### PR DESCRIPTION
#### Motivation

[This change](https://github.com/linz/topo-workflows/pull/520) introduced the fact that Argo Workflow Controller is not picking up changes in ConfigMap, [as specified for the added `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS` environment variable](https://argo-workflows.readthedocs.io/en/stable/environment-variables/#controller).
An initial test showed that the `semaphore` changes were picked up, but, unfortunately, no further test on the controller ConfigMap has been done.

#### Modification

The workaround is to restart the controller at each kubernetes config deployment to make sure changes are picked up. This does not cause downtime.

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
