### PR TITLE
fix: set default geographic_description for stac-setup TDE-1318

### DIFF
--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -28,6 +28,7 @@ spec:
             description: 'Region of the dataset'
           - name: geographic_description
             description: '(Optional) Additional dataset description'
+            default: ''
           - name: geospatial_category
             description: 'Geospatial category of the dataset'
           - name: odr_url


### PR DESCRIPTION
`geographic_description` will not be supplied for all datasets e.g. the National DEM.
