### PR TITLE
fix: stac-validate cron job argument parameters TDE-1214

### DIFF
--- a/workflows/cron/cron-stac-validate-fast.yaml
+++ b/workflows/cron/cron-stac-validate-fast.yaml
@@ -37,7 +37,7 @@ spec:
                   - name: 'checksum_assets'
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
-                    value: '{{workflow.parameters.checksum_assets}}'
+                    value: '{{workflow.parameters.checksum_links}}'
             - name: stac-validate-elevation
               templateRef:
                 name: tpl-at-stac-validate
@@ -49,4 +49,4 @@ spec:
                   - name: 'checksum_assets'
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
-                    value: '{{workflow.parameters.checksum_assets}}'
+                    value: '{{workflow.parameters.checksum_links}}'

--- a/workflows/cron/cron-stac-validate-full.yaml
+++ b/workflows/cron/cron-stac-validate-full.yaml
@@ -45,7 +45,7 @@ spec:
                   - name: 'checksum_assets'
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
-                    value: '{{workflow.parameters.checksum_assets}}'
+                    value: '{{workflow.parameters.checksum_links}}'
             - name: stac-validate-elevation
               templateRef:
                 name: stac-validate-parallel
@@ -61,4 +61,4 @@ spec:
                   - name: 'checksum_assets'
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
-                    value: '{{workflow.parameters.checksum_assets}}'
+                    value: '{{workflow.parameters.checksum_links}}'


### PR DESCRIPTION
#### Motivation

The STAC validation cron job fast workflow was not checking link checksums due to a duplication of a workflow parameter template variable.

#### Modification

Correct copy and paste error in the STAC validation cron job workflows.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
