### PR TITLE
feat: Add includeDerived to tileindex-validate

### DIFF
--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -31,6 +31,10 @@ spec:
             description: Limit the input list to this regexp
             default: ''
 
+          - name: includeDerived
+            description: Sets includeDerived=true/false in file-list.json
+            default: 'false'
+
           - name: validate
             description: Validate that all input tiffs perfectly align to tile grid
             default: 'true'
@@ -85,6 +89,7 @@ spec:
           - '--preset={{= inputs.parameters.preset }}'
           - "{{= sprig.empty(inputs.parameters.source_epsg) ? '' : '--source-epsg=' + inputs.parameters.source_epsg }}"
           - "{{= sprig.empty(inputs.parameters.include) ? '' : '--include=' + inputs.parameters.include }}"
+          - '--includeDerived={{= inputs.parameters.includeDerived }}'
           - '{{= sprig.trim(inputs.parameters.source) }}'
         resources:
           requests:


### PR DESCRIPTION
#### Motivation

Expose new CLI args for `tileindex-validate` from Argo Tasks through the respective workflow

#### Modification

Added input parameter with default value to make this a non-breaking change.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
