### PR TITLE
build: Bump Node.js to latest LTS, 20.13.1 TDE-1090

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,61 +1,52 @@
 on: [push]
-
 jobs:
   main:
     name: Build, Format and Test
     runs-on: ubuntu-latest
     steps:
       - uses: linz/action-typescript@9bf69b0f313b3525d3ba3116f26b1aff7eb7a6c0 # v3.1.0
-
+        with:
+          node-version: 20.x
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
-
       - name: Run actionlint to check workflow files
         run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color
-
       - name: Install Argo
         run: |
           curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.5.5/argo-linux-amd64.gz
           gunzip argo-linux-amd64.gz
           chmod +x argo-linux-amd64
           ./argo-linux-amd64 version
-
       - name: Lint workflows
         run: |
           ./argo-linux-amd64 lint --offline templates/ workflows/
-
   deploy-prod:
     runs-on: ubuntu-latest
     concurrency: deploy-prod-${{ github.ref }}
     needs: [main]
     if: ${{ github.ref == 'refs/heads/master' }}
-
     environment:
       name: prod
-
     permissions:
       id-token: write
       contents: read
-
     env:
       CLUSTER_NAME: Workflows
-
     steps:
       - uses: linz/action-typescript@9bf69b0f313b3525d3ba3116f26b1aff7eb7a6c0 # v3.1.0
-
+        with:
+          node-version: 20.x
       # Configure access to AWS / EKS
       - name: Setup kubectl
         uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
         with:
           version: 'latest'
-
       - name: AWS Configure
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
-
       - name: Find Changes in Infra
         id: get-infra-changes
         run: |
@@ -65,7 +56,6 @@ jobs:
           else
             echo "run_infra=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: (CDK) Deploy
         if: steps.get-infra-changes.outputs.run_infra == 'true'
         run: |
@@ -73,15 +63,12 @@ jobs:
             -c maintainer-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }} \
             -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }} \
             --require-approval never
-
       - name: Login to EKS
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ap-southeast-2
-
       - name: Check EKS connection
         run: |
           kubectl get nodes
-
       # Configure the Kubernetes cluster with CDK8s
       - name: (CDK8s) Synth
         if: steps.get-infra-changes.outputs.run_infra == 'true'
@@ -89,13 +76,11 @@ jobs:
           npx cdk8s synth
           # nb: kubectl diff - is somewhat dangerous as it dumps out secrets in plain text
           # so it should not be used in this pipeline
-
       # TODO use a --prune and --applyset to remove unused objects
       - name: (CDK8s) Deploy
         if: steps.get-infra-changes.outputs.run_infra == 'true'
         run: |
           kubectl apply -f dist/
-
       - name: Deploy workflows
         if: github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,9 +1,7 @@
 name: Pull Request lint
-
 on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -11,6 +9,5 @@ jobs:
       - uses: linz/action-pull-request-lint@290a98eb0ac22b16476c147ce402eff61171e042 # v1
         with:
           conventional: 'error' # require conventional pull request title (default: "error" options: "error", "warn", "off")
-
           jira: 'warn' # Require JIRA ticket references (default: "warn", options: "error", "warn", "off")
           jira-projects: 'BM,TDE' # optional list of jira projects

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "tsx": "^4.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^20.13.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^20.13.1"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
#### Motivation

Support current LTS release.

#### Modification

1. Update the engine:

   ```
   jq '.engines.node = "^20.13.1"' package.json | sponge package.json
   ```
2. Update the lock file:

   ```
   npm install
   ```
3. Update the uses of `linz/action-typescript`:

   ```
   for path in .github/workflows/*.y*ml; do
       yq --inplace '(.jobs.*.steps[] | select(.uses == "linz/action-typescript*").with.node-version) = "20.x"' "$path";
   done
   ```

#### Checklist

- [ ] Tests updated (N/A)
- [ ] Docs updated (N/A)
- [x] Issue linked in Title
