### PR TITLE
build: update to Node.js 22 TDE-1193

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@9bf69b0f313b3525d3ba3116f26b1aff7eb7a6c0 # v3.1.0
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
       - name: Run actionlint to check workflow files
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@9bf69b0f313b3525d3ba3116f26b1aff7eb7a6c0 # v3.1.0
         with:
-          node-version: 20.x
+          node-version: 22.x
       # Configure access to AWS / EKS
       - name: Setup kubectl
         uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "tsx": "^4.6.2"
       },
       "engines": {
-        "node": "^20.13.1"
+        "node": "^22.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "private": true,
   "engines": {
-    "node": "^20.13.1"
+    "node": "^22.2.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
1. Update the engine:

   ```
   jq '.engines.node = "^22.2.0"' package.json | sponge package.json
   ```
2. Update the lock file:

   ```
   npm install
   ```
3. Update the uses of `linz/action-typescript`:

   ```
   for path in .github/workflows/*.y*ml; do
       yq --inplace '(.jobs.*.steps[] | select(.uses == "linz/action-typescript*").with.node-version) = "22.x"' "$path"
   done
   ```

Verified with `git grep --word-regexp -e 14 -e 16 -e 18 -e 20`.