### PR TITLE
fix: remove the log field after its parsed into data field TDE-1337

### DIFF
--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -100,6 +100,12 @@ HC_Period 5
            * See: https://github.com/argoproj/argo-workflows/issues/13314
            */
           bufferSize: '128k',
+          /**
+           * Remove the `log` field from the logs
+           * as it has been parsed into the `data` field
+           * so we don't want duplicated logs
+           */
+          keepLog: 'Off',
         },
         // FIXME: `livenessProbe` and `readinessProbe` deactivated https://github.com/aws/eks-charts/issues/995
         livenessProbe: false,


### PR DESCRIPTION
#### Motivation

The logs are parsed into a `data` field by fluentbit. It is unecessary duplication to keep the `log` field once it has been merged into `data`.

#### Modification

Tells fluentbit to not keep the `log` field once it's parsed into `data`.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
