### PR TITLE
refactor: create-collection does not use dates anymore TDE-1258

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -43,7 +43,7 @@ spec:
         value: 'v7'
       - name: version_topo_imagery
         description: 'Specify a version of the topo-imagery image to use, e.g. "v4.8" or "latest"'
-        value: 'v4'
+        value: 'v5'
       - name: user_group
         description: Group of users running the workflow
         value: 'none'
@@ -574,10 +574,6 @@ spec:
           - '{{=sprig.trim(workflow.parameters.gsd)}}'
           - '--geographic-description'
           - '{{=sprig.trim(workflow.parameters.geographic_description)}}'
-          - '--start-date'
-          - '{{=sprig.trim(workflow.parameters.start_datetime)}}'
-          - '--end-date'
-          - '{{=sprig.trim(workflow.parameters.end_datetime)}}'
           - '--event'
           - '{{=sprig.trim(workflow.parameters.event)}}'
           - '--historic-survey-number'


### PR DESCRIPTION
#### Motivation

Dates are pulled from Items: https://github.com/linz/topo-imagery/pull/1099

#### Modification

- remove start and end date parameters from create-collection
- bump topo-imagery version

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
