### PR TITLE
fix: location for create-collection is missing flat dir

### DIFF
--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -171,7 +171,7 @@ spec:
                 - name: linz_slug
                   value: '{{tasks.stac-setup.outputs.parameters.linz_slug}}'
                 - name: location
-                  value: '{{tasks.get-location.outputs.parameters.location}}'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: current_datetime
                   value: '{{tasks.stac-setup.finishedAt}}'
                 - name: odr_url


### PR DESCRIPTION
### Motivation

The `create-collection` task in the `national-dem` workflow is missing the `flat/` directory to be specified.

### Modifications

- specify the `flat/` directory in the location passed to `create-collection` template.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Argo Workflows
<!-- TODO: Say how you tested your changes. -->
