### PR TITLE
fix: Collection created updated should be the workflow run datetime TDE-1341

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -433,6 +433,8 @@ spec:
                   value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
                 - name: location
                   value: '{{tasks.get-location.outputs.parameters.location}}'
+                - name: current_datetime
+                  value: '{{tasks.stac-setup.finishedAt}}'
             depends: 'standardise-validate'
 
           - name: stac-validate
@@ -560,6 +562,7 @@ spec:
           - name: collection_id
           - name: linz_slug
           - name: location
+          - name: current_datetime
       outputs:
         artifacts:
           - name: capture-area
@@ -607,6 +610,8 @@ spec:
           - '{{=sprig.trim(workflow.parameters.licensor_list)}}'
           - '--concurrency'
           - '25'
+          - '--current-datetime'
+          - '{{inputs.parameters.current_datetime}}'
 
     - name: create-overview
       inputs:


### PR DESCRIPTION
#### Motivation

When creating a Collection from the imagery-standardising workflow, the created and updated date should remains the same as for the Items, using a constant rather than the system execution time.

#### Modification

- Use the same datetime that is used for the Items

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
