### PR TITLE
feat: require a stac collection.json when importing into basemaps BM-1047

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -161,6 +161,7 @@ spec:
           - name: cutline
           - name: cutline_blend
           - name: group_size
+          - name: require_stac_collection
       dag:
         tasks:
           # For each tile matrix specified run the "cogify" template

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -75,6 +75,13 @@ spec:
       - name: source
         description: Source imagery location "s3://linz-imagery"
         value: 's3://linz-imagery-staging/test/sample/'
+      
+      - name: require_stac_collection
+        description: Validate that a STAC collection.json exists with the source
+        value: 'true'
+        enum:
+          - 'true'
+          - 'false'
 
       - name: create_pull_request
         description: 'Create pull request after importing imagery.'
@@ -176,6 +183,8 @@ spec:
                   value: '{{ inputs.parameters.cutline_blend }}'
                 - name: group_size
                   value: '{{ inputs.parameters.group_size }}'
+                - name: require_stac_collection
+                  value: '{{ inputs.parameters.require_stac_collection }}'
           - name: create-pull-request
             template: create-pull-request
             arguments:
@@ -196,6 +205,7 @@ spec:
           - name: cutline_blend
           - name: group_size
           - name: preset
+          - name: require_stac_collection
       dag:
         tasks:
           # generate a tile covering from the source imagery
@@ -215,6 +225,8 @@ spec:
                   value: '{{ inputs.parameters.cutline }}'
                 - name: cutline_blend
                   value: '{{ inputs.parameters.cutline_blend }}'
+                - name: require_stac_collection
+                  value: '{{ inputs.parameters.require_stac_collection }}'
 
           # Group covering output into chunks to pass to create-cog
           - name: group
@@ -286,6 +298,7 @@ spec:
           - name: cutline
           - name: cutline_blend
           - name: preset
+          - name: require_stac_collection
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
         resources:
@@ -299,6 +312,7 @@ spec:
           - 'cover'
           - '--preset={{ inputs.parameters.preset }}'
           - '--tile-matrix={{ inputs.parameters.tile_matrix }}'
+          - '--require-stac-collection={{ inputs.parameters.require_stac_collection }}'
           - "{{= sprig.empty(inputs.parameters.cutline) ? '' : '--cutline=' + inputs.parameters.cutline }}"
           - '--cutline-blend={{ inputs.parameters.cutline_blend }}'
           - '--target={{= sprig.trim(inputs.parameters.target) }}'


### PR DESCRIPTION
#### Motivation

When importing imagery into basemaps sometimes URLs are misstyped and import the wrong colleciton of imagery, by requiring a collection.json to be present at the root of the imagery we can reducee the chance of incorrect imagery being imported.

#### Modification

_Why is this change being made? What implications or other considerations are there?_

Adds "--require-stac-collection" flag to the basemaps import process which is defaulted to true.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
