### PR TITLE
fix: Don't override topo-imagery Docker entrypoint for Python TDE-1179

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -436,7 +436,7 @@ spec:
     - name: collection-id-setup
       script:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(workflow.parameters.version_topo_imagery)}}'
-        command: [python]
+        args: [python]
         source: |
           import ulid
           collection_id = "{{workflow.parameters.collection_id}}"
@@ -472,10 +472,9 @@ spec:
         volumeMounts:
           - name: ephemeral
             mountPath: '/tmp'
-        command:
+        args:
           - python
           - '/app/scripts/standardise_validate.py'
-        args:
           - '--from-file'
           - '/tmp/input/{{inputs.parameters.group_id}}.json'
           - '--target'
@@ -519,10 +518,9 @@ spec:
           requests:
             memory: 7.8Gi
             cpu: 15000m
-        command:
+        args:
           - python
           - '/app/scripts/collection_from_items.py'
-        args:
           - '--uri'
           - '{{inputs.parameters.location}}flat/'
           - '--collection-id'

--- a/workflows/raster/tests.yaml
+++ b/workflows/raster/tests.yaml
@@ -24,11 +24,6 @@ spec:
     - name: test-script
       script:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{workflow.parameters.version_topo_imagery}}
-        command: [python]
+        args: [python]
         source: |
-          import sys
-
-          # Because Argo Workflow executes the script under "/argo/staging/script"
-          sys.path.append("/app/scripts/")
-
           # Put your code below

--- a/workflows/test/env.yaml
+++ b/workflows/test/env.yaml
@@ -12,7 +12,6 @@ spec:
     - name: env
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:latest
-        # Leave `command` if you want to print the environment variables outside the virtualenv, or `args` if you want
+        # Use `command` if you want to print the environment variables outside the virtualenv, or `args` if you want
         # to print the variables inside the virtualenv.
         command: [env]
-        args: [env]

--- a/workflows/test/env.yaml
+++ b/workflows/test/env.yaml
@@ -12,4 +12,7 @@ spec:
     - name: env
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:latest
+        # Leave `command` if you want to print the environment variables outside the virtualenv, or `args` if you want
+        # to print the variables inside the virtualenv.
         command: [env]
+        args: [env]

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -92,10 +92,9 @@ spec:
         volumeMounts:
           - name: ephemeral
             mountPath: '/tmp'
-        command:
+        args:
           - python
           - '/app/scripts/thumbnails.py'
-        args:
           - '--from-file'
           - '/tmp/file_list.json'
           - '--target'


### PR DESCRIPTION
#### Motivation

We use the Docker `ENTRYPOINT` (Argo `command`) to activate the virtualenv before running Python. We've [verified that this change is backwards compatible by running it with topo-imagery v4.7.1](https://argo.linzaccess.com/workflows/argo/test-is-docker-args-w9p88?tab=workflow&nodeId=test-is-docker-args-w9p88-2719834120&nodePanelView=containers&uid=e8af157e-77c5-403c-bbaa-12525efdf7db).

#### Modification

Use `args` rather than `command` for specifying the interpreter and file to run.

#### Checklist

- [ ] Tests updated (N/A)
- [x] Docs updated
- [x] Issue linked in Title
