### PR TITLE
refactor: templates for standardise-validate and create-collection topo-imagery commands TDE-1346

### DIFF
--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -1,0 +1,110 @@
+# Topo-Imagery templates
+
+## Contents:
+
+- [Standardise Validate](##topo-imagery/standardise-validate)
+- [Create Collection](##topo-imagery/create-collection)
+
+## topo-imagery/standardise-validate - `tpl-ti-standardise-validate`
+
+Template for TIFF standardisation and non-visual QA.
+
+See [standardise_validate.py](https://github.com/linz/topo-imagery/blob/master/scripts/standardise_validate.py)
+
+### Template usage
+```yaml
+- name: standardise-validate
+  templateRef:
+    name: tpl-ti-standardise-validate
+    template: main
+  arguments:
+    parameters:
+      - name: group_id
+        value: '{{item}}'
+      - name: odr_url
+        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+      - name: collection_id
+        value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
+      - name: compression
+        value: '{{= workflow.parameters.compression}}'
+      - name: current_datetime
+        value: '{{tasks.stac-setup.finishedAt}}'
+      - name: start_datetime
+        value: '{{=sprig.trim(workflow.parameters.start_datetime)}}'
+      - name: end_datetime
+        value: '{{=sprig.trim(workflow.parameters.end_datetime)}}'
+      - name: create_capture_area
+        value: '{{=sprig.trim(workflow.parameters.create_capture_area)}}'
+      - name: cutline
+        value: '{{=sprig.trim(workflow.parameters.cutline)}}'
+      - name: gsd
+        value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+      - name: target
+        value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+      - name: source_epsg
+        value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
+      - name: target_epsg
+        value: '{{=sprig.trim(workflow.parameters.target_epsg)}}'
+      - name: version
+        value: '{{= workflow.parameters.version_topo_imagery}}'
+    artifacts:
+      - name: group_data
+        from: '{{ tasks.group.outputs.artifacts.output }}'
+```
+
+The Workflow caller must have the following volume:
+
+```yaml
+volumes:
+  - name: ephemeral
+    emptyDir: {}
+```
+
+## topo-imagery/create-collection - `tpl-ti-create-collection`
+
+Template for TIFF standardisation and non-visual QA.
+
+See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/scripts/collection_from_items.py)
+
+### Template usage
+```yaml
+- name: create-collection
+  templateRef:
+    name: tpl-ti-create-collection
+    template: main
+  arguments:
+    parameters:
+      - name: collection_id
+        value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
+      - name: linz_slug
+        value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
+      - name: odr_url
+        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+      - name: location
+        value: '{{tasks.get-location.outputs.parameters.location}}'
+      - name: current_datetime
+        value: '{{tasks.stac-setup.finishedAt}}'
+      - name: category
+        value: '{{=sprig.trim(workflow.parameters.category)}}'
+      - name: region
+        value: '{{=sprig.trim(workflow.parameters.region)}}'
+      - name: gsd
+        value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+      - name: geographic_description
+        value: '{{=sprig.trim(workflow.parameters.geographic_description)}}'
+      - name: event
+        value: '{{=sprig.trim(workflow.parameters.event)}}'
+      - name: historic_survey_number
+        value: '{{=sprig.trim(workflow.parameters.historic_survey_number)}}'
+      - name: lifecycle
+        value: '{{=sprig.trim(workflow.parameters.lifecycle)}}'
+      - name: producer
+        value: '{{workflow.parameters.producer}}'
+      - name: producer_list
+        value: '{{=sprig.trim(workflow.parameters.producer_list)}}'
+      - name: licensor
+        value: '{{workflow.parameters.licensor}}'
+      - name: licensor_list
+        value: '{{=sprig.trim(workflow.parameters.licensor_list)}}'
+      - name: version
+        value: '{{= workflow.parameters.version_argo_tasks}}'

--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -12,6 +12,7 @@ Template for TIFF standardisation and non-visual QA.
 See [standardise_validate.py](https://github.com/linz/topo-imagery/blob/master/scripts/standardise_validate.py)
 
 ### Template usage
+
 ```yaml
 - name: standardise-validate
   templateRef:
@@ -67,6 +68,7 @@ Template for TIFF standardisation and non-visual QA.
 See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/scripts/collection_from_items.py)
 
 ### Template usage
+
 ```yaml
 - name: create-collection
   templateRef:
@@ -108,3 +110,4 @@ See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/
         value: '{{=sprig.trim(workflow.parameters.licensor_list)}}'
       - name: version
         value: '{{= workflow.parameters.version_argo_tasks}}'
+```

--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -63,7 +63,8 @@ volumes:
 
 ## topo-imagery/create-collection - `tpl-ti-create-collection`
 
-Template for TIFF standardisation and non-visual QA.
+Template for creating a STAC collection from existing STAC items and asset TIFFs.
+If TIFF footprint files exist, a `capture-area.geojson` output artifact will be created.
 
 See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/scripts/collection_from_items.py)
 

