### PR TITLE
fix: node nodeAntiAffinity seems to break karpenter TDE-1112 BM-1018

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -147,8 +147,10 @@ export class ArgoWorkflows extends Chart {
                 },
               ],
               parallelism: 3,
-              // FIXME: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
-              retryStrategy: { limit: 2, affinity: { nodeAntiAffinity: {} } },
+              /** TODO: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
+               * `affinity: { nodeAntiAffinity: {} }` seems to break `karpenter`, need more investigation
+               */
+              retryStrategy: { limit: 2 },
             },
           },
         },


### PR DESCRIPTION
#### Motivation

We've noticed that karpenter is erroring since https://github.com/linz/topo-workflows/pull/506. Errors makes us thinking that it could be related. Since the retry on a new node using `nodeAntiAffinity` [is not working](https://github.com/argoproj/argo-workflows/pull/12701), it's a good idea to remove it to see if it solved `karpenter` issues.

#### Modification

Remove the `affinity` in the `retryStrategy`.

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
