### PR TITLE
fix: task should retry when pod get deleted TDE-1241

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -151,7 +151,7 @@ export class ArgoWorkflows extends Chart {
                 /** TODO: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
                  * `affinity: { nodeAntiAffinity: {} }` seems to break `karpenter`, need more investigation
                  */
-                retryStrategy: { limit: 2 },
+                retryStrategy: { limit: 2, retryPolicy: 'OnError' },
               },
             },
           },


### PR DESCRIPTION
#### Motivation

When a task fails because a pod get deleted (not linked to an application error), the task is not retried.

#### Modification

- set the `retryPolicy` to `OnError` so the task get retried if a pod is deleted. See: https://argo-workflows.readthedocs.io/en/latest/tolerating-pod-deletion/#tolerating-pod-deletion

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
