### PR TITLE
fix: enable Basemaps preview for Elevation data TDE-1151 BM-932

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -121,9 +121,9 @@ graph TD;
     get-location-->standardise-validate;
     tileindex-validate-->standardise-validate;
     standardise-validate-->create-collection;
-    standardise-validate-.->|compression != dem_lerc|create-overview;
+    standardise-validate-->create-overview;
     create-collection-->stac-validate-.->|publish_to_odr == true|publish-odr;
-    create-overview-.->create-config-.->|publish_to_odr == true|publish-odr;
+    create-overview-->create-config-.->|publish_to_odr == true|publish-odr;
 ```
 
 ### [collection-id-setup](./standardising.yaml)

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -123,7 +123,7 @@ graph TD;
     standardise-validate-->create-collection;
     standardise-validate-->create-overview;
     create-collection-->stac-validate-.->|publish_to_odr == true|publish-odr;
-    create-overview-->create-config-.->|publish_to_odr == true|publish-odr;
+    create-overview-.->|compression != dem_lerc|create-config-.->|publish_to_odr == true|publish-odr;
 ```
 
 ### [collection-id-setup](./standardising.yaml)

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -377,7 +377,7 @@ spec:
             template: get-location
 
           - name: create-overview
-            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857'"
+            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857' && '{{workflow.parameters.compression}}' != 'dem_lerc'"
             arguments:
               parameters:
                 - name: location

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -377,7 +377,7 @@ spec:
             template: get-location
 
           - name: create-overview
-            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857' && '{{workflow.parameters.compression}}' != 'dem_lerc'"
+            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857'"
             arguments:
               parameters:
                 - name: location
@@ -386,7 +386,7 @@ spec:
             depends: 'standardise-validate'
 
           - name: create-config
-            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857' && '{{workflow.parameters.compression}}' != 'dem_lerc'"
+            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857'"
             arguments:
               parameters:
                 - name: location


### PR DESCRIPTION
#### Motivation

Enable the Basemaps configuration for `dem_lerc`, as Basemaps now supports previewing Elevation data.

#### Modification

Remove exclusion for `dem_lerc` preset.

#### Checklist

- [ ] Tests updated N/A
- [x] Docs updated
- [x] Issue linked in Title
