### PR TITLE
feat: add RSHL as a licensor

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -212,6 +212,7 @@ spec:
             'Porirua City Council',
             'Queenstown-Lakes District Council',
             'Rangitīkei District Council',
+            'Regional Software Holdings Limited',
             'Rotorua District Council',
             'Ruapehu District Council',
             'Selwyn District Council',


### PR DESCRIPTION
#### Motivation

NIWE Lidar contracted by Regional Software Holdings Limited (RSHL)

#### Modification

Add RSHL as a licensor

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
