### PR TITLE
feat: add CronWorkflow to update the national DEM dataset TDE-1162

### DIFF
--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -1,15 +1,16 @@
-# Contents:
+# Contents
 
 - [cron-stac-validate-fast](#cron-stac-validate-fast)
 - [cron-stac-validate-full](#cron-stac-validate-full)
+- [National DEM](#national-dem)
 
-# STAC validation
+## STAC validation
 
 The goal of the following [Cron Workflows](https://argo-workflows.readthedocs.io/en/stable/cron-workflows/) is to check the validity of the STAC metadata published in the AWS Open Data Registries [NZ Elevation](https://registry.opendata.aws/nz-elevation/) and [NZ Imagery](https://registry.opendata.aws/nz-imagery/).
 
 > **_NOTE:_** To simplify the overall workflow deployment process, these `CronWorkflow`s have one main task per registry. It looks like a duplication that could be avoided but as we are not using [`argo` CLI](https://argo-workflows.readthedocs.io/en/stable/walk-through/argo-cli/) to deploy the workflows - which allows parameter passing - we could not deploy one `CronWorkflow` per `uri` (or registry).
 
-## cron-stac-validate-fast
+### cron-stac-validate-fast
 
 Workflow that validates the STAC metadata by calling the [`stac-validate` argo-tasks command](https://github.com/linz/argo-tasks/blob/master/README.md#stac-validate) using the [`tpl-at-stac-validate`](https://github.com/linz/topo-workflows/blob/master/templates/argo-tasks/README.md#argo-tasksstac-validate).
 
@@ -17,7 +18,7 @@ It does verify that the [STAC links](https://github.com/radiantearth/stac-spec/b
 
 - schedule: **every day at 5am**
 
-## cron-stac-validate-full
+### cron-stac-validate-full
 
 Workflow that validates the STAC metadata by calling the [`stac-validate` argo-tasks command](https://github.com/linz/argo-tasks/blob/master/README.md#stac-validate) using the [`stac-validate-parallel`](https://github.com/linz/topo-workflows/blob/master/workflows/stac/README.md#stac-validate-parallel).
 
@@ -26,3 +27,7 @@ It also validate that the [STAC assets](https://github.com/radiantearth/stac-spe
 > **_NOTE:_** Due to the parallelism design, this workflow does not validate the root parent `catalog.json` in order to validate each `collection.json` separately. This is not an issue as the `catalog.json` does not contain any `asset` and is already validated by the [cron-stac-validata-fast](#cron-stac-validate-fast) job.
 
 - schedule: **every 1st of the month**
+
+## National DEM
+
+This cron triggers the `national-dem` workflow on a regular basis to make sure that any update made on the 1m DEM datasets (`s3://nz-elevation`) that are listed in [the configuration](https://github.com/linz/basemaps-config/blob/master/config/tileset/elevation.json), or any update in the configuration itself, are propagated to [the whole New Zealand LiDAR 1m DEM dataset](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem_1m/2193/collection.json).

--- a/workflows/cron/cron-national-dem.yaml
+++ b/workflows/cron/cron-national-dem.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: cron-national-dem
+  labels:
+    linz.govt.nz/category: raster
+    linz.govt.nz/data-type: raster
+spec:
+  schedule: '0 6 * * *' # 6 AM every day
+  timezone: 'NZ'
+  concurrencyPolicy: 'Allow'
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  suspend: false
+  workflowSpec:
+    podMetadata:
+      labels:
+        linz.govt.nz/category: raster
+        linz.govt.nz/data-type: raster
+        linz.govt.nz/region: 'new-zealand'
+    workflowTemplateRef:
+      name: national-dem
+    arguments:
+      parameters:
+        - name: 'config_file'
+          value: 'https://raw.githubusercontent.com/linz/basemaps-config/master/config/tileset/elevation.json'
+        - name: 'odr_url'
+          value: 's3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/'
+        - name: publish_to_odr
+          value: 'true'
+        - name: 'copy_option'
+          value: '--force-no-clobber'


### PR DESCRIPTION
#### Motivation

Making sure that any update made on the 1m DEM datasets (`s3://nz-elevation`) that are listed in [the configuration](https://github.com/linz/basemaps-config/blob/master/config/tileset/elevation.json), or any update in the configuration itself, are propagated to [the whole New Zealand LiDAR 1m DEM dataset](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem_1m/2193/collection.json).

#### Modification

Deploy a CronWorkflow to trigger the `national-dem` workflow against the published [New Zealand LiDAR 1m DEM](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem_1m/2193/collection.json) dataset.

This should be merged after https://github.com/linz/topo-workflows/pull/890

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
