### PR TITLE
feat: log imagery-standardising workflow information onExit TDE-1230

### DIFF
--- a/templates/common/README.md
+++ b/templates/common/README.md
@@ -1,0 +1,91 @@
+# Common Templates
+
+## Exit Handler - `tpl-exit-handler`
+
+Template for handling a workflow `onExit`.
+See <https://argo-workflows.readthedocs.io/en/latest/walk-through/exit-handlers/>
+The script ran by this template is generating a log, including the status of the workflow and its parameters, with the following format:
+
+```json
+{
+  "time": 1722568553969,
+  "level": 20,
+  "pid": 1,
+  "msg": "Workflow:Succeeded",
+  "version_argo_tasks": "v4",
+  "version_basemaps_cli": "v7",
+  "version_topo_imagery": "v4",
+  "ticket": "",
+  "region": "new-zealand",
+  "source": "s3://linz-imagery-staging/test/sample/",
+  "include": ".tiff?$",
+  "scale": "500",
+  "validate": "false",
+  "retile": "false",
+  "source_epsg": "2193",
+  "target_epsg": "2193",
+  "group": "50",
+  "compression": "webp",
+  "create_capture_area": "false",
+  "cutline": "",
+  "collection_id": "",
+  "category": "urban-aerial-photos",
+  "gsd": "0.3m",
+  "producer": "Unknown",
+  "producer_list": "",
+  "licensor": "Unknown",
+  "licensor_list": "",
+  "start_datetime": "2024-08-02",
+  "end_datetime": "2024-08-02",
+  "geographic_description": "",
+  "lifecycle": "completed",
+  "event": "",
+  "historic_survey_number": "",
+  "publish_to_odr": "false",
+  "target_bucket_name": "",
+  "copy_option": "--no-clobber"
+}
+```
+
+### Template usage
+
+The information to pass to this `WorkflowTemplate` is the status and the parameters of the workflow (`workflow.status` & `workflow.parameters`).
+
+As the `onExit` event [does not handle a `templateRef`](https://github.com/argoproj/argo-workflows/issues/3188),
+an additional template called by the `onExit` event has to be added to the templates so it can finally call the `tpl-exit-handler` template.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: hello
+  onExit: exit-handler
+  arguments:
+    parameters:
+      - name: message
+        value: Hello world!
+  templates:
+    - name: hello
+      inputs:
+        parameters:
+          - name: message
+      container:
+        image: alpine:latest
+        command: [sh, -c]
+        args: ['echo {{inputs.parameters.message}}']
+
+    - name: exit-handler
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'
+```

--- a/templates/common/exit.handler.yaml
+++ b/templates/common/exit.handler.yaml
@@ -35,6 +35,6 @@ spec:
               level: 20,
               pid: 1,
               msg: 'Workflow:{{inputs.parameters.workflow_status}}',
-              ...parameters,
+              parameters: parameters,
             }),
           );

--- a/templates/common/exit.handler.yaml
+++ b/templates/common/exit.handler.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template to log the workflow status and its parameters.
+  name: tpl-exit-handler
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: workflow_status
+            description: Status of the workflow
+          - name: workflow_parameters
+            description: Parameters of the workflow
+          - name: version_argo_tasks
+            description: Version of argo-tasks to use
+            default: 'v4'
+      script:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
+        command: [node]
+        source: |
+          let parameters = {};
+          {{= inputs.parameters.workflow_parameters }}.forEach((pair) => (parameters[pair.name] = pair.value));
+
+          console.log(
+            JSON.stringify({
+              time: Date.now(),
+              level: 20,
+              pid: 1,
+              msg: 'Workflow:{{inputs.parameters.workflow_status}}',
+              ...parameters,
+            }),
+          );

--- a/templates/common/exit.handler.yaml
+++ b/templates/common/exit.handler.yaml
@@ -35,6 +35,6 @@ spec:
               level: 20,
               pid: 1,
               msg: 'Workflow:{{inputs.parameters.workflow_status}}',
-              parameters: parameters,
+              parameters,
             }),
           );

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -12,6 +12,7 @@ spec:
   nodeSelector:
     karpenter.sh/capacity-type: 'spot'
   entrypoint: main
+  onExit: exit-handler
   synchronization:
     semaphore:
       configMapKeyRef:
@@ -660,6 +661,19 @@ spec:
               key: '{{inputs.parameters.key}}flat/config-url'
             archive:
               none: {}
+
+    - name: exit-handler
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'
 
   volumes:
     - name: ephemeral


### PR DESCRIPTION
#### Motivation

The Argo Workflows workflows parameters are not logged in our log discovery system. The workflows status is handled by Kubernetes Event Exporter.
Having a log that record the workflow status and its parameter on the `onExit` event is helpful to implement more specific alerting.

#### Modification

- Add a `tpl-exit-handler` workflowTemplate that create a log containing the workflow status and parameters. For example:
   ``` json
   {"time":1722568553969,"level":20,"pid":1,"msg":"Workflow:Succeeded","version_argo_tasks":"v4","version_basemaps_cli":"v7","version_topo_imagery":"v4","ticket":"","region":"new-zealand","source":"s3://linz-imagery-staging/test/sample/","include":".tiff?$","scale":"500","validate":"false","retile":"false","source_epsg":"2193","target_epsg":"2193","group":"50","compression":"webp","create_capture_area":"false","cutline":"","collection_id":"","category":"urban-aerial-photos","gsd":"0.3m","producer":"Unknown","producer_list":"","licensor":"Unknown","licensor_list":"","start_datetime":"2024-08-02","end_datetime":"2024-08-02","geographic_description":"","lifecycle":"completed","event":"","historic_survey_number":"","publish_to_odr":"false","target_bucket_name":"","copy_option":"--no-clobber"}
   ```
- Call `tpl-exit-handler` on the `imagery-standardising` workflow `onExit` event.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - tested in Argo
- [X] Docs updated
- [X] Issue linked in Title
