### PR TITLE
feat: --no_date_in_survey_path handling TDE-1261

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -193,6 +193,8 @@ arguments:
       value: '{{workflow.parameters.version_argo_tasks}}'
     - name: target_bucket_name
       value: '{{inputs.parameters.target_bucket_name}}'
+    - name: no_date_in_survey_path
+      value: '{{inputs.parameters.no_date_in_survey_path}}'
     - name: source
       value: '{{inputs.parameters.source}}'
 ```

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -36,7 +36,7 @@ spec:
           - 'generate-path'
           - '--target-bucket-name'
           - '{{=sprig.trim(inputs.parameters.target_bucket_name)}}'
-          - '--no_date_in_survey_path={{=sprig.trim(inputs.parameters.no_date_in_survey_path)}}'
+          - '--no-date-in-survey-path={{=sprig.trim(inputs.parameters.no_date_in_survey_path)}}'
           - '{{=sprig.trim(inputs.parameters.source)}}'
 
       outputs:

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -19,6 +19,9 @@ spec:
             description: s3 path of source data
           - name: target_bucket_name
             description: target bucket name e.g. 'nz-imagery'
+          - name: no_date_in_survey_path
+            description: 'If the survey path should not contain the date'
+            default: 'false'
           - name: version
             description: argo-task Container version to use
             default: 'v4'
@@ -33,6 +36,7 @@ spec:
           - 'generate-path'
           - '--target-bucket-name'
           - '{{=sprig.trim(inputs.parameters.target_bucket_name)}}'
+          - '--no_date_in_survey_path={{=sprig.trim(inputs.parameters.no_date_in_survey_path)}}'
           - '{{=sprig.trim(inputs.parameters.source)}}'
 
       outputs:


### PR DESCRIPTION
#### Motivation

Allowing the generate-path template to use the new flag available https://github.com/linz/argo-tasks/pull/1067

#### Modification

add a new parameter to handle the flag

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
