### PR TITLE
fix: pass odr_url to the hillshade task TDE-1452

### DIFF
--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -148,6 +148,8 @@ See [generate_hillshade.py](https://github.com/linz/topo-imagery/pull/1253)
         value: '{{=sprig.trim(workflow.parameters.gsd)}}'
       - name: current_datetime
         value: '{{tasks.stac-setup-hillshade.finishedAt}}'
+      - name: odr_url
+        value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
     artifacts:
       - name: group_data
         from: '{{tasks.group.outputs.artifacts.output}}'

--- a/templates/topo-imagery/generate-hillshade.yaml
+++ b/templates/topo-imagery/generate-hillshade.yaml
@@ -26,6 +26,10 @@ spec:
             description: 'The ID of the group of files to use as the input.'
             default: ''
 
+          - name: odr_url
+            description: '(Optional) The path of the published dataset. Example: "s3://nz-elevation/new-zealand/new-zealand/dem-hillshade_1m/2193/"'
+            default: ''
+
           - name: target
             description: 'Location for output files'
             default: ''
@@ -76,3 +80,5 @@ spec:
           - '{{inputs.parameters.gsd}}'
           - '--current-datetime'
           - '{{inputs.parameters.current_datetime}}'
+          - '--odr-url'
+          - '{{inputs.parameters.odr_url}}'

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -161,6 +161,8 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.gsd)}}'
                 - name: current_datetime
                   value: '{{tasks.stac-setup-hillshade.finishedAt}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
               artifacts:
                 - name: group_data
                   from: '{{tasks.group.outputs.artifacts.output}}'


### PR DESCRIPTION
### Motivation

When updating an existing hillshade dataset, the ODR URL needs to be passed to the `generate_hillshade.py` script so the update can be done rather than creating new STAC. Related to https://github.com/linz/topo-imagery/pull/1310

### Modifications

Pass ODR URL to the hillshade template

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
Submitted test workflow
