### PR TITLE
fix: exit-handler template already retries TDE-1230

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -663,6 +663,8 @@ spec:
               none: {}
 
     - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
       steps:
         - - name: exit
             templateRef:


### PR DESCRIPTION
#### Motivation

As `tpl-exit-handler` template already retries its own task, we don't need the caller template to retry it if there is a failure.

#### Modification

- limit the retry of the entire `tpl-exit-handler` template to 0 when called from `standardising` workflow

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