--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -22,14 +22,16 @@ See [standardise_validate.py](https://github.com/linz/topo-imagery/blob/master/s
     parameters:
       - name: group_id
         value: '{{item}}'
-      - name: odr_url
-        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
       - name: collection_id
         value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
-      - name: compression
-        value: '{{= workflow.parameters.compression}}'
       - name: current_datetime
         value: '{{tasks.stac-setup.finishedAt}}'
+      - name: target
+        value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+      - name: compression
+        value: '{{= workflow.parameters.compression}}'
+      - name: odr_url
+        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
       - name: start_datetime
         value: '{{=sprig.trim(workflow.parameters.start_datetime)}}'
       - name: end_datetime
@@ -40,8 +42,6 @@ See [standardise_validate.py](https://github.com/linz/topo-imagery/blob/master/s
         value: '{{=sprig.trim(workflow.parameters.cutline)}}'
       - name: gsd
         value: '{{=sprig.trim(workflow.parameters.gsd)}}'
-      - name: target
-        value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
       - name: source_epsg
         value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
       - name: target_epsg
@@ -80,12 +80,12 @@ See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/
         value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
       - name: linz_slug
         value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
-      - name: odr_url
-        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
       - name: location
         value: '{{tasks.get-location.outputs.parameters.location}}'
       - name: current_datetime
         value: '{{tasks.stac-setup.finishedAt}}'
+      - name: odr_url
+        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
       - name: category
         value: '{{=sprig.trim(workflow.parameters.category)}}'
       - name: region

--- a/templates/topo-imagery/create-collection.yml
+++ b/templates/topo-imagery/create-collection.yml
@@ -1,0 +1,138 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from https://github.com/linz/topo-imagery
+  # see https://github.com/linz/topo-imagery/blob/master/scripts/collection_from_items.py
+  name: tpl-ti-create-collection
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: version_topo_imagery
+            description: version of topo-imagery to use
+            default: 'v7'
+
+          - name: collection_id
+            description: 'Collection ID of existing dataset, or else a generated collection ID'
+            default: ''
+
+          - name: linz_slug
+            description: 'Dataset identifying slug'
+            default: ''
+
+          - name: odr_url
+            description: '(Optional) If an existing dataset add the S3 path to the dataset here to load existing metadata e.g. "s3://nz-imagery/taranaki/new-plymouth_2017_0.1m/rgb/2193/"'
+            default: ''
+
+          - name: location
+            description: 'Location for output files'
+            default: ''
+
+          - name: current_datetime
+            description: 'Current date and time of the workflow'
+            default: ''
+
+          - name: category
+            description: 'Geospatial category of the dataset'
+            default: ''
+
+          - name: region
+            description: 'Region of the dataset'
+            default: ''
+
+          - name: gsd
+            description: 'Dataset GSD in metres, e.g., "0.3" for 30 centimetres'
+            default: ''
+
+          - name: geographic_description
+            description: '(Optional) Additional dataset description, to be used in the title in place of the Region, e.g. "Hamilton"'
+            default: ''
+
+          - name: event
+            description: '(Optional) Event name if dataset has been captured in association with an event, e.g. "Top of the South Floods"'
+            default: ''
+
+          - name: historic_survey_number
+            description: '(Optional) Survey Number associated with historical datasets, e.g. "SN8844"'
+            default: ''
+
+          - name: lifecycle
+            description: 'The release lifecycle status of the dataset, e.g. "completed or "ongoing"'
+            default: ''
+
+          - name: producer
+            description: 'The producer of the source dataset, e.g. aerial or bathymetric survey company'
+            default: ''
+
+          - name: producer_list
+            description: '(Optional) List of imagery producers, separated by semicolon (;). Has no effect unless a semicolon delimited list is entered.'
+            default: ''
+
+          - name: licensor
+            description: 'The licensor of the dataset, e.g. local or regional council, government agency, satellite provider'
+            default: ''
+
+          - name: licensor_list
+            description: '(Optional) List of imagery licensors, separated by semicolon (;). Has no effect unless a semicolon delimited list is entered.'
+            default: ''
+
+      outputs:
+        artifacts:
+          - name: capture-area
+            path: '/tmp/capture-area.geojson'
+            optional: true
+            archive:
+              none: {}
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(inputs.parameters.version_topo_imagery)}}'
+        args:
+          - python
+          - '/app/scripts/collection_from_items.py'
+          - '--uri'
+          - '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/'
+          - '--collection-id'
+          - '{{inputs.parameters.collection_id}}'
+          - '--linz-slug'
+          - '{{inputs.parameters.linz_slug}}'
+          - '--odr-url'
+          - '{{=sprig.trim(inputs.parameters.odr_url)}}'
+          - '--category'
+          - '{{=sprig.trim(inputs.parameters.category)}}'
+          - '--region'
+          - '{{=sprig.trim(inputs.parameters.region)}}'
+          - '--gsd'
+          - '{{=sprig.trim(inputs.parameters.gsd)}}'
+          - '--geographic-description'
+          - '{{=sprig.trim(inputs.parameters.geographic_description)}}'
+          - '--event'
+          - '{{=sprig.trim(inputs.parameters.event)}}'
+          - '--historic-survey-number'
+          - '{{=sprig.trim(inputs.parameters.historic_survey_number)}}'
+          - '--lifecycle'
+          - '{{=sprig.trim(inputs.parameters.lifecycle)}}'
+          - '--add-title-suffix'
+          - '--producer'
+          - '{{inputs.parameters.producer}}'
+          - '--producer-list'
+          - '{{=sprig.trim(inputs.parameters.producer_list)}}'
+          - '--licensor'
+          - '{{inputs.parameters.licensor}}'
+          - '--licensor-list'
+          - '{{=sprig.trim(inputs.parameters.licensor_list)}}'
+          - '--concurrency'
+          - '25'
+          - '--current-datetime'
+          - '{{inputs.parameters.current_datetime}}'
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 15000m

