### PR TITLE
fix(basemaps): Using dist/index.cjs for cogify commands.

### DIFF
--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -35,7 +35,7 @@ spec:
             description: Location of the imagery to create config for
       container:
         image: ghcr.io/linz/basemaps/cli:{{=sprig.trim(workflow.parameters.version_basemaps_cli)}}
-        command: [node, /app/node_modules/.bin/cogify]
+        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -291,7 +291,7 @@ spec:
         resources:
           requests:
             memory: 2Gi
-        command: [node, /app/node_modules/.bin/cogify]
+        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json
@@ -336,7 +336,7 @@ spec:
             cpu: 15000m # AWS gives 2x cpu cores = memory for most instances
             ephemeral-storage: 98Gi # 2 pods per 200GB of storage
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, /app/node_modules/.bin/cogify]
+        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json
@@ -353,7 +353,7 @@ spec:
             description: Location of the imagery to create config for
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, /app/node_modules/.bin/cogify]
+        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -611,7 +611,7 @@ spec:
           - name: key
       container:
         image: 'ghcr.io/linz/basemaps/cli:{{=sprig.trim(workflow.parameters.version_basemaps_cli)}}'
-        command: [node, /app/node_modules/.bin/cogify]
+        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json


### PR DESCRIPTION
#### Motivation

Cogify commands was using the .bin/cogify which require dev dependencies to be installed as well. We can just use the index.cjs instead.

This will required https://github.com/linz/basemaps/commit/6610322a12b89c20060346b24763c62e0225e3bf to be released

#### Modification

Call cogify from `/app/node_modules/.bin/cogify` to `/app/node_modules/@basemaps/cogify/dist/index.cjs`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
