### PR TITLE
fix: entire workflow should not retry TDE-1236

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -147,10 +147,12 @@ export class ArgoWorkflows extends Chart {
                 },
               ],
               parallelism: 3,
-              /** TODO: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
-               * `affinity: { nodeAntiAffinity: {} }` seems to break `karpenter`, need more investigation
-               */
-              retryStrategy: { limit: 2 },
+              templateDefaults: {
+                /** TODO: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
+                 * `affinity: { nodeAntiAffinity: {} }` seems to break `karpenter`, need more investigation
+                 */
+                retryStrategy: { limit: 2 },
+              },
             },
           },
         },

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,6 +1,12 @@
-## Workflow creation
+# Workflow creation
 
-### Using `sprig` functions
+## `retryStrategy` on entrypoint template
+
+A default `retryStrategy` is set as a default template value in the [`argo.workflows.ts`](https://github.com/linz/topo-workflows/blob/master/infra/charts/argo.workflows.ts) chart. That means every template will be retried when a failure happens on a pod using them.
+
+To avoid the entire workflow retrying if a pod did reach the retry limit without any success, the entrypoint template (or `main` by convention) should override this `retryStrategy` to disable the retry, using [`expression: 'false'`](https://argo-workflows.readthedocs.io/en/latest/retries/#conditional-retries). This apply to the workflows in `workflows/`, but should not apply to the `workflowTemplate` located in `template/` as they have only one template which is their entrypoint and will be called from a workflow so we want them to retry.
+
+## Using `sprig` functions
 
 While using [sprig functions](http://masterminds.github.io/sprig/) a task or workflow parameter should not contain `-`, all spaces should be subsituted with `_` to be correctly parsed:
 `workflow.parameters.my-param` -> `workflow.parameters.my_param`

--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -20,6 +20,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       dag:
         tasks:
           - name: create-config

--- a/workflows/basemaps/create-overview-all.yaml
+++ b/workflows/basemaps/create-overview-all.yaml
@@ -23,6 +23,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       dag:
         tasks:
           - name: list-imagery

--- a/workflows/basemaps/create-overview.yaml
+++ b/workflows/basemaps/create-overview.yaml
@@ -24,6 +24,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       dag:
         tasks:
           - name: create-overview

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -152,6 +152,8 @@ spec:
   templates:
     # Main entrypoint into the workflow
     - name: main
+      retryStrategy:
+        expression: 'false'
       inputs:
         parameters:
           - name: source

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -28,6 +28,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       dag:
         tasks:
           - name: fetch-layer

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -59,6 +59,8 @@ spec:
 
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       dag:
         tasks:
           - name: vector-etl

--- a/workflows/cron/cron-stac-validate-fast.yaml
+++ b/workflows/cron/cron-stac-validate-fast.yaml
@@ -24,7 +24,7 @@ spec:
     templates:
       - name: main
         retryStrategy:
-          limit: '0'
+          expression: 'false'
         steps:
           - - name: stac-validate-imagery
               templateRef:

--- a/workflows/cron/cron-stac-validate-full.yaml
+++ b/workflows/cron/cron-stac-validate-full.yaml
@@ -28,7 +28,7 @@ spec:
     templates:
       - name: main
         retryStrategy:
-          limit: '0'
+          expression: 'false'
         steps:
           - - name: stac-validate-imagery
               templateRef:

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -84,6 +84,8 @@ spec:
 
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       inputs:
         parameters:
           - name: source

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -78,6 +78,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       inputs:
         parameters:
           - name: copy_option

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -38,6 +38,8 @@ spec:
       image: ''
   templates:
     - name: main
+      retryStrategy:
+        expression: 'false'
       inputs:
         parameters:
           - name: version_argo_tasks
@@ -50,8 +52,6 @@ spec:
             value: '{{workflow.parameters.checksum_assets}}'
           - name: checksum_links
             value: '{{workflow.parameters.checksum_links}}'
-      retryStrategy:
-        limit: '0' # avoid retrying any of the following task as `tpl-at-stac-validate` already retries its own tasks.
       dag:
         tasks:
           - name: aws-list-collections


### PR DESCRIPTION
#### Motivation

With the current default `retryStrategy`, all templates are retried with the limit put in place. When a pod withing a workflow reach its retry limit without any success, the entrypoint template (`main`) of the workflow is also retried using this `retryStrategy`. It is not efficient as at that point the entire workflow is retried (and the failing template/pod as well!).

#### Modification

- avoid the retry on entrypoint template for the workflows in `workflows/`, not the `workflowTemplate` in `templates` as they have only one template which is also their entrypoint.
- move the default `retryStrategy` to `templateDefaults` as it is there that it belongs. This did not change the behaviour from the test I ran.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
