### PR TITLE
fix: missing odr_url parameter

### DIFF
--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -264,6 +264,8 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.copy_option)}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
             depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config.Succeeded'
 
       outputs:


### PR DESCRIPTION
### Motivation

Github actions - argo linter failed:
```
workflows/raster/hillshade.yaml:
   ✖ in "hillshade" (WorkflowTemplate): templates.main.tasks.publish-odr failed to resolve {{inputs.parameters.odr_url}}
```
### Modifications

Added `odr_url` to publish_to_odr workflow step in hillshade.yaml

### Verification
`argo lint --offline templates/ workflows/`
