### PR TITLE
feat: Add scale_to_resolution to standardise-validate

### DIFF
--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -43,6 +43,8 @@ See [standardise_validate.py](https://github.com/linz/topo-imagery/blob/master/s
         value: '{{=sprig.trim(workflow.parameters.cutline)}}'
       - name: gsd
         value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+      - name: scale_to_resolution
+        value: '{{=sprig.trim(workflow.parameters.scale_to_resolution)}}'
       - name: source_epsg
         value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
       - name: target_epsg

--- a/templates/topo-imagery/standardise-validate.yaml
+++ b/templates/topo-imagery/standardise-validate.yaml
@@ -64,6 +64,10 @@ spec:
             description: 'Dataset GSD in metres, e.g., "0.3" for 30 centimetres'
             default: ''
 
+          - name: scale_to_resolution
+            description: 'Scale output TIFFs to x,y resolution (e.g. 1,1 - leave blank for no scaling)'
+            default: ''
+
           - name: source_epsg
             description: 'EPSG of the source files'
             default: '2193'
@@ -110,6 +114,8 @@ spec:
           - '{{=sprig.trim(inputs.parameters.odr_url)}}'
           - '--current-datetime'
           - '{{inputs.parameters.current_datetime}}'
+          - '--scale-to-resolution'
+          - '{{=sprig.trim(inputs.parameters.scale_to_resolution)}}'
         resources:
           requests:
             memory: 7.8Gi


### PR DESCRIPTION
#### Motivation

Expose new CLI args for standardise_validate.py from topo-imagery in the workflow.

#### Modification

Added `scale_to_resolution` input parameter with default value to make this a non-breaking change.


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [x] Docs updated
- [ ] Issue linked in Title
