### PR TITLE
fix: publish to ODR to accept odr_url TDE-1447

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -268,18 +268,23 @@ This workflow creates a GitHub pull request to be reviewed for publishing to `s3
 
 ```mermaid
 graph TD;
-  generate-path-->push-to-github;
+  subgraph "if **odr_url == &quot;&quot;**"
+    generate-path
+  end
+  generate-path --> push-to-github;
 ```
 
 ## Workflow Input Parameters
 
 | Parameter          | Type | Default                                | Description                                                                                                                                                                                                                 |
-| ------------------ | ---- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| ------------------ | ---- | -------------------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ticket             | str  |                                        | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
 | region             | enum |                                        | Region of the dataset                                                                                                                                                                                                       |
 | source             | str  | s3://linz-imagery-staging/test/sample/ | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
 | target_bucket_name | enum |                                        | The bucket name of the target location                                                                                                                                                                                      |     |
 | copy_option        | enum | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
+| odr_url | str | | s3 path to the existing dataset, if updating. Providing this will skip `generate_path` (i.e. ignore `target_bucket_name` etc) and publish to the provided location instead.                                                 |
+
 
 ## Examples
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -277,14 +277,13 @@ graph TD;
 ## Workflow Input Parameters
 
 | Parameter          | Type | Default                                | Description                                                                                                                                                                                                                 |
-| ------------------ | ---- | -------------------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------ | ---- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ticket             | str  |                                        | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
 | region             | enum |                                        | Region of the dataset                                                                                                                                                                                                       |
 | source             | str  | s3://linz-imagery-staging/test/sample/ | The URIs (paths) to the s3 source location                                                                                                                                                                                  |
-| target_bucket_name | enum |                                        | The bucket name of the target location                                                                                                                                                                                      |     |
+| target_bucket_name | enum |                                        | The bucket name of the target location                                                                                                                                                                                      |
 | copy_option        | enum | --no-clobber                           | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
-| odr_url | str | | s3 path to the existing dataset, if updating. Providing this will skip `generate_path` (i.e. ignore `target_bucket_name` etc) and publish to the provided location instead.                                                 |
-
+| odr_url            | str  |                                        | s3 path to the existing dataset, if updating. Providing this will skip `generate_path` (i.e. ignore `target_bucket_name` etc) and publish to the provided location instead.                                                 |
 
 ## Examples
 

--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -352,6 +352,8 @@ spec:
                   value: '{{inputs.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(inputs.parameters.ticket)}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(inputs.parameters.odr_url)}}'
             depends: 'stac-validate.Succeeded && create-config.Succeeded'
 
       outputs:

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -257,6 +257,8 @@ spec:
                   value: '{{workflow.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(inputs.parameters.odr_url)}}'
             depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config.Succeeded'
 
       outputs:

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -79,6 +79,9 @@ spec:
           - '--no-clobber'
           - '--force'
           - '--force-no-clobber'
+      - name: odr_url
+        description: '(Optional) URL of existing dataset to update. If provided, the target_bucket_name will be ignored.'
+        value: ''
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -93,9 +96,11 @@ spec:
           - name: source
           - name: target_bucket_name
           - name: ticket
+          - name: odr_url
       dag:
         tasks:
           - name: generate-path
+            when: '{{= inputs.parameters.odr_url == ""}}'
             templateRef:
               name: tpl-at-generate-path
               template: main
@@ -117,7 +122,7 @@ spec:
                 - name: source
                   value: '{{inputs.parameters.source}}'
                 - name: target
-                  value: '{{tasks.generate-path.outputs.parameters.target}}'
+                  value: '{{= inputs.parameters.odr_url == "" ? tasks["generate-path"].outputs.parameters.target : inputs.parameters.odr_url}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
                 - name: repository

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -567,6 +567,8 @@ spec:
                   value: '{{workflow.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(inputs.parameters.odr_url)}}'
             depends: '(stac-validate-all || stac-validate-only-updated) && create-config'
 
       outputs:


### PR DESCRIPTION
### Motivation

Publish to ODR workflow currently ignores the `odr_url` pointing to the existing dataset.

### Modifications

- Added `odr_url` input parameter to `publish-odr` workflow and made `generate-path` an optional step.
- Modified `standardising`, `national-dem` and `merge-layers` workflows to pass through `odr_url` when calling `publish-odr`.
- updated readme.

### Verification
Manual verification of modified `publish-odr` workflow.