### PR TITLE
fix: cron national dem should not run on weekends TDE-1162

### DIFF
--- a/workflows/cron/cron-national-dem.yaml
+++ b/workflows/cron/cron-national-dem.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '0 6 * * *' # 6 AM every day
+  schedule: '0 6 * * 1-5' # 6AM every day from Monday to Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3

--- a/workflows/cron/cron-national-dem.yaml
+++ b/workflows/cron/cron-national-dem.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '0 6 * * 1-5' # 6AM every day from Monday to Friday
+  schedule: '0 6 * * 1-5' # At 06:00 AM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
#### Motivation

The cron national dem workflow should not run on weekend to avoid trying to create several PR over the weekend if data has been published on a Friday.

#### Modification

Change the cron schedule

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
