### PR TITLE
fix: use value instead of default in copy wf TDE-1323

### DIFF
--- a/workflows/raster/copy.yaml
+++ b/workflows/raster/copy.yaml
@@ -87,7 +87,7 @@ spec:
           - '--force-no-clobber'
       - name: flatten
         description: Flatten the files in the target location
-        default: 'false'
+        value: 'false'
         enum:
           - 'true'
           - 'false'


### PR DESCRIPTION
#### Motivation

`value` sounds more appropriate to use for the WorkflowTemplate parameter values we want to default for the users.

#### Modification

- `flatten` workflow parameter default value is now stored in `value` rather than `default`

Note on `default` vs `value`:
From my understanding, `default` would used if no `value` is  supplied. In the case of a user of the WorkflowTemplate and at a `arguments.parameters` level, using `value` seems more appropriate.
Using `default` and `value` would be appropriate in the following example:
```
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: my-wft
  entrypoint: main
  arguments:
    parameters:
      - name: my_param
        value: ''
  templates:
    - name: main
      dag:
        tasks:
          - name: my-task
            templateRef:
              name: my-tpl
              template: main
            arguments:
              parameters:
                - name: my_param
                  value: '{{workflow.parameters.my_param}}'
                  default: 'default value'
```
In that example, if the user does not pass a value to the workflow parameter `my_param`, `{{workflow.parameters.my_param}}` would be null so `default` would be use instead.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
