### PR TITLE
refactor: remove metadata.namespace from WorkflowTemplates and CronWorkflows TDE-1149

### DIFF
--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: basemaps-config-create
-  namespace: argo
   labels:
     linz.govt.nz/category: basemaps
 spec:

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: basemaps-imagery-import-cogify
-  namespace: argo
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: raster

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: basemaps-create-mapsheet-json
-  namespace: argo
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: raster

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: basemaps-vector-etl
-  namespace: argo
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: vector

--- a/workflows/cron/cron-vector-etl-roads-addressing.yaml
+++ b/workflows/cron/cron-vector-etl-roads-addressing.yaml
@@ -3,7 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: cron-vector-etl-roads-addressing
-  namespace: argo
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: vector

--- a/workflows/cron/cron-vector-etl.yaml
+++ b/workflows/cron/cron-vector-etl.yaml
@@ -3,7 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: cron-vector-etl-topographic
-  namespace: argo
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: vector

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: copy
-  namespace: argo
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: publish-odr
-  namespace: argo
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: imagery-standardising
-  namespace: argo
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster

--- a/workflows/stac/stac-validate.yaml
+++ b/workflows/stac/stac-validate.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: stac-validate
-  namespace: argo
   labels:
     linz.govt.nz/category: stac
 spec:

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: test-flatten
-  namespace: argo
   labels:
     linz.govt.nz/category: test
 spec:

--- a/workflows/test/generate-path.yaml
+++ b/workflows/test/generate-path.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: test-generate-target
-  namespace: argo
   labels:
     linz.govt.nz/category: test
 spec:

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: create-thumbnails
-  namespace: argo
   labels:
     linz.govt.nz/category: util
     linz.govt.nz/data-type: raster


### PR DESCRIPTION
#### Motivation

The `metadata.namespace` is overriden when the WorkflowTemplates and CronWorkflows are deployed (using `--namespace`).
Having this data is redundant but also create issue while linting locally (`argo lint --offline`) the WorkflowTemplates with `templateRefs` when namespaces do not match.

#### Modification

Remove the default namespace in `metadata.namespace` from all WorkflowTemplate and CronWorkflow files

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [x] Issue linked in Title