--- a/templates/topo-imagery/standardise-validate.yml
+++ b/templates/topo-imagery/standardise-validate.yml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from https://github.com/linz/topo-imagery
+  # see https://github.com/linz/topo-imagery/blob/master/scripts/standardise_validate.py
+  name: tpl-ti-standardise-validate
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: version_topo_imagery
+            description: version of topo-imagery to use
+            default: 'v7'
+
+          - name: group_id
+            description: 'The ID of the group of files to use as the input.'
+            default: ''
+
+          - name: odr_url
+            description: '(Optional) If an existing dataset add the S3 path to the dataset here to load existing metadata e.g. "s3://nz-imagery/taranaki/new-plymouth_2017_0.1m/rgb/2193/"'
+            default: ''
+
+          - name: target
+            description: 'Location for output files'
+            default: ''
+
+          - name: collection_id
+            description: 'Collection ID of existing dataset, or else a generated collection ID'
+            default: ''
+
+          - name: compression
+            description: 'Compression type to use when standardising TIFFs, e.g. "webp" for imagery or "dem_lerc" for elevation data'
+            default: ''
+
+          - name: current_datetime
+            description: 'Current date and time of the workflow'
+            default: ''
+
+          - name: start_datetime
+            description: 'Dataset capture start date in numeric format YYYY-MM-DD, e.g. "2024-01-14"'
+            default: ''
+
+          - name: end_datetime
+            description: 'Dataset capture end date in numeric format YYYY-MM-DD, e.g. "2024-02-23"'
+            default: ''
+
+          - name: create_capture_area
+            description: 'Create a capture area GeoJSON file for the standardised dataset'
+            default: ''
+
+          - name: cutline
+            description: '(Optional) location of a cutline file to cut the imagery to .fgb or .geojson'
+            default: ''
+
+          - name: gsd
+            description: 'Dataset GSD in metres, e.g., "0.3" for 30 centimetres'
+            default: ''
+
+          - name: source_epsg
+            description: 'EPSG of the source files'
+            default: '2193'
+
+          - name: target_epsg
+            description: 'EPSG of the standardised output files'
+            default: '2193'
+
+        artifacts:
+          - name: group_data
+            path: /tmp/input/
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(inputs.parameters.version_topo_imagery)}}'
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          - python
+          - '/app/scripts/standardise_validate.py'
+          - '--from-file'
+          - '/tmp/input/{{inputs.parameters.group_id}}.json'
+          - '--target'
+          - '{{inputs.parameters.target}}'
+          - '--preset'
+          - '{{inputs.parameters.compression}}'
+          - '--start-datetime'
+          - '{{=sprig.trim(inputs.parameters.start_datetime)}}'
+          - '--end-datetime'
+          - '{{=sprig.trim(inputs.parameters.end_datetime)}}'
+          - '--collection-id'
+          - '{{inputs.parameters.collection_id}}'
+          - '--create-footprints'
+          - '{{workflow.parameters.create_capture_area}}'
+          - '--cutline'
+          - '{{=sprig.trim(inputs.parameters.cutline)}}'
+          - '--source-epsg'
+          - '{{=sprig.trim(inputs.parameters.source_epsg)}}'
+          - '--target-epsg'
+          - '{{=sprig.trim(inputs.parameters.target_epsg)}}'
+          - '--gsd'
+          - '{{=sprig.trim(inputs.parameters.gsd)}}'
+          - '--odr-url'
+          - '{{=sprig.trim(inputs.parameters.odr_url)}}'
+          - '--current-datetime'
+          - '{{inputs.parameters.current_datetime}}'
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 15000m
+            ephemeral-storage: 29.5Gi
+        volumeMounts:
+          # This volume must be defined in the workflow calling this workflowTemplate
+          - name: ephemeral
+            mountPath: '/tmp'

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -406,17 +406,39 @@ spec:
             depends: 'tile-index-validate'
 
           - name: standardise-validate
