### PR TITLE
refactor: remove command override for containers that specifiy a entrypoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,6 @@ Environment variables can be set in the containers as below, which is setting th
 ```yaml
 container:
   image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:latest
-  command: [node, /app/index.js]
   env:
     - name: AWS_ROLE_CONFIG_PATH
       value: s3://linz-bucket-config/config.json

--- a/docs/training/examples/wf_output_parallel.yaml
+++ b/docs/training/examples/wf_output_parallel.yaml
@@ -43,7 +43,6 @@ spec:
           - name: include
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:v2'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/docs/training/workshop.md
+++ b/docs/training/workshop.md
@@ -513,7 +513,6 @@ spec:
           - name: include
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:v2'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -41,7 +41,6 @@ spec:
           requests:
             memory: 7.8Gi
             cpu: 2000m
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: '{{inputs.parameters.aws_role_config_path}},s3://linz-bucket-config/config.json'

--- a/templates/argo-tasks/generate-path.yml
+++ b/templates/argo-tasks/generate-path.yml
@@ -26,7 +26,6 @@ spec:
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{= inputs.parameters.version }}'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/templates/argo-tasks/group.yml
+++ b/templates/argo-tasks/group.yml
@@ -61,7 +61,6 @@ spec:
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{= inputs.parameters.version }}'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -44,7 +44,6 @@ spec:
               secretKeyRef:
                 name: github-linz-li-bot-pat
                 key: pat
-        command: [node, /app/index.js]
         args:
           [
             'stac',

--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -40,7 +40,6 @@ spec:
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=inputs.parameters.version}}'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/templates/argo-tasks/stac-validate.yml
+++ b/templates/argo-tasks/stac-validate.yml
@@ -46,7 +46,6 @@ spec:
           requests:
             cpu: 15000m
             memory: 7.8Gi
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -72,7 +72,6 @@ spec:
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=inputs.parameters.version}}'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -436,7 +436,6 @@ spec:
           - name: target
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -64,7 +64,6 @@ spec:
           - name: layer
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}
-        command: [node, index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
@@ -96,7 +95,6 @@ spec:
             path: /tmp/flatGeobuf.fgb
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}
-        command: [node, index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -146,7 +146,6 @@ spec:
           - name: target
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{ workflow.parameters.version_argo_tasks }}
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -222,7 +222,6 @@ spec:
           requests:
             cpu: 3000m
             memory: 7.8Gi
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -91,7 +91,6 @@ spec:
         limit: '2' # force retrying this specific task
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/workflows/test/flatten.yaml
+++ b/workflows/test/flatten.yaml
@@ -58,7 +58,6 @@ spec:
           - name: filter
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
@@ -91,5 +90,4 @@ spec:
           requests:
             memory: 7.8Gi
             cpu: 2000m
-        command: [node, /app/index.js]
         args: ['copy', '{{workflow.parameters.copy_option}}', '{{inputs.parameters.file}}']

--- a/workflows/test/list.arm.yaml
+++ b/workflows/test/list.arm.yaml
@@ -61,7 +61,6 @@ spec:
           - name: include
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{= workflow.parameters.version_argo_tasks }}
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json

--- a/workflows/test/list.yaml
+++ b/workflows/test/list.yaml
@@ -41,22 +41,16 @@ spec:
           - name: include
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
         args:
-          [
-            'list',
-            '--verbose',
-            '--include',
-            '{{inputs.parameters.include}}',
-            '--group',
-            '2',
-            '--output',
-            '/tmp/file_list.json',
-            '{{inputs.parameters.uri}}',
-          ]
+          - 'list'
+          - '--verbose'
+          - '--include={{inputs.parameters.include}}'
+          - '--group=2'
+          - '--output=/tmp/file_list.json'
+          - '{{inputs.parameters.uri}}'
       outputs:
         parameters:
           - name: files

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -54,7 +54,6 @@ spec:
     - name: aws-list
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json


### PR DESCRIPTION
### Motivation

Some containers specify a `ENTRYPOINT` by using "command" we override the entrypoint, argo-tasks is about to change its `ENTRYPOINT` which would require this repository to update too, however if we do not override the `ENTRYPOINT` here we when argo-tasks updates its entrypoint there will be no changes required here.


### Modifications

Remove all `command` overrides for `argo-tasks` 

### Verification

run a few testing workflows with and without the `command` ovveride.