### PR TITLE
fix(basemaps): Stop running create pr if no etl update required.

### DIFF
--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -81,7 +81,7 @@ spec:
               parameters:
                 - name: target
                   value: '{{ tasks.vector-etl.outputs.parameters.target }}'
-            when: '{{ workflow.parameters.create_pull_request }} == true'
+            when: '{{ workflow.parameters.create_pull_request }} == true && {{tasks.check-updates.outputs.parameters.updatesRequired}} == true'
             depends: 'vector-etl'
 
     - name: check-updates


### PR DESCRIPTION
#### Motivation

Seems `create-pr` still running when etl skipped. So we might need add the `requiredUpdate` check to `create-pr` condition as well.

![image](https://github.com/user-attachments/assets/eea085c9-5824-4287-8ed6-62af3ef572a4)

#### Modification

_Why is this change being made? What implications or other considerations are there?_

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
