### PR TITLE
feat: turn national-dem cron job back on TDE-1440

### DIFF
--- a/workflows/cron/cron-national-dem.yaml
+++ b/workflows/cron/cron-national-dem.yaml
@@ -12,7 +12,6 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1130'


### PR DESCRIPTION
### Motivation

Updating an existing Collection had been fixed so we can turn this cron job back on.

### Modifications

- remove the `suspend` to be act to its default `false` value.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
