### PR TITLE
feat: validate STAC of only updated files TDE-1359

### DIFF
--- a/workflows/cron/cron-stac-validate-full.yaml
+++ b/workflows/cron/cron-stac-validate-full.yaml
@@ -29,6 +29,10 @@ spec:
           value: 'true'
         - name: 'checksum_links'
           value: 'true'
+        - name: 'recursive'
+          value: 'true'
+        - name: 'concurrency'
+          value: '1'
     templates:
       - name: main
         retryStrategy:
@@ -50,6 +54,10 @@ spec:
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
                     value: '{{workflow.parameters.checksum_links}}'
+                  - name: 'recursive'
+                    value: '{{workflow.parameters.recursive}}'
+                  - name: 'concurrency'
+                    value: '{{workflow.parameters.concurrency}}'
             - name: stac-validate-elevation
               templateRef:
                 name: stac-validate-parallel
@@ -66,6 +74,10 @@ spec:
                     value: '{{workflow.parameters.checksum_assets}}'
                   - name: 'checksum_links'
                     value: '{{workflow.parameters.checksum_links}}'
+                  - name: 'recursive'
+                    value: '{{workflow.parameters.recursive}}'
+                  - name: 'concurrency'
+                    value: '{{workflow.parameters.concurrency}}'
       - name: exit-handler
         retryStrategy:
           limit: '0' # `tpl-exit-handler` retries itself

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -126,7 +126,13 @@ graph TD;
     tileindex-validate-->standardise-validate;
     standardise-validate-->create-collection;
     standardise-validate-->create-overview;
