### PR TITLE
fix: pass compression as preset to tileindex-validate TDE-895 TDE-1151

### DIFF
--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -39,6 +39,10 @@ spec:
             description: Output tile configuration for retiling
             default: 'false'
 
+          - name: preset
+            description: Compression type of dataset e.g. webp, lzw, dem_lerc
+            default: 'webp'
+
           - name: version
             description: container version to use
             default: 'v3'
@@ -78,6 +82,7 @@ spec:
           - '--scale={{= inputs.parameters.scale }}'
           - '--validate={{= inputs.parameters.validate }}'
           - '--retile={{= inputs.parameters.retile }}'
+          - '--preset={{= inputs.parameters.compression }}'
           - "{{= sprig.empty(inputs.parameters.source_epsg) ? '' : '--source-epsg=' + inputs.parameters.source_epsg }}"
           - "{{= sprig.empty(inputs.parameters.include) ? '' : '--include=' + inputs.parameters.include }}"
           - '{{= sprig.trim(inputs.parameters.source) }}'

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -133,7 +133,7 @@ If no input collection ID is provided a ULID is generated and used as the collec
 
 ### [tileindex-validate](https://github.com/linz/argo-tasks/blob/master/src/commands/tileindex-validate/)
 
-Lists tiffs from source input, validates they match a LINZ Mapsheet tile index and asserts that there will be no duplicates.
+Lists tiffs from source input, validates they match a LINZ Mapsheet tile index and asserts that there will be no duplicates. Checks `webp` files are 8-bit.
 
 ### [standardise-validate](https://github.com/linz/topo-imagery/blob/master/scripts/standardise_validate.py)
 

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -318,6 +318,8 @@ spec:
                   value: '{{= workflow.parameters.validate}}'
                 - name: retile
                   value: '{{= workflow.parameters.retile}}'
+                - name: preset
+                  value: '{{= workflow.parameters.compression}}'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
 


### PR DESCRIPTION
#### Motivation

We only want to check `webp` datasets are 8-bit so Argo Tasks tileindex-validate needs to know the dataset type.

#### Modification

Pass the `compression` type of the dataset to Argo Tasks tileindex-validate as `preset` for validation

#### Checklist

- [ ] Tests updated N/A
- [x] Docs updated
- [x] Issue linked in Title
