### PR TITLE
docs: fix group description

### DIFF
--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -39,7 +39,7 @@ spec:
         description: '(Optional) If an existing dataset add the S3 path to the dataset here to load existing metadata e.g. "s3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/"'
         value: ''
       - name: group
-        description: 'How many output tiles to process in each standardising task "pod". Change if you have resource or performance issues when standardising a dataset.'
+        description: 'How many output tiles to process in each standardise-validate task "pod". Change if you have resource or performance issues when standardising a dataset.'
         value: '2'
       - name: publish_to_odr
         description: 'Create a Pull Request for publishing to imagery or elevation ODR bucket'

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -114,7 +114,7 @@ spec:
         description: 'EPSG of the standardised output files'
         value: '2193'
       - name: group
-        description: 'How many output tiles to process in each standardising task "pod". Change if you have resource or performance issues when standardising a dataset.'
+        description: 'How many output tiles to process in each standardise-validate task "pod". Change if you have resource or performance issues when standardising a dataset.'
         value: '50'
       - name: compression
         description: 'Compression type to use when standardising TIFFs, e.g. "webp" for imagery or "dem_lerc" for elevation data'


### PR DESCRIPTION
#### Motivation

The `group` field in the `imagery-standardising` workflow was mentioning `standardising` task rather than `standardise-validate`.

#### Modification

Rename task in the description

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
