### PR TITLE
fix: increase storage of standardising pods to prevent out of diskspace errors TDE-1271

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -509,7 +509,7 @@ spec:
           requests:
             memory: 7.8Gi
             cpu: 15000m
-            ephemeral-storage: 3Gi
+            ephemeral-storage: 29.5Gi
         volumeMounts:
           - name: ephemeral
             mountPath: '/tmp'


### PR DESCRIPTION
#### Motivation

Large standardizing jobs need more than 3Gi of storage, the nodes are allocated 200Gi of storage so we need a number that somewhat divides from 200Gi but not exactly so prefer 19.8Gi over 20Gi

#### Modification

Up the diskspace allocation to 29.5Gi per pod from 3Gi

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