-            template: standardise-validate
+            templateRef:
+              name: tpl-ti-standardise-validate
+              template: main
             arguments:
               parameters:
                 - name: group_id
                   value: '{{item}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: collection_id
                   value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
+                - name: compression
+                  value: '{{= workflow.parameters.compression}}'
                 - name: current_datetime
                   value: '{{tasks.stac-setup.finishedAt}}'
+                - name: start_datetime
+                  value: '{{=sprig.trim(workflow.parameters.start_datetime)}}'
+                - name: end_datetime
+                  value: '{{=sprig.trim(workflow.parameters.end_datetime)}}'
+                - name: create_capture_area
+                  value: '{{=sprig.trim(workflow.parameters.create_capture_area)}}'
+                - name: cutline
+                  value: '{{=sprig.trim(workflow.parameters.cutline)}}'
+                - name: gsd
+                  value: '{{=sprig.trim(workflow.parameters.gsd)}}'
                 - name: target
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+                - name: source_epsg
+                  value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
+                - name: target_epsg
+                  value: '{{=sprig.trim(workflow.parameters.target_epsg)}}'
+                - name: version
+                  value: '{{= workflow.parameters.version_topo_imagery}}'
               artifacts:
                 - name: group_data
                   from: '{{ tasks.group.outputs.artifacts.output }}'
