### PR TITLE
fix: WorkflowTemplates linting fails TDE-1143 TDE-1149

### DIFF
--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -62,6 +62,7 @@ spec:
         enum:
           - 'nz-elevation'
           - 'nz-imagery'
+          - ''
       - name: copy_option
         value: '--no-clobber'
         enum:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -279,6 +279,7 @@ spec:
         enum:
           - 'nz-imagery'
           - 'nz-elevation'
+          - ''
       - name: copy_option
         value: '--no-clobber'
         enum:


### PR DESCRIPTION
#### Motivation

An enum default value should be one of the enum values. `argo lint` fails on this.

#### Modification

Add the default value in the enum values.

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [x] Issue linked in Title
