### PR TITLE
docs: update description for copy_option parameter

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -325,7 +325,7 @@ spec:
           - 'nz-elevation'
           - ''
       - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", or "force" overwriting files in the target location'
+        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
         value: '--no-clobber'
         enum:
           - '--no-clobber'


### PR DESCRIPTION
#### Motivation

The description of the `copy_option` parameter is missing information about the `--force-no-clobber`.

#### Modification

- update documentation

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
