### PR TITLE
feat: add a workflowTemplate to create national DEM TDE-1166

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -3,6 +3,7 @@
 - [Standardising](#Standardising)
 - [copy](#copy)
 - [publish-odr](#Publish-odr)
+- [National DEM](#national-dem)
 - [tests](#Tests)
 
 # Standardising
@@ -16,7 +17,7 @@ Publishing to the AWS Registry of Open Data is an optional step [publish-odr](#P
 ## Workflow Input Parameters
 
 | Parameter              | Type  | Default                               | Description                                                                                                                                                                                                                                                       |
-|------------------------| ----- | ------------------------------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | ----- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | user_group             | enum  | none                                  | Group of users running the workflow                                                                                                                                                                                                                               |
 | ticket                 | str   |                                       | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                                                           |
 | region                 | enum  |                                       | Region of the dataset                                                                                                                                                                                                                                             |
@@ -53,7 +54,7 @@ Publishing to the AWS Registry of Open Data is an optional step [publish-odr](#P
 ### Example Input Parameters
 
 | Parameter              | Value                                                                             |
-|------------------------| --------------------------------------------------------------------------------- |
+| ---------------------- | --------------------------------------------------------------------------------- |
 | ticket                 | AIP-55                                                                            |
 | region                 | bay-of-plenty                                                                     |
 | source                 | s3://linz-imagery-upload/PRJ39741_BOPLASS_Imagery_2021-22/PRJ39741_03/01_GeoTiff/ |
@@ -65,7 +66,7 @@ Publishing to the AWS Registry of Open Data is an optional step [publish-odr](#P
 | compression            | webp                                                                              |
 | create_capture_area    | true                                                                              |
 | cutline                | s3://linz-imagery-staging/cutline/bay-of-plenty_2021-2022.fgb                     |
-| odr_url                | s3://nz-imagery/taranaki/new-plymouth_2017_0.1m/rgb/2193/                                                         |
+| odr_url                | s3://nz-imagery/taranaki/new-plymouth_2017_0.1m/rgb/2193/                         |
 | category               | rural-aerial-photos                                                               |
 | gsd                    | 0.3                                                                               |
 | producer               | Aerial Surveys                                                                    |
@@ -133,6 +134,7 @@ graph TD;
 
 if `odr_url` is provided, gets existing `linz:slug` and `collection-id` STAC metadata fields (e.g. for dataset resupply),
 If no `odr_url` is provided:
+
 - a ULID is generated for the collection ID
 - the input parameters are used to generate the LINZ slug
 
@@ -212,7 +214,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 ## Workflow Input Parameters
 
 | Parameter            | Type  | Default                                                                                                                                                       | Description                                                                                                                                                                                                                 |
-| -------------------- | ----- |---------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | user_group           | enum  | none                                                                                                                                                          | Group of users running the workflow                                                                                                                                                                                         |
 | ticket               | str   |                                                                                                                                                               | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
 | region               | enum  |                                                                                                                                                               | Region of the dataset                                                                                                                                                                                                       |
@@ -283,6 +285,24 @@ graph TD;
 **copy_option:** `--no-clobber`
 
 See the [copy template](#copy) for more information.
+
+# national-dem
+
+This workflow combines a set of DEMs datasets in order to create a single national dataset composed of 1:50k tiles.
+
+Upon completion all standardised TIFF and STAC files will be located with the ./flat/ directory of the workflow in the artifacts scratch bucket. In addition, a Basemaps link is produced enabling visual QA.
+
+Publishing to the AWS Registry of Open Data is an optional step [publish-odr](#Publish-odr) that can be run automatically after standardisation.
+
+## Workflow Input Parameters
+
+| Parameter      | Type | Default                                                                                     | Description                                                                                                                                                                                                                                                       |
+| -------------- | ---- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| config_file    | str  | https://raw.githubusercontent.com/linz/basemaps-config/master/config/tileset/elevation.json | Location of the configuration file listing the source datasets to merge.                                                                                                                                                                                          |
+| odr_url        | str  |                                                                                             | (Optional) If an existing dataset add the S3 path to the dataset here to load existing metadata e.g. "s3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/"                                                                                                     |
+| group          | 2    |                                                                                             | How many output tiles to process in each standardising task "pod". Change if you have resource or performance issues when standardising a dataset.                                                                                                                |
+| publish_to_odr | str  | false                                                                                       | Run [publish-odr](#Publish-odr) after standardising has completed successfully                                                                                                                                                                                    |
+| copy_option    | enum | --force-no-clobber                                                                          | Used only if `publish_to_odr` is true.<dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
 
 # Tests
 

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -1,0 +1,417 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: national-dem
+  labels:
+    linz.govt.nz/category: raster
+    linz.govt.nz/data-type: raster
+spec:
+  parallelism: 50
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  onExit: exit-handler
+  workflowMetadata:
+    labels:
+      linz.govt.nz/region: 'new-zealand'
+  podMetadata:
+    labels:
+      linz.govt.nz/category: raster
+      linz.govt.nz/data-type: raster
+      linz.govt.nz/region: 'new-zealand'
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        description: 'Specify a version of the argo-tasks image to use, e.g. "v4.1" or "latest"'
+        value: 'v4'
+      - name: version_basemaps_cli
+        description: 'Specify a version of the basemaps-cli image to use, e.g. "v7.1" or "latest"'
+        value: 'v7'
+      - name: version_topo_imagery
+        description: 'Specify a version of the topo-imagery image to use, e.g. "v4.8" or "latest"'
+        value: 'v7'
+      - name: config_file
+        description: 'Location of the configuration file listing the source datasets to merge.'
+        value: 'https://raw.githubusercontent.com/linz/basemaps-config/master/config/tileset/elevation.json'
+      - name: odr_url
+        description: '(Optional) If an existing dataset add the S3 path to the dataset here to load existing metadata e.g. "s3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/"'
+        value: ''
+      - name: group
+        description: 'How many output tiles to process in each standardising task "pod". Change if you have resource or performance issues when standardising a dataset.'
+        value: '2'
+      - name: publish_to_odr
+        description: 'Create a Pull Request for publishing to imagery or elevation ODR bucket'
+        value: 'false'
+        enum:
+          - 'false'
+          - 'true'
+      - name: copy_option
+        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
+        value: '--force-no-clobber'
+        enum:
+          - '--no-clobber'
+          - '--force'
+          - '--force-no-clobber'
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  templates:
+    - name: main
+      retryStrategy:
+        expression: 'false'
+      dag:
+        tasks:
+          - name: get-location
+            templateRef:
+              name: tpl-get-location
+              template: main
+
+          - name: create-mapsheet
+            template: create-mapsheet
+            arguments:
+              parameters:
+                - name: config_file
+                  value: '{{workflow.parameters.config_file}}'
+                - name: compare
+                  # Workaround --compare with empty value will fail so we add the flag inside the input parameter
+                  value: '{{= workflow.parameters.odr_url == "" ? "" : "--compare=" + sprig.trimSuffix("/", workflow.parameters.odr_url) + "/collection.json" }}'
+                - name: bucket
+                  value: '{{tasks.get-location.outputs.parameters.bucket}}'
+                - name: key
+                  value: '{{tasks.get-location.outputs.parameters.key}}'
+            depends: 'get-location.Succeeded'
+
+          - name: group
+            templateRef:
+              name: tpl-at-group
+              template: main
+            arguments:
+              artifacts:
+                - name: input
+                  from: '{{ tasks.create-mapsheet.outputs.artifacts.files }}'
+              parameters:
+                - name: size
+                  value: '{{workflow.parameters.group}}'
+                - name: version
+                  value: '{{= workflow.parameters.version_argo_tasks}}'
+            depends: 'create-mapsheet'
+            when: "{{= len(sprig.fromJson(tasks['create-mapsheet'].outputs.parameters.file_list)) > 0 }}"
+
+          - name: stac-setup
+            templateRef:
+              name: tpl-at-stac-setup
+              template: main
+            arguments:
+              parameters:
+                - name: gsd
+                  value: '1'
+                - name: region
+                  value: 'new zealand'
+                - name: geospatial_category
+                  value: 'dem'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                - name: version
+                  value: '{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
+                - name: add_date_in_survey_path
+                  value: 'false'
+            depends: 'group.Succeeded'
+
+          - name: standardise-validate
+            template: standardise-validate
+            arguments:
+              parameters:
+                - name: group_id
+                  value: '{{item}}'
+                - name: collection_id
+                  value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
+                - name: current_datetime
+                  value: '{{tasks.stac-setup.finishedAt}}'
+                - name: target
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+              artifacts:
+                - name: group_data
+                  from: '{{ tasks.group.outputs.artifacts.output }}'
+            depends: 'stac-setup.Succeeded && get-location.Succeeded'
+            withParam: '{{ tasks.group.outputs.parameters.output }}'
+
+          - name: create-collection
+            template: create-collection
+            arguments:
+              parameters:
+                - name: collection_id
+                  value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
+                - name: linz_slug
+                  value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
+                - name: location
+                  value: '{{tasks.get-location.outputs.parameters.location}}'
+                - name: current_datetime
+                  value: '{{tasks.stac-setup.finishedAt}}'
+            depends: 'standardise-validate.Succeeded'
+
+          - name: stac-validate
+            templateRef:
+              name: tpl-at-stac-validate
+              template: main
+            arguments:
+              parameters:
+                - name: uri
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/collection.json'
+              artifacts:
+                - name: stac-result
+                  raw:
+                    data: '{{tasks.stac-validate.outputs.result}}'
+            depends: 'create-collection.Succeeded'
+
+          - name: create-config
+            arguments:
+              parameters:
+                - name: location
+                  value: '{{tasks.get-location.outputs.parameters.location}}'
+                - name: bucket
+                  value: '{{tasks.get-location.outputs.parameters.bucket}}'
+                - name: key
+                  value: '{{tasks.get-location.outputs.parameters.key}}'
+            template: create-config
+            depends: 'standardise-validate'
+
+          - name: publish-odr
+            templateRef:
+              name: publish-odr
+              template: main
+            when: "'{{workflow.parameters.publish_to_odr}}' == 'true'"
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+                - name: target_bucket_name
+                  value: 'nz-elevation'
+                - name: copy_option
+                  value: '{{workflow.parameters.copy_option}}'
+                - name: ticket
+                  value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+            depends: 'stac-validate.Succeeded && create-config.Succeeded'
+
+      outputs:
+        parameters:
+          - name: target
+            valueFrom:
+              parameter: '{{tasks.get-location.outputs.parameters.location}}'
+              default: ''
+      # END TEMPLATE `main`
+
+    - name: create-mapsheet
+      inputs:
+        parameters:
+          - name: config_file
+          - name: compare
+          - name: bucket
+          - name: key
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
+        resources:
+          requests:
+            cpu: 3000m
+            memory: 7.8Gi
+        command: [node, /app/index.js]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          [
+            'mapsheet-coverage',
+            '--verbose',
+            '--location',
+            '{{inputs.parameters.config_file}}',
+            '--epsg-code',
+            '2193',
+            '{{inputs.parameters.compare}}',
+          ]
+      outputs:
+        parameters:
+          - name: file_list
+            valueFrom:
+              path: /tmp/mapsheet-coverage/file-list.json
+        artifacts:
+          # List of tiff files that need to be processed
+          - name: files
+            path: /tmp/mapsheet-coverage/file-list.json
+            optional: true
+            archive:
+              none: {}
+          - name: layers_source
+            path: /tmp/mapsheet-coverage/layers-source.geojson.gz
+            optional: true
+            archive:
+              none: {}
+          - name: layers_combined
+            path: /tmp/mapsheet-coverage/layers-combined.geojson.gz
+            optional: true
+            archive:
+              none: {}
+          # Provenance information for the collection
+          - name: capture_dates
+            path: /tmp/mapsheet-coverage/capture-dates.geojson
+            s3:
+              bucket: '{{inputs.parameters.bucket}}'
+              key: '{{=sprig.trimSuffix("/", inputs.parameters.key)}}/flat/capture-dates.geojson'
+            archive:
+              none: {}
+
+    - name: standardise-validate
+      nodeSelector:
+        karpenter.sh/capacity-type: 'spot'
+      inputs:
+        parameters:
+          - name: group_id
+          - name: collection_id
+          - name: current_datetime
+          - name: target
+        artifacts:
+          - name: group_data
+            path: /tmp/input/
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(workflow.parameters.version_topo_imagery)}}'
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 15000m
+            ephemeral-storage: 3Gi
+        volumeMounts:
+          - name: ephemeral
+            mountPath: '/tmp'
+        args:
+          - python
+          - '/app/scripts/standardise_validate.py'
+          - '--from-file'
+          - '/tmp/input/{{inputs.parameters.group_id}}.json'
+          - '--target'
+          - '{{inputs.parameters.target}}'
+          - '--preset'
+          - 'dem_lerc'
+          - '--collection-id'
+          - '{{inputs.parameters.collection_id}}'
+          - '--create-footprints'
+          - 'true'
+          - '--source-epsg'
+          - '2193'
+          - '--target-epsg'
+          - '2193'
+          - '--gsd'
+          - '1'
+          - '--odr-url'
+          - '{{=sprig.trim(workflow.parameters.odr_url)}}'
+          - '--current-datetime'
+          - '{{inputs.parameters.current_datetime}}'
+
+    - name: create-collection
+      nodeSelector:
+        karpenter.sh/capacity-type: 'spot'
+      inputs:
+        parameters:
+          - name: collection_id
+          - name: linz_slug
+          - name: location
+          - name: current_datetime
+      outputs:
+        artifacts:
+          - name: capture-area
+            path: '/tmp/capture-area.geojson'
+            optional: true
+            archive:
+              none: {}
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(workflow.parameters.version_topo_imagery)}}'
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 15000m
+        args:
+          - python
+          - '/app/scripts/collection_from_items.py'
+          - '--uri'
+          - '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/'
+          - '--collection-id'
+          - '{{inputs.parameters.collection_id}}'
+          - '--linz-slug'
+          - '{{inputs.parameters.linz_slug}}'
+          - '--odr-url'
+          - '{{=sprig.trim(workflow.parameters.odr_url)}}'
+          - '--category'
+          - 'dem'
+          - '--region'
+          - 'new-zealand'
+          - '--gsd'
+          - '1'
+          - '--lifecycle'
+          - 'ongoing'
+          - '--producer'
+          - 'Toitū Te Whenua Land Information New Zealand'
+          - '--producer-list'
+          - ''
+          - '--licensor'
+          - 'Toitū Te Whenua Land Information New Zealand'
+          - '--licensor-list'
+          - ''
+          - '--concurrency'
+          - '25'
+          - '--capture-dates'
+          - '--current-datetime'
+          - '{{inputs.parameters.current_datetime}}'
+
+    - name: create-config
+      inputs:
+        parameters:
+          - name: location
+            description: 'Location of the imagery to create config for'
+          - name: bucket
+          - name: key
+      container:
+        image: 'ghcr.io/linz/basemaps/cli:{{=sprig.trim(workflow.parameters.version_basemaps_cli)}}'
+        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.basemaps.json
+        args:
+          - 'config'
+          - '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/'
+      outputs:
+        parameters:
+          - name: url
+            description: 'Basemaps URL to view the imagery'
+            valueFrom:
+              path: '/tmp/cogify/config-url'
+          - name: config
+            description: 'Location of the config file'
+            valueFrom:
+              path: '/tmp/cogify/config-path'
+        artifacts:
+          - name: url
+            path: '/tmp/cogify/config-url'
+            s3:
+              bucket: '{{inputs.parameters.bucket}}'
+              key: '{{=sprig.trimSuffix("/", inputs.parameters.key)}}/flat/config-url'
+            archive:
+              none: {}
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'
+
+  volumes:
+    - name: ephemeral
+      emptyDir: {}


### PR DESCRIPTION
#### Motivation

Having a Nationally combined set of DEMs is useful for any data consumer wanted to access to the entire country DEM. This dataset is aimed to be updated on a regular basis to include all new single region/area dataset that is newly published or updated.

![image](https://github.com/user-attachments/assets/e9d363f5-c586-4ced-8385-24d626ace894)


#### Modification

Add a WorkflowTemplate that create a nationally combined set of DEM based off a configuration file that list the datasets to include in order of priority. This WF template is able to be used to run a cron workflow.

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
