### PR TITLE
feat(basemaps): Add new target for the elevation imports. BM-1040

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -99,6 +99,7 @@ spec:
         value: 's3://linz-basemaps/'
         enum:
           - 's3://linz-basemaps/'
+          - 's3://linz-basemaps/elevation/'
           - 's3://linz-basemaps-staging/'
           - 's3://linz-workflowsnp-scratch/'
 


### PR DESCRIPTION
#### Motivation

All the elevation data should be imported into the new target path `s3://linz-basemaps/elevation/`.

#### Modification

Add new target option `s3://linz-basemaps/elevation/`

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
