### PR TITLE
fix: create config url should be stored in /flat TDE-1321

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -394,7 +394,7 @@ spec:
                 - name: collection-id
                   value: '{{tasks.collection-id-setup.outputs.parameters.collection-id}}'
                 - name: target
-                  value: '{{tasks.get-location.outputs.parameters.location}}flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
               artifacts:
                 - name: group_data
                   from: '{{ tasks.group.outputs.artifacts.output }}'
@@ -418,7 +418,7 @@ spec:
             arguments:
               parameters:
                 - name: uri
-                  value: '{{tasks.get-location.outputs.parameters.location}}flat/collection.json'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/collection.json'
               artifacts:
                 - name: stac-result
                   raw:
@@ -460,7 +460,7 @@ spec:
             arguments:
               parameters:
                 - name: source
-                  value: '{{tasks.get-location.outputs.parameters.location}}flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: target_bucket_name
                   value: '{{workflow.parameters.target_bucket_name}}'
                 - name: copy_option
@@ -565,7 +565,7 @@ spec:
           - python
           - '/app/scripts/collection_from_items.py'
           - '--uri'
-          - '{{inputs.parameters.location}}flat/'
+          - '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/'
           - '--collection-id'
           - '{{inputs.parameters.collection-id}}'
           - '--category'
@@ -614,9 +614,9 @@ spec:
             '-V',
             'create-overview',
             '--source',
-            '{{inputs.parameters.location}}flat/',
+            '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/',
             '--output',
-            '{{inputs.parameters.location}}flat/',
+            '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/',
           ]
 
     - name: create-config
@@ -634,7 +634,7 @@ spec:
             value: s3://linz-bucket-config/config.basemaps.json
         args:
           - 'config'
-          - '{{ inputs.parameters.location }}flat/'
+          - '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/'
       outputs:
         parameters:
           - name: url
@@ -650,7 +650,7 @@ spec:
             path: '/tmp/cogify/config-url'
             s3:
               bucket: '{{inputs.parameters.bucket}}'
-              key: '{{inputs.parameters.key}}/flat/config-url'
+              key: '{{=sprig.trimSuffix("/", inputs.parameters.key)}}/flat/config-url'
             archive:
               none: {}
 

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -650,7 +650,7 @@ spec:
             path: '/tmp/cogify/config-url'
             s3:
               bucket: '{{inputs.parameters.bucket}}'
-              key: '{{inputs.parameters.key}}flat/config-url'
+              key: '{{inputs.parameters.key}}/flat/config-url'
             archive:
               none: {}
 


### PR DESCRIPTION
#### Motivation

The key output by get-location does not end with a trailing `/`. The create-config task should manage the path within the bucket correctly.

#### Modification

Add a `/` between the key and the `flat` in the artifact path for the config-url.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
