### PR TITLE
feat: include ticket number in basemaps pull requests TDE-1146

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -372,10 +372,9 @@ spec:
                 name: github-linz-li-bot-pat
                 key: pat
         args:
-          [
-            'bmc',
-            'create-pr',
-            '--target={{inputs.parameters.target}}',
-            "--individual={{= workflow.parameters.create_pull_request == 'individual'? 'true' : 'false' }}",
-            '--category={{workflow.parameters.category}}',
-          ]
+          - 'bmc'
+          - 'create-pr'
+          - '--target={{inputs.parameters.target}}'
+          - '--ticket={{workflow.parameters.ticket}}'
+          - "--individual={{= workflow.parameters.create_pull_request == 'individual'? 'true' : 'false' }}"
+          - '--category={{workflow.parameters.category}}'


### PR DESCRIPTION
#### Motivation

It is helpful to have all pull requests linked to the ticket, since we now have the ticket number in the workflow we should pass it into anything interacting with github

#### Modification

Adds ticket number to basemaps `create-pr` action.

This pull request needs https://github.com/linz/argo-tasks/pull/962 to be merged first.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
