### PR TITLE
build: upgrade basemaps cli to v7 for DEM support BM-932

### DIFF
--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -11,7 +11,7 @@ spec:
   arguments:
     parameters:
       - name: version_basemaps_cli
-        value: 'v6'
+        value: 'v7'
       - name: location
         value: 's3://bucket/path/to'
   templateDefaults:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -575,7 +575,8 @@ spec:
         parameters:
           - name: location
       container:
-        image: 'ghcr.io/linz/basemaps/cli:{{=sprig.trim(workflow.parameters.version_basemaps_cli)}}'
+        # Basemaps v7+ has removed overview creation
+        image: 'ghcr.io/linz/basemaps/cli:v6'
         resources:
           requests:
             cpu: 3000m

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -28,7 +28,7 @@ spec:
       - name: version_argo_tasks
         value: 'v3'
       - name: version_basemaps_cli
-        value: 'v6'
+        value: 'v7'
       - name: version_topo_imagery
         value: 'v4'
       - name: ticket


### PR DESCRIPTION
#### Motivation

Basemaps need to be on v7+ for DEM support

#### Modification

Upgrades basmeaps cli from v6 to v7
Locks create-overview to v6 until overview creation is redone in v7 BM-944

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
