### PR TITLE
feat: Add keep_derived_from_links to standardise-validate TDE-1436

### DIFF
--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -45,6 +45,8 @@ See [standardise_validate.py](https://github.com/linz/topo-imagery/blob/master/s
         value: '{{=sprig.trim(workflow.parameters.gsd)}}'
       - name: scale_to_resolution
         value: '{{=sprig.trim(workflow.parameters.scale_to_resolution)}}'
+      - name: keep_derived_from_links
+        value: '{{=sprig.trim(workflow.parameters.keep_derived_from_links)}}'
       - name: source_epsg
         value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
       - name: target_epsg

--- a/templates/topo-imagery/standardise-validate.yaml
+++ b/templates/topo-imagery/standardise-validate.yaml
@@ -65,8 +65,12 @@ spec:
             default: ''
 
           - name: scale_to_resolution
-            description: 'Scale output TIFFs to x,y resolution (e.g. 1,1 - leave blank for no scaling)'
+            description: '(Optional) Scale output TIFFs to x,y resolution (e.g. 1,1 - leave blank for no scaling)'
             default: ''
+
+          - name: keep_derived_from_links
+            description: '(Optional) whether to keep derived_from links from source/parent file. Defaults to "false".'
+            default: 'false'
 
           - name: source_epsg
             description: 'EPSG of the source files'
@@ -116,6 +120,8 @@ spec:
           - '{{inputs.parameters.current_datetime}}'
           - '--scale-to-resolution'
           - '{{=sprig.trim(inputs.parameters.scale_to_resolution)}}'
+          - '--keep-derived-from-links'
+          - '{{=sprig.trim(inputs.parameters.keep_derived_from_links)}}'
         resources:
           requests:
             memory: 7.8Gi


### PR DESCRIPTION
#### Motivation
📢  Do not merge before https://github.com/linz/topo-imagery/pull/1296 has been released. 📢 

_What does this change aim to achieve?_

#### Modification

_Why is this change being made? What implications or other considerations are there?_

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
