### PR TITLE
fix: preset parameter name TDE-895 TDE-1151

### DIFF
--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -82,7 +82,7 @@ spec:
           - '--scale={{= inputs.parameters.scale }}'
           - '--validate={{= inputs.parameters.validate }}'
           - '--retile={{= inputs.parameters.retile }}'
-          - '--preset={{= inputs.parameters.compression }}'
+          - '--preset={{= inputs.parameters.preset }}'
           - "{{= sprig.empty(inputs.parameters.source_epsg) ? '' : '--source-epsg=' + inputs.parameters.source_epsg }}"
           - "{{= sprig.empty(inputs.parameters.include) ? '' : '--include=' + inputs.parameters.include }}"
           - '{{= sprig.trim(inputs.parameters.source) }}'


### PR DESCRIPTION
#### Motivation

Mistake in parameter name, renamed to `preset`
