### PR TITLE
feat: publish odr historic imagery workflow TDE-1184

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -283,7 +283,7 @@ See the [copy template](#copy) for more information.
 
 ## Workflow Description
 
-This is a copy of the publish-odr workflow with the addition of a `target` parameter. This workflow allows data managers to bypass the `generate-path` step as it has not yet been implemented for historic imagery.
+_publish-odr-historic-imagery_ is a copy of the publish-odr workflow with the addition of a `target` parameter. This workflow allows data managers to bypass the `generate-path` step as it has not yet been implemented for historic imagery.
 
 > [!IMPORTANT]
 > This workflow should only be used when the target path automation is not implemented, for all other instances use `publish-odr`.

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -288,11 +288,6 @@ This is a copy of the publish-odr workflow with the addition of a `target` param
 > [!IMPORTANT]
 > This workflow should only be used when the target path automation is not implemented, for all other instances use `publish-odr`.
 
-```mermaid
-graph TD;
-  push-to-github;
-```
-
 ## Workflow Input Parameters
 
 | Parameter          | Type | Default                                | Description                                                                                                                                                                                                                 |

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -3,7 +3,7 @@
 - [Standardising](#Standardising)
 - [copy](#copy)
 - [publish-odr](#Publish-odr)
-- [publish-odr-historic-imagery](#Publish-odr-historic-imagery)
+- [Publish ODR Historic Imagery](#Publish-odr-historic-imagery)
 - [tests](#Tests)
 
 # Standardising
@@ -279,7 +279,7 @@ graph TD;
 
 See the [copy template](#copy) for more information.
 
-# Publish-odr-historic-imagery
+# Publish ODR Historic Imagery
 
 ## Workflow Description
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -286,7 +286,7 @@ See the [copy template](#copy) for more information.
 This is a copy of the publish-odr workflow with the addition of a `target` parameter. This workflow allows data managers to bypass the `generate-path` step as it has not yet been implemented for historic imagery.
 
 > [!IMPORTANT]
-> This workflow should only be used when the target path automation is not implemented, for all other instances us `publish-odr`.
+> This workflow should only be used when the target path automation is not implemented, for all other instances use `publish-odr`.
 
 ```mermaid
 graph TD;

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -3,6 +3,7 @@
 - [Standardising](#Standardising)
 - [copy](#copy)
 - [publish-odr](#Publish-odr)
+- [publish-odr-historic-imagery](#Publish-odr-historic-imagery)
 - [tests](#Tests)
 
 # Standardising
@@ -278,6 +279,44 @@ graph TD;
 
 See the [copy template](#copy) for more information.
 
+# Publish-odr-historic-imagery
+
+## Workflow Description
+
+This is a copy of the publish-odr workflow with the addition of a `target` parameter. This workflow allows data managers to bypass the `generate-path` step as it has not yet been implemented for historic imagery.
+
+> [!IMPORTANT]
+> This workflow should only be used when the target path automation is not implemented, for all other instances us `publish-odr`.
+
+```mermaid
+graph TD;
+  push-to-github;
+```
+
+## Workflow Input Parameters
+
+| Parameter          | Type | Default                                | Description                                                                                                                                                                                                                 |
+| ------------------ | ---- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| ticket             | str  |                                        | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
+| region             | enum |                                        | Region of the dataset                                                                                                                                                                                                       |
+| source             | str  | s3://linz-imagery-staging/test/sample/ | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
+| target             | str  | s3://target/path/                      | the target path where the data will be stored in the ODR                                                                                                                                                                    |
+| target_bucket_name | enum |                                        | The bucket name of the target location                                                                                                                                                                                      |     |
+| copy_option        | enum | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
+
+## Examples
+
+### Publish:
+
+**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+
+**target:** `s3://nz-imagery/auckland/auckland_sn1100_1994-1995_0.5m/rgb/2193/`
+
+**target_bucket_name:** `nz-imagery`
+
+**copy_option:** `--no-clobber`
+
+See the [copy template](#copy) for more information.
 
 # Tests
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -290,14 +290,14 @@ This is a copy of the publish-odr workflow with the addition of a `target` param
 
 ## Workflow Input Parameters
 
-| Parameter          | Type | Default                                | Description                                                                                                                                                                                                                 |
-| ------------------ | ---- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| ticket             | str  |                                        | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
-| region             | enum |                                        | Region of the dataset                                                                                                                                                                                                       |
-| source             | str  | s3://linz-imagery-staging/test/sample/ | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
+| Parameter          | Type  | Default                                   | Description                                                                                                                                                      |
+| ------------------ | ----- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticket             | str   |                                           | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
+| region             | enum  |                                           | Region of the dataset                                                                                                                                            |
+| source             | str   | s3://linz-imagery-staging/test/sample/    | The URIs (paths) to the s3 source location                                                                                                                       |
+| target_bucket_name | enum   |                                           | The bucket name of the target location                                                                                                                  |                                                  |
+| copy_option        | enum  | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
 | target             | str  | s3://target/path/                      | the target path where the data will be stored in the ODR                                                                                                                                                                    |
-| target_bucket_name | enum |                                        | The bucket name of the target location                                                                                                                                                                                      |     |
-| copy_option        | enum | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
 
 ## Examples
 

--- a/workflows/raster/publish-odr-historic-imagery.yaml
+++ b/workflows/raster/publish-odr-historic-imagery.yaml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: publish-odr-historic-imagery
+  labels:
+    linz.govt.nz/category: raster
+    linz.govt.nz/data-type: raster
+spec:
+  parallelism: 50
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  synchronization:
+    semaphore:
+      configMapKeyRef:
+        name: semaphores
+        key: bulkcopy
+  workflowMetadata:
+    labelsFrom:
+      linz.govt.nz/ticket:
+        expression: workflow.parameters.ticket
+      linz.govt.nz/region:
+        expression: workflow.parameters.region
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        value: 'v4'
+      - name: ticket
+        description: Ticket ID e.g. 'AIP-55'
+        value: ''
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'antarctica'
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'global'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'pacific-islands'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
+      - name: source
+        value: 's3://linz-imagery-staging/test/sample/'
+      - name: target
+        value: 's3://target/path/'
+      - name: target_bucket_name
+        value: ''
+        enum:
+          - 'nz-elevation'
+          - 'nz-imagery'
+          - ''
+      - name: copy_option
+        value: '--no-clobber'
+        enum:
+          - '--no-clobber'
+          - '--force'
+          - '--force-no-clobber'
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: copy_option
+          - name: source
+          - name: target_bucket_name
+          - name: ticket
+          - name: target
+      dag:
+        tasks:
+          - name: push-to-github
+            templateRef:
+              name: tpl-push-to-github
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{inputs.parameters.source}}'
+                - name: target
+                  value: '{{inputs.parameters.target}}'
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+                - name: repository
+                  value: "{{=sprig.trimPrefix('nz-', inputs.parameters.target_bucket_name)}}"
+                - name: ticket
+                  value: '{{=sprig.trim(inputs.parameters.ticket)}}'
+                - name: copy_option
+                  value: '{{inputs.parameters.copy_option}}'


### PR DESCRIPTION
#### Motivation

the target path automation is not implemented for historic imagery as required information is missing from the stac metadata (survey number).

To continue to publish historic imagery this workflow has been created as a workaround allowing data managers to specify the target path and bypass the automation.

#### Modification

A second workflow has been created called `publish-odr-historic-imagery`, which is a copy of `publish-odr` with the following changes:
- Added `target` workflow parameter
- Removed the `generate-path` task and replaced it with the workflow parameter

This has been kept separate from the `publish-odr` workflow as this functionality should be reserved only for historic imagery cases. 

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated - successfully created https://github.com/linz/imagery/pull/416
- [x] Docs updated
- [x] Issue linked in Title
