### PR TITLE
test: test exit-handler template script TDE-1230

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,8 @@
-module.exports = {
+const cfg = {
   ...require('@linzjs/style/.eslintrc.cjs'),
 };
+// Disable no floating promises in tests until https://github.com/nodejs/node/issues/51292 is solved
+const testOverrides = cfg.overrides.find((ovr) => ovr.files.find((f) => f.includes('.test.ts')));
+testOverrides.rules['@typescript-eslint/no-floating-promises'] = 'off';
+
+module.exports = cfg;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "tsc",
     "lint": "npx eslint . --ignore-path .gitignore",
     "format": "npx prettier . -w",
-    "test": "node --import tsx --test infra/**/*.test.ts"
+    "test": "node --import tsx --test infra/**/*.test.ts templates/common/__test__/*.test.mjs"
   },
   "devDependencies": {
     "@aws-cdk/lambda-layer-kubectl-v28": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "tsc",
     "lint": "npx eslint . --ignore-path .gitignore",
     "format": "npx prettier . -w",
-    "test": "node --import tsx --test infra/**/*.test.ts templates/common/__test__/*.test.mjs"
+    "test": "node --import tsx --test infra/**/*.test.ts templates/common/__test__/*.test.ts"
   },
   "devDependencies": {
     "@aws-cdk/lambda-layer-kubectl-v28": "^2.1.0",
@@ -28,6 +28,7 @@
     "@aws-sdk/client-eks": "3.451.0",
     "@aws-sdk/client-ssm": "3.451.0",
     "@linzjs/style": "^5.2.0",
+    "@types/node": "^22.5.2",
     "aws-cdk": "2.108.x",
     "aws-cdk-lib": "2.108.x",
     "cdk8s": "^2.68.4",

--- a/templates/common/__test__/exit.handler.test.mjs
+++ b/templates/common/__test__/exit.handler.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { describe, it } from 'node:test';
+
+/**
+ * Read the workflow YAML file and create a function from the script inside.
+ * replacing {{ inputs.* }} with ctx
+ *
+ * @param {*} ctx
+ * @returns Function that requires a `context` and `core` parameter
+ */
+function createTestFunction(ctx) {
+  const func = fs.readFileSync('./templates/common/exit.handler.yml', 'utf-8').split('source: |')[1];
+
+  const newFunc = func
+    // Replace inputs
+    .replace('{{= inputs.parameters.workflow_parameters }}', `${ctx.workflowParameters ?? '[]'}`)
+    .replace('{{inputs.parameters.workflow_status}}', `${ctx.workflowStatus ?? 'Failed'}`)
+    .split('\n')
+    .join('\n');
+  return new Function('context', newFunc);
+}
+
+function runScript(ctx) {
+  return createTestFunction(ctx)();
+}
+
+describe('exit handler script template', () => {
+  it('should log workflow status and parameters', (t) => {
+    const spy = t.mock.method(console, 'log');
+
+    runScript({
+      workflowParameters: JSON.stringify([
+        { name: 'source', value: 's3://linz-topographic-upload/abc/', description: 'Source bucket' },
+        { name: 'ticket', value: 'GDE-123', description: 'JIRA Ticket' },
+      ]),
+      workflowStatus: `Succeeded`,
+    });
+
+    assert.equal(spy.mock.callCount(), 1);
+
+    const logOutputDict = JSON.parse(spy.mock.calls[0].arguments[0]);
+    // override time
+    logOutputDict.time = 1724037007216;
+
+    assert.deepEqual(logOutputDict, {
+      time: 1724037007216,
+      level: 20,
+      pid: 1,
+      msg: 'Workflow:Done',
+      workflowStatus: 'Succeeded',
+      parameters: { source: 's3://linz-topographic-upload/abc/', ticket: 'GDE-123' },
+    });
+  });
+});

--- a/templates/common/__test__/exit.handler.test.ts
+++ b/templates/common/__test__/exit.handler.test.ts
@@ -2,34 +2,33 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import { describe, it } from 'node:test';
 
+type scriptContext = { workflowParameters: string; workflowStatus: string };
+
 /**
  * Read the workflow YAML file and create a function from the script inside.
  * replacing {{ inputs.* }} with ctx
  *
  * @param {*} ctx
- * @returns Function that requires a `context` and `core` parameter
+ * @returns Function that requires a `context`
  */
-function createTestFunction(ctx) {
+function runTestFunction(ctx: scriptContext): void {
   const func = fs.readFileSync('./templates/common/exit.handler.yml', 'utf-8').split('source: |')[1];
-
+  if (!func) {
+    throw new Error('No script found in the workflow');
+  }
   const newFunc = func
     // Replace inputs
     .replace('{{= inputs.parameters.workflow_parameters }}', `${ctx.workflowParameters ?? '[]'}`)
-    .replace('{{inputs.parameters.workflow_status}}', `${ctx.workflowStatus ?? 'Failed'}`)
-    .split('\n')
-    .join('\n');
-  return new Function('context', newFunc);
-}
-
-function runScript(ctx) {
-  return createTestFunction(ctx)();
+    .replace('{{inputs.parameters.workflow_status}}', `${ctx.workflowStatus ?? 'Failed'}`);
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function(newFunc)();
 }
 
 describe('exit handler script template', () => {
   it('should log workflow status and parameters', (t) => {
     const spy = t.mock.method(console, 'log');
 
-    runScript({
+    runTestFunction({
       workflowParameters: JSON.stringify([
         { name: 'source', value: 's3://linz-topographic-upload/abc/', description: 'Source bucket' },
         { name: 'ticket', value: 'GDE-123', description: 'JIRA Ticket' },
@@ -39,7 +38,8 @@ describe('exit handler script template', () => {
 
     assert.equal(spy.mock.callCount(), 1);
 
-    const logOutputDict = JSON.parse(spy.mock.calls[0].arguments[0]);
+    const logOutputDict = JSON.parse(String(spy.mock.calls[0]?.arguments[0])) as { time: number };
+
     // override time
     logOutputDict.time = 1724037007216;
 

--- a/templates/common/__test__/exit.handler.test.ts
+++ b/templates/common/__test__/exit.handler.test.ts
@@ -2,16 +2,13 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import { describe, it } from 'node:test';
 
-type scriptContext = { workflowParameters: string; workflowStatus: string };
-
 /**
  * Read the workflow YAML file and create a function from the script inside.
  * replacing {{ inputs.* }} with ctx
  *
- * @param {*} ctx
- * @returns Function that requires a `context`
+ * @param ctx
  */
-function runTestFunction(ctx: scriptContext): void {
+function runTestFunction(ctx: { workflowParameters: string; workflowStatus: string }): void {
   const func = fs.readFileSync('./templates/common/exit.handler.yml', 'utf-8').split('source: |')[1];
   if (!func) {
     throw new Error('No script found in the workflow');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "lib": ["ES2022"],
     "noEmit": true
   },
-  "include": ["infra/"]
+  "include": ["infra/", "templates/common/__test__/"]
 }


### PR DESCRIPTION
#### Motivation

Bring a test for the inner script in the exit-handler workflowTemplate.

#### Modification

- add a function that grab the script content of the exit handler template to test it
- modify the npm test script to target this new test file

#### Checklist

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