@@ -424,17 +446,45 @@ spec:
             withParam: '{{ tasks.group.outputs.parameters.output }}'
 
           - name: create-collection
-            template: create-collection
+            templateRef:
+              name: tpl-ti-create-collection
+              template: main
             arguments:
               parameters:
                 - name: collection_id
                   value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
                 - name: linz_slug
                   value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: location
                   value: '{{tasks.get-location.outputs.parameters.location}}'
                 - name: current_datetime
                   value: '{{tasks.stac-setup.finishedAt}}'
+                - name: category
+                  value: '{{=sprig.trim(workflow.parameters.category)}}'
+                - name: region
+                  value: '{{=sprig.trim(workflow.parameters.region)}}'
+                - name: gsd
+                  value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+                - name: geographic_description
+                  value: '{{=sprig.trim(workflow.parameters.geographic_description)}}'
+                - name: event
+                  value: '{{=sprig.trim(workflow.parameters.event)}}'
+                - name: historic_survey_number
+                  value: '{{=sprig.trim(workflow.parameters.historic_survey_number)}}'
+                - name: lifecycle
+                  value: '{{=sprig.trim(workflow.parameters.lifecycle)}}'
+                - name: producer
+                  value: '{{workflow.parameters.producer}}'
+                - name: producer_list
+                  value: '{{=sprig.trim(workflow.parameters.producer_list)}}'
+                - name: licensor
+                  value: '{{workflow.parameters.licensor}}'
+                - name: licensor_list
+                  value: '{{=sprig.trim(workflow.parameters.licensor_list)}}'
+                - name: version
+                  value: '{{= workflow.parameters.version_argo_tasks}}'
             depends: 'standardise-validate'
 
           - name: stac-validate
@@ -501,119 +551,6 @@ spec:
             valueFrom:
               parameter: '{{tasks.get-location.outputs.parameters.location}}'
       # END TEMPLATE `main`
