### PR TITLE
fix: increase Fluent Bit Kubernetes Filter Buffer_Size to 128k TDE-1232

### DIFF
--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -93,6 +93,14 @@ HC_Period 5
         kinesis: { enabled: false },
         elasticsearch: { enabled: false },
         service: { extraParsers, extraService },
+        filter: {
+          /**
+           * Increase the Buffer_Size (default "32k")
+           * as we experienced logs not coming through
+           * See: https://github.com/argoproj/argo-workflows/issues/13314
+           */
+          bufferSize: '128k',
+        },
         // FIXME: `livenessProbe` and `readinessProbe` deactivated https://github.com/aws/eks-charts/issues/995
         livenessProbe: false,
         readinessProbe: false,


### PR DESCRIPTION
#### Motivation

We're not seeing some logs propagated from Argo Workflows workflow pods to Elasticsearch.
This issue and a solution can be found here: https://github.com/argoproj/argo-workflows/issues/13314. 

#### Modification

Increase the [Fluent Bit Kubernetes Filter `Buffer_Size`](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#configuration-parameters) from its default `32k` to `128k` as it seems to solve our problem.
If we experience this issue again, it could not be enough and we'll proceed to another increase in time.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
