### PR TITLE
feat: add exit handler tasks TDE-1230

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -10,6 +10,7 @@ metadata:
 spec:
   parallelism: 100
   entrypoint: main
+  onExit: exit-handler
   synchronization:
     semaphore:
       configMapKeyRef:
@@ -452,3 +453,18 @@ spec:
           - '--config-type={{workflow.parameters.config_type}}'
           - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
           - '--category={{workflow.parameters.category}}'
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -9,6 +9,7 @@ metadata:
     linz.govt.nz/data-type: vector
 spec:
   entrypoint: main
+  onExit: exit-handler
   podMetadata:
     labels:
       linz.govt.nz/category: basemaps
@@ -160,3 +161,18 @@ spec:
           - '--target={{ inputs.parameters.target }}'
           - '--config-type=vector'
           - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'

--- a/workflows/cron/cron-stac-validate-fast.yaml
+++ b/workflows/cron/cron-stac-validate-fast.yaml
@@ -15,6 +15,7 @@ spec:
   suspend: false
   workflowSpec:
     entrypoint: main
+    onExit: exit-handler
     podMetadata:
       labels:
         linz.govt.nz/category: stac
@@ -53,3 +54,17 @@ spec:
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
                     value: '{{workflow.parameters.checksum_links}}'
+      - name: exit-handler
+        retryStrategy:
+          limit: '0' # `tpl-exit-handler` retries itself
+        steps:
+          - - name: exit
+              templateRef:
+                name: tpl-exit-handler
+                template: main
+              arguments:
+                parameters:
+                  - name: workflow_status
+                    value: '{{workflow.status}}'
+                  - name: workflow_parameters
+                    value: '{{workflow.parameters}}'

--- a/workflows/cron/cron-stac-validate-full.yaml
+++ b/workflows/cron/cron-stac-validate-full.yaml
@@ -15,6 +15,7 @@ spec:
   suspend: false
   workflowSpec:
     entrypoint: main
+    onExit: exit-handler
     podMetadata:
       labels:
         linz.govt.nz/category: stac
@@ -65,3 +66,17 @@ spec:
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
                     value: '{{workflow.parameters.checksum_links}}'
+      - name: exit-handler
+        retryStrategy:
+          limit: '0' # `tpl-exit-handler` retries itself
+        steps:
+          - - name: exit
+              templateRef:
+                name: tpl-exit-handler
+                template: main
+              arguments:
+                parameters:
+                  - name: workflow_status
+                    value: '{{workflow.status}}'
+                  - name: workflow_parameters
+                    value: '{{workflow.parameters}}'

--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -12,6 +12,7 @@ spec:
   nodeSelector:
     karpenter.sh/capacity-type: 'spot'
   entrypoint: main
+  onExit: exit-handler
   synchronization:
     semaphore:
       configMapKeyRef:
@@ -158,3 +159,18 @@ spec:
                   value: '{{workflow.parameters.aws_role_config_path}}'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -12,6 +12,7 @@ spec:
   nodeSelector:
     karpenter.sh/capacity-type: 'spot'
   entrypoint: main
+  onExit: exit-handler
   synchronization:
     semaphore:
       configMapKeyRef:
@@ -126,3 +127,18 @@ spec:
                 - name: copy_option
                   value: '{{inputs.parameters.copy_option}}'
             depends: 'generate-path'
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'


### PR DESCRIPTION
#### Motivation

The exit handler logs some useful information about a workflow when it's done. These can be helpful for logging and alerting.

#### Modification

- call exit-handler task `onExit`

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
