### PR TITLE
feat: stac-validate workflows use specific checksum flags TDE-1134

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -211,8 +211,10 @@ See (https://github.com/linz/argo-tasks#stac-validate)
     parameters:
       - name: uri
         value: 's3://my-bucket/path/collection.json'
-      - name: checksum
-        value: '{{workflow.parameters.checksum}}'
+      - name: checksum_assets
+        value: '{{workflow.parameters.checksum_assets}}'
+      - name: checksum_links
+        value: '{{workflow.parameters.checksum_links}}'
       - name: recursive
         value: '{{workflow.parameters.recursive}}'
       - name: concurrency

--- a/templates/argo-tasks/stac-validate.yml
+++ b/templates/argo-tasks/stac-validate.yml
@@ -28,8 +28,12 @@ spec:
             description: Number of requests to run concurrently
             default: '50'
 
-          - name: checksum
-            description: Validate the file:checksum if it exists
+          - name: checksum_assets
+            description: Validate the file:checksum of each asset if it exists
+            default: 'false'
+
+          - name: checksum_links
+            description: Validate the file:checksum of each link if it exists
             default: 'false'
 
           - name: version
@@ -51,5 +55,6 @@ spec:
             - 'validate'
             - '--concurrency={{inputs.parameters.concurrency}}'
             - '--recursive={{inputs.parameters.recursive}}'
-            - '--checksum={{inputs.parameters.checksum}}'
+            - '--checksum-assets={{inputs.parameters.checksum_assets}}'
+            - '--checksum-links={{inputs.parameters.checksum_links}}'
             - '{{inputs.parameters.uri}}'

--- a/templates/argo-tasks/stac-validate.yml
+++ b/templates/argo-tasks/stac-validate.yml
@@ -38,7 +38,7 @@ spec:
 
           - name: version
             description: container version to use
-            default: 'v3'
+            default: 'v4'
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version)}}'

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -50,8 +50,10 @@ spec:
               parameters:
                 - name: uri
                   value: '{{item}}'
-                - name: checksum
-                  value: '{{workflow.parameters.checksum}}'
+                - name: checksum_assets
+                  value: '{{workflow.parameters.checksum_assets}}'
+                - name: checksum_links
+                  value: '{{workflow.parameters.checksum_links}}'
             depends: aws-list-collections
             withParam: '{{tasks.aws-list-collections.outputs.parameters.files}}'
     - name: aws-list-collections

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -20,9 +20,15 @@ spec:
         value: 's3://linz-imagery-staging/test/stac-validate/'
       - name: include
         value: 'collection.json$'
-      - name: checksum
-        description: 'Validate asset checksums.'
+      - name: checksum_assets
+        description: 'Validate the file:checksum of each asset if it exists'
         value: 'false'
+        enum:
+          - 'true'
+          - 'false'
+      - name: checksum_links
+        description: 'Validate the file:checksum of each link if it exists'
+        value: 'true'
         enum:
           - 'false'
           - 'true'

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -14,7 +14,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v3'
+        value: 'v4'
       - name: uri
         description: 'Path(s) to the STAC file(s).'
         value: 's3://linz-imagery-staging/test/stac-validate/'


### PR DESCRIPTION
#### Motivation

`stac-validate` has changed its flags for checksum validation in https://github.com/linz/argo-tasks/pull/982 & https://github.com/linz/argo-tasks/pull/972

#### Modification

Use the `--checksum-assets` and `--checksum-links` flags

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated NA
- [x] Docs updated
- [x] Issue linked in Title
