### PR TITLE
fix: stac-validate-collections retries should be managed by tpl-at-stac-validate only TDE-1178

### DIFF
--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -38,6 +38,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        limit: '0' # avoid retrying any of the following task as `tpl-at-stac-validate` already retries its own tasks.
       dag:
         tasks:
           - name: aws-list-collections
@@ -57,6 +59,8 @@ spec:
             depends: aws-list-collections
             withParam: '{{tasks.aws-list-collections.outputs.parameters.files}}'
     - name: aws-list-collections
+      retryStrategy:
+        limit: '2' # force retrying this specific task
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
         command: [node, /app/index.js]


### PR DESCRIPTION
#### Motivation
In the case of a task in `tpl-at-stac-validate` fails more than twice and the workflow came back failing, the entire `stac-validate-collections` is retried twice which cause to run the inner stac-validate workflow.

#### Modification

Avoid tasks in the `stac-validate-parallel` workflow to retry by default.
Force `aws-list-collections` to retry twice if it fails.
This is a work around as I could not find a way to specify the retryStrategy at a task level using a `templateRef`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