-    create-collection-->stac-validate-.->|publish_to_odr == true|publish-odr;
+
+    create-collection-->|odr_url == ''|stac-validate-all;
+    create-collection-->|odr_url != ''|stac-validate-only-updated;
+
+    stac-validate-all-.->|publish_to_odr == true|publish-odr;
+    stac-validate-only-updated-.->|publish_to_odr == true|publish-odr;
+
     create-overview-.->|compression != dem_lerc|create-config-.->|publish_to_odr == true|publish-odr;
 ```
 

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -194,7 +194,7 @@ spec:
                   value: '{{= workflow.parameters.version_topo_imagery}}'
             depends: 'standardise-validate.Succeeded'
 
-          - name: stac-validate
+          - name: stac-validate-all
             templateRef:
               name: tpl-at-stac-validate
               template: main
@@ -205,13 +205,13 @@ spec:
               artifacts:
                 - name: stac-result
                   raw:
-                    data: '{{tasks.stac-validate.outputs.result}}'
+                    data: '{{tasks.stac-validate-all.outputs.result}}'
             depends: 'create-collection.Succeeded'
             when: "'{{workflow.parameters.odr_url}}' == ''"
-          
+
           - name: stac-validate-only-updated
             templateRef:
-              name: tpl-at-stac-validate
+              name: stac-validate-parallel # Needs to validate a list of STAC documents
               template: main
             arguments:
               parameters:
@@ -219,10 +219,14 @@ spec:
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: recursive
                   value: 'false' # The Collection might have some Items that are only in the published location
-              artifacts:
-                - name: stac-result
-                  raw:
-                    data: '{{tasks.stac-validate.outputs.result}}'
+                - name: checksum_links
+                  value: 'false'
+                - name: checksum_assets
+                  value: 'true'
+                - name: include
+                  value: '\.json$' # FIXME: For now, assuming we have only STAC as JSON files in the scratch location
+                - name: concurrency
+                  value: '50'
             depends: 'create-collection.Succeeded'
             when: "'{{workflow.parameters.odr_url}}' != ''"
 

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -171,6 +171,24 @@ spec:
                   raw:
                     data: '{{tasks.stac-validate.outputs.result}}'
             depends: 'create-collection.Succeeded'
+            when: "'{{workflow.parameters.odr_url}}' == ''"
+          
+          - name: stac-validate-only-updated
+            templateRef:
+              name: tpl-at-stac-validate
+              template: main
+            arguments:
+              parameters:
+                - name: uri
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+                - name: recursive
+                  value: 'false' # The Collection might have some Items that are only in the published location
+              artifacts:
+                - name: stac-result
+                  raw:
+                    data: '{{tasks.stac-validate.outputs.result}}'
+            depends: 'create-collection.Succeeded'
+            when: "'{{workflow.parameters.odr_url}}' != ''"
 
           - name: create-config
             arguments:

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -257,7 +257,7 @@ spec:
                   value: '{{workflow.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
-            depends: 'stac-validate.Succeeded && create-config.Succeeded'
+            depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config.Succeeded'
 
       outputs:
         parameters:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -489,7 +489,7 @@ spec:
                   value: '{{= workflow.parameters.version_topo_imagery}}'
             depends: 'standardise-validate'
 
-          - name: stac-validate
+          - name: stac-validate-all
             templateRef:
               name: tpl-at-stac-validate
               template: main
@@ -500,13 +500,13 @@ spec:
               artifacts:
                 - name: stac-result
                   raw:
-                    data: '{{tasks.stac-validate.outputs.result}}'
+                    data: '{{tasks.stac-validate-all.outputs.result}}'
             depends: 'create-collection.Succeeded'
             when: "'{{workflow.parameters.odr_url}}' == ''"
-          
+
           - name: stac-validate-only-updated
             templateRef:
-              name: tpl-at-stac-validate
+              name: stac-validate-parallel # Needs to validate a list of STAC documents
               template: main
             arguments:
               parameters:
@@ -514,10 +514,14 @@ spec:
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: recursive
                   value: 'false' # The Collection might have some Items that are only in the published location
-              artifacts:
-                - name: stac-result
-                  raw:
-                    data: '{{tasks.stac-validate.outputs.result}}'
+                - name: checksum_links
+                  value: 'false'
+                - name: checksum_assets
+                  value: 'true'
+                - name: include
+                  value: '\.json$' # FIXME: For now, assuming we have only STAC as JSON files in the scratch location
+                - name: concurrency
+                  value: '50'
             depends: 'create-collection.Succeeded'
             when: "'{{workflow.parameters.odr_url}}' != ''"
 
@@ -563,7 +567,7 @@ spec:
                   value: '{{workflow.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
-            depends: 'stac-validate && create-config'
+            depends: '(stac-validate-all || stac-validate-only-updated) && create-config'
 
       outputs:
         parameters:

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -449,7 +449,25 @@ spec:
                 - name: stac-result
                   raw:
                     data: '{{tasks.stac-validate.outputs.result}}'
-            depends: 'create-collection'
+            depends: 'create-collection.Succeeded'
+            when: "'{{workflow.parameters.odr_url}}' == ''"
+          
+          - name: stac-validate-only-updated
+            templateRef:
+              name: tpl-at-stac-validate
+              template: main
+            arguments:
+              parameters:
+                - name: uri
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
+                - name: recursive
+                  value: 'false' # The Collection might have some Items that are only in the published location
+              artifacts:
+                - name: stac-result
+                  raw:
+                    data: '{{tasks.stac-validate.outputs.result}}'
+            depends: 'create-collection.Succeeded'
+            when: "'{{workflow.parameters.odr_url}}' != ''"
 
           - name: get-location
             templateRef:

--- a/workflows/stac/README.md
+++ b/workflows/stac/README.md
@@ -1,6 +1,6 @@
 # stac-validate-parallel
 
-This Workflow will validate each collection (and linked items/assets) in a separate pod so that multiple collections can be processed in parallel, using the `tpl-at-stac-validate` template.
+This Workflow will validate each stac document (searched based on name, i.e. `collection.json$`) (and linked items/assets if options specified) in a separate pod so that multiple documents can be processed in parallel, using the `tpl-at-stac-validate` template.
 
 ## Workflow Outputs
 

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -35,6 +35,15 @@ spec:
         enum:
           - 'false'
           - 'true'
+      - name: recursive
+        description: 'Follow and validate STAC links'
+        value: 'true'
+        enum:
+          - 'false'
+          - 'true'
+      - name: concurrency
+        description: 'Number of parent STAC documents to be validated concurrently. Used to group the files by aws-list.'
+        value: '1'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -55,10 +64,14 @@ spec:
             value: '{{workflow.parameters.checksum_assets}}'
           - name: checksum_links
             value: '{{workflow.parameters.checksum_links}}'
+          - name: recursive
+            value: '{{workflow.parameters.recursive}}'
+          - name: concurrency
+            value: '{{workflow.parameters.concurrency}}'
       dag:
         tasks:
-          - name: aws-list-collections
-            template: aws-list-collections
+          - name: aws-list
+            template: aws-list
             arguments:
               parameters:
                 - name: version_argo_tasks
@@ -67,7 +80,9 @@ spec:
                   value: '{{inputs.parameters.include}}'
                 - name: uri
                   value: '{{inputs.parameters.uri}}'
-          - name: stac-validate-collections
+                - name: group
+                  value: '{{inputs.parameters.concurrency}}'
+          - name: stac-validate
             templateRef:
               name: tpl-at-stac-validate
               template: main
@@ -79,14 +94,17 @@ spec:
                   value: '{{inputs.parameters.checksum_assets}}'
                 - name: checksum_links
                   value: '{{inputs.parameters.checksum_links}}'
-            depends: aws-list-collections
-            withParam: '{{tasks.aws-list-collections.outputs.parameters.files}}'
-    - name: aws-list-collections
+                - name: recursive
+                  value: '{{inputs.parameters.recursive}}'
+            depends: aws-list
+            withParam: '{{tasks.aws-list.outputs.parameters.files}}'
+    - name: aws-list
       inputs:
         parameters:
           - name: version_argo_tasks
           - name: include
           - name: uri
+          - name: group
       retryStrategy:
         limit: '2' # force retrying this specific task
       container:
@@ -102,7 +120,7 @@ spec:
             '--include',
             '{{=sprig.trim(inputs.parameters.include)}}',
             '--group',
-            '1',
+            '{{=sprig.trim(inputs.parameters.group)}}',
             '--output',
             '/tmp/file_list.json',
             '{{=sprig.trim(inputs.parameters.uri)}}',


### PR DESCRIPTION
#### Motivation

When updating an existing Collection, some `links` `item` (the ones not updated) may not be located in the scratch (or `*/flat/`) directory. This causes a recursive stac-validation on the Collection to fail (the system can't locate the linked Items as their path is relative). This PR takes the approach of validating the Collection not recursively (excluding its links) and validating every single STAC Items that have been created and saved in the scratch directory during the process. _The already published STAC documents are validated on a regular basis._

#### Modification

- Allow `stac-validate-parallel` to validate any file, not only Collections
- A temporary solution of validating any JSON files has been implemented as the scratch directory has only STAC document as JSON files. This could be fixed by allowing the [`stac-validate` command](https://github.com/linz/argo-tasks/tree/master/src/commands/stac-validate) to validate a path to a directory and filtering STAC documents before validation.
- Condition the STAC validation based on the `odr_url` value: if not empty, that is a re-supply and we should not validate the Collection recursively but use the other approach.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
