### PR TITLE
fix: update generate-path template to remove add-date-in-survey-path

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -195,8 +195,6 @@ arguments:
       value: '{{workflow.parameters.version_argo_tasks}}'
     - name: target_bucket_name
       value: '{{inputs.parameters.target_bucket_name}}'
-    - name: add_date_in_survey_path
-      value: '{{inputs.parameters.add_date_in_survey_path}}'
     - name: source
       value: '{{inputs.parameters.source}}'
 ```

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -20,9 +20,6 @@ spec:
             description: s3 path of source data
           - name: target_bucket_name
             description: target bucket name e.g. 'nz-imagery'
-          - name: add_date_in_survey_path
-            description: 'The survey path should contain the date'
-            default: 'true'
           - name: version
             description: argo-task Container version to use
             default: 'v4'
@@ -37,7 +34,6 @@ spec:
           - 'generate-path'
           - '--target-bucket-name'
           - '{{=sprig.trim(inputs.parameters.target_bucket_name)}}'
-          - '--add-date-in-survey-path={{=sprig.trim(inputs.parameters.add_date_in_survey_path)}}'
           - '{{=sprig.trim(inputs.parameters.source)}}'
 
       outputs:


### PR DESCRIPTION
#### Motivation

Remove the no longer required `--add-date-in-survey-path` after merging https://github.com/linz/argo-tasks/pull/1136 as this change will now construct the path from the `linz:slug`

#### Modification

Remove the `--add-date-in-survey-path` parameter from the `tpl-at-generate-path` workflowtemplate.
#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated N/A
- [x] Docs updated
- [x] Issue linked in Title
