### PR TITLE
feat(basemaps): Support elevation config for the config import. BM-936

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -389,5 +389,5 @@ spec:
           - '--target={{inputs.parameters.target}}'
           - '--ticket={{workflow.parameters.ticket}}'
           - '--config-type={{workflow.parameters.config_type}}'
-          - "--individual={{= workflow.parameters.filename == 'individual'? 'true' : 'false' }}"
+          - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
           - '--category={{workflow.parameters.category}}'

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -70,11 +70,24 @@ spec:
 
       - name: create_pull_request
         description: 'Create pull request after importing imagery.'
-        value: 'aerial'
+        value: 'true'
         enum:
-          - 'aerial'
-          - 'individual'
-          - 'none'
+          - 'true'
+          - 'false'
+
+      - name: config_type
+        description: 'Type of Basemaps Config file to create in pull requests'
+        value: 'raster'
+        enum:
+          - 'raster'
+          - 'elevation'
+
+      - name: individual
+        description: 'Individual Config or Combined Config'
+        value: 'false'
+        enum:
+          - 'true'
+          - 'false'
 
       - name: category
         value: 'Rural Aerial Photos'
@@ -149,7 +162,7 @@ spec:
               parameters:
                 - name: target
                   value: '{{ tasks.cogify.outputs.parameters.target }}'
-            when: '{{workflow.parameters.create_pull_request}} != none'
+            when: '{{workflow.parameters.create_pull_request}} == true'
             depends: 'cogify'
 
     # Generate COGs for a specific tile matrix from a given collection of source imagery
@@ -375,5 +388,6 @@ spec:
           - 'create-pr'
           - '--target={{inputs.parameters.target}}'
           - '--ticket={{workflow.parameters.ticket}}'
-          - "--individual={{= workflow.parameters.create_pull_request == 'individual'? 'true' : 'false' }}"
+          - '--config-type={{workflow.parameters.config_type}}''
+          - '--individual={{workflow.parameters.individual}}''
           - '--category={{workflow.parameters.category}}'

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -84,10 +84,10 @@ spec:
 
       - name: individual
         description: 'Individual Config or Combined Config'
-        value: 'false'
+        value: 'combined'
         enum:
-          - 'true'
-          - 'false'
+          - 'individual'
+          - 'combined'
 
       - name: category
         value: 'Rural Aerial Photos'
@@ -389,5 +389,5 @@ spec:
           - '--target={{inputs.parameters.target}}'
           - '--ticket={{workflow.parameters.ticket}}'
           - '--config-type={{workflow.parameters.config_type}}'
-          - '--individual={{workflow.parameters.individual}}'
+          - "--individual={{= workflow.parameters.filename == 'individual'? 'true' : 'false' }}"
           - '--category={{workflow.parameters.category}}'

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -388,6 +388,6 @@ spec:
           - 'create-pr'
           - '--target={{inputs.parameters.target}}'
           - '--ticket={{workflow.parameters.ticket}}'
-          - '--config-type={{workflow.parameters.config_type}}''
-          - '--individual={{workflow.parameters.individual}}''
+          - '--config-type={{workflow.parameters.config_type}}'
+          - '--individual={{workflow.parameters.individual}}'
           - '--category={{workflow.parameters.category}}'

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -122,4 +122,4 @@ spec:
           - 'create-pr'
           - '--target={{ inputs.parameters.target }}'
           - '--config-type=vector'
-          - "--individual={{= workflow.parameters.filename == 'individual'? 'true' : 'false' }}"
+          - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -43,10 +43,10 @@ spec:
 
       - name: individual
         description: 'Individual Config or Combined Config'
-        value: 'false'
+        value: 'combined'
         enum:
-          - 'true'
-          - 'false'
+          - 'individual'
+          - 'combined'
 
       - name: retry
         description: Number of retry on failure vector-etl task
@@ -122,4 +122,4 @@ spec:
           - 'create-pr'
           - '--target={{ inputs.parameters.target }}'
           - '--config-type=vector'
-          - '--individual={{workflow.parameters.individual}}'
+          - "--individual={{= workflow.parameters.filename == 'individual'? 'true' : 'false' }}"

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -41,6 +41,13 @@ spec:
           - 'true'
           - 'false'
 
+      - name: individual
+        description: 'Individual Config or Combined Config'
+        value: 'false'
+        enum:
+          - 'true'
+          - 'false'
+
       - name: retry
         description: Number of retry on failure vector-etl task
         value: '1'
@@ -114,4 +121,5 @@ spec:
           - 'bmc'
           - 'create-pr'
           - '--target={{ inputs.parameters.target }}'
-          - '--vector'
+          - '--config-type=vector'
+          - '--individual={{workflow.parameters.individual}}'

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -14,7 +14,7 @@ spec:
       - name: version_argo_tasks
         description: Version of the Argo Tasks CLI docker container to use
         value: 'v4'
-      
+
       - name: version_basemaps_etl
         description: Version of the Basemaps ETL eks container to use
         value: 'v1'

--- a/workflows/cron/cron-vector-etl-roads-addressing.yaml
+++ b/workflows/cron/cron-vector-etl-roads-addressing.yaml
@@ -23,5 +23,7 @@ spec:
           value: '53382-nz-roads-addressing'
         - name: 'title'
           value: 'NZ Roads (Addressing)'  
+        - name: 'individual'
+          value: 'true'
         - name: 'retry'
           value: '2'

--- a/workflows/cron/cron-vector-etl-roads-addressing.yaml
+++ b/workflows/cron/cron-vector-etl-roads-addressing.yaml
@@ -22,7 +22,7 @@ spec:
         - name: 'filename'
           value: '53382-nz-roads-addressing'
         - name: 'title'
-          value: 'NZ Roads (Addressing)'  
+          value: 'NZ Roads (Addressing)'
         - name: 'individual'
           value: 'true'
         - name: 'retry'

--- a/workflows/cron/cron-vector-etl-roads-addressing.yaml
+++ b/workflows/cron/cron-vector-etl-roads-addressing.yaml
@@ -24,6 +24,6 @@ spec:
         - name: 'title'
           value: 'NZ Roads (Addressing)'
         - name: 'individual'
-          value: 'true'
+          value: 'individual'
         - name: 'retry'
           value: '2'


### PR DESCRIPTION
#### Motivation

We are adding new config type for elevation data which leads to three types of configs in Basemaps. So [pull request](https://github.com/linz/argo-tasks/pull/953) will need to select which config type that is needed for the imported imagery.

#### Modification

This is blocking by argo-tasks release. Not ready yet. Sorry to make this as non draft PR, accidentally pushed enter when editing.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
