### PR TITLE
fix: avoid double negative arguments TDE-1261

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -193,8 +193,8 @@ arguments:
       value: '{{workflow.parameters.version_argo_tasks}}'
     - name: target_bucket_name
       value: '{{inputs.parameters.target_bucket_name}}'
-    - name: no_date_in_survey_path
-      value: '{{inputs.parameters.no_date_in_survey_path}}'
+    - name: add_date_in_survey_path
+      value: '{{inputs.parameters.add_date_in_survey_path}}'
     - name: source
       value: '{{inputs.parameters.source}}'
 ```

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -10,6 +10,7 @@ spec:
   templateDefaults:
     container:
       imagePullPolicy: Always
+      image: ''
   entrypoint: main
   templates:
     - name: main
@@ -19,9 +20,9 @@ spec:
             description: s3 path of source data
           - name: target_bucket_name
             description: target bucket name e.g. 'nz-imagery'
-          - name: no_date_in_survey_path
-            description: 'If the survey path should not contain the date'
-            default: 'false'
+          - name: add_date_in_survey_path
+            description: 'The survey path should contain the dates'
+            default: 'true'
           - name: version
             description: argo-task Container version to use
             default: 'v4'
@@ -36,7 +37,7 @@ spec:
           - 'generate-path'
           - '--target-bucket-name'
           - '{{=sprig.trim(inputs.parameters.target_bucket_name)}}'
-          - '--no-date-in-survey-path={{=sprig.trim(inputs.parameters.no_date_in_survey_path)}}'
+          - '--add-date-in-survey-path={{=sprig.trim(inputs.parameters.add_date_in_survey_path)}}'
           - '{{=sprig.trim(inputs.parameters.source)}}'
 
       outputs:

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -21,7 +21,7 @@ spec:
           - name: target_bucket_name
             description: target bucket name e.g. 'nz-imagery'
           - name: add_date_in_survey_path
-            description: 'The survey path should contain the dates'
+            description: 'The survey path should contain the date'
             default: 'true'
           - name: version
             description: argo-task Container version to use


### PR DESCRIPTION
#### Motivation

see https://github.com/linz/argo-tasks/pull/1104

#### Modification

- `no_date_in_survey_path` --> `add_date_in_survey_path`

#### Checklist

- [ ] Tests updated NA
- [x] Docs updated
- [x] Issue linked in Title