-
-    - name: standardise-validate
-      nodeSelector:
-        karpenter.sh/capacity-type: 'spot'
-      inputs:
-        parameters:
-          - name: group_id
-          - name: collection_id
-          - name: current_datetime
-          - name: target
-        artifacts:
-          - name: group_data
-            path: /tmp/input/
-      container:
-        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(workflow.parameters.version_topo_imagery)}}'
-        resources:
-          requests:
-            memory: 7.8Gi
-            cpu: 15000m
-            ephemeral-storage: 29.5Gi
-        volumeMounts:
-          - name: ephemeral
-            mountPath: '/tmp'
-        args:
-          - python
-          - '/app/scripts/standardise_validate.py'
-          - '--from-file'
-          - '/tmp/input/{{inputs.parameters.group_id}}.json'
-          - '--target'
-          - '{{inputs.parameters.target}}'
-          - '--preset'
-          - '{{workflow.parameters.compression}}'
-          - '--start-datetime'
-          - '{{=sprig.trim(workflow.parameters.start_datetime)}}'
-          - '--end-datetime'
-          - '{{=sprig.trim(workflow.parameters.end_datetime)}}'
-          - '--collection-id'
-          - '{{inputs.parameters.collection_id}}'
-          - '--create-footprints'
-          - '{{workflow.parameters.create_capture_area}}'
-          - '--cutline'
-          - '{{=sprig.trim(workflow.parameters.cutline)}}'
-          - '--source-epsg'
-          - '{{=sprig.trim(workflow.parameters.source_epsg)}}'
-          - '--target-epsg'
-          - '{{=sprig.trim(workflow.parameters.target_epsg)}}'
-          - '--gsd'
-          - '{{=sprig.trim(workflow.parameters.gsd)}}'
-          - '--odr-url'
-          - '{{=sprig.trim(workflow.parameters.odr_url)}}'
-          - '--current-datetime'
-          - '{{inputs.parameters.current_datetime}}'
-
-    - name: create-collection
-      nodeSelector:
-        karpenter.sh/capacity-type: 'spot'
-      inputs:
-        parameters:
-          - name: collection_id
-          - name: linz_slug
-          - name: location
-          - name: current_datetime
-      outputs:
-        artifacts:
-          - name: capture-area
-            path: '/tmp/capture-area.geojson'
-            optional: true
-            archive:
-              none: {}
-      container:
-        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/topo-imagery:{{=sprig.trim(workflow.parameters.version_topo_imagery)}}'
-        resources:
-          requests:
-            memory: 7.8Gi
-            cpu: 15000m
-        args:
-          - python
-          - '/app/scripts/collection_from_items.py'
-          - '--uri'
-          - '{{=sprig.trimSuffix("/", inputs.parameters.location)}}/flat/'
-          - '--collection-id'
-          - '{{inputs.parameters.collection_id}}'
-          - '--linz-slug'
-          - '{{inputs.parameters.linz_slug}}'
-          - '--odr-url'
-          - '{{=sprig.trim(workflow.parameters.odr_url)}}'
-          - '--category'
-          - '{{=sprig.trim(workflow.parameters.category)}}'
-          - '--region'
-          - '{{=sprig.trim(workflow.parameters.region)}}'
-          - '--gsd'
-          - '{{=sprig.trim(workflow.parameters.gsd)}}'
-          - '--geographic-description'
-          - '{{=sprig.trim(workflow.parameters.geographic_description)}}'
-          - '--event'
-          - '{{=sprig.trim(workflow.parameters.event)}}'
-          - '--historic-survey-number'
-          - '{{=sprig.trim(workflow.parameters.historic_survey_number)}}'
-          - '--lifecycle'
-          - '{{=sprig.trim(workflow.parameters.lifecycle)}}'
-          - '--add-title-suffix'
-          - '--producer'
-          - '{{workflow.parameters.producer}}'
-          - '--producer-list'
-          - '{{=sprig.trim(workflow.parameters.producer_list)}}'
-          - '--licensor'
-          - '{{workflow.parameters.licensor}}'
-          - '--licensor-list'
-          - '{{=sprig.trim(workflow.parameters.licensor_list)}}'
-          - '--concurrency'
-          - '25'
-          - '--current-datetime'
-          - '{{inputs.parameters.current_datetime}}'
 
     - name: create-overview
       inputs:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -413,14 +413,16 @@ spec:
               parameters:
                 - name: group_id
                   value: '{{item}}'
-                - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: collection_id
                   value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
-                - name: compression
-                  value: '{{= workflow.parameters.compression}}'
                 - name: current_datetime
                   value: '{{tasks.stac-setup.finishedAt}}'
+                - name: target
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                - name: compression
+                  value: '{{= workflow.parameters.compression}}'
                 - name: start_datetime
                   value: '{{=sprig.trim(workflow.parameters.start_datetime)}}'
                 - name: end_datetime
@@ -431,8 +433,6 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.cutline)}}'
                 - name: gsd
                   value: '{{=sprig.trim(workflow.parameters.gsd)}}'
-                - name: target
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: source_epsg
                   value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
                 - name: target_epsg
@@ -455,12 +455,12 @@ spec:
                   value: '{{tasks.stac-setup.outputs.parameters.collection_id}}'
                 - name: linz_slug
                   value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
-                - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: location
                   value: '{{tasks.get-location.outputs.parameters.location}}'
                 - name: current_datetime
                   value: '{{tasks.stac-setup.finishedAt}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: category
                   value: '{{=sprig.trim(workflow.parameters.category)}}'
                 - name: region


### PR DESCRIPTION
#### Motivation

The [standardise-validate](https://github.com/linz/topo-imagery/blob/master/scripts/standardise_validate.py) and [create-collection](https://github.com/linz/topo-imagery/blob/master/scripts/collection_from_items.py) commands need to be used by multiple workflows, as we are now publishing multiple products such as a National DEM and National Hillshades.

#### Modification

Create separate WorkflowTemplates for `standardise-validate` and `create-collection`.

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
