### PR TITLE
ci: exclude md files when determining if infra changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Find Changes in Infra
         id: get-infra-changes
         run: |
-          mapfile -d '' modified_infra_files < <(git diff --name-only -z ${{ github.event.before }} ${{ github.event.after }} -- "infra/*")
+          mapfile -d '' modified_infra_files < <(git diff --name-only -z ${{ github.event.before }} ${{ github.event.after }} -- "infra/*" ":(exclude)infra/*.md")
           if [[ "${#modified_infra_files[@]}" -ge 1 ]]; then
             echo "run_infra=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
#### Motivation

If a `md` file is modified, the CI process should not deployed the infrastructure as there is no change.

#### Modification

- exclude `md` files from the `git diff`

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
