### PR TITLE
feat: suspend national dem cron until the process works TDE-1359

### DIFF
--- a/workflows/cron/cron-national-dem.yaml
+++ b/workflows/cron/cron-national-dem.yaml
@@ -12,7 +12,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  suspend: false
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1130'


### PR DESCRIPTION
#### Motivation

The National DEM cron workflow is based on the fact that an existing dataset can be updated without reprocessing the entire dataset (existing files + new files). We don't want to remove this workflow but only suspending it until the updating feature get released.
Suspending it on the deployed cron workflow has the limitation that when a PR get merged to this repo, all the workflows get re-deployed, removing the suspend flag...

#### Modification

Hardcode the suspend flag until the updating feature is released.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
