### PR TITLE
refactor: remove command override for containers that specifiy entrypoint

### DIFF
--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -69,7 +69,6 @@ spec:
 
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
-        command: [node, /app/index.js]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json


### PR DESCRIPTION
### Motivation

This one got missed here https://github.com/linz/topo-workflows/pull/985

Some containers specify a `ENTRYPOINT` by using "command" we override the entrypoint, argo-tasks is about to change its `ENTRYPOINT` which would require this repository to update too, however if we do not override the `ENTRYPOINT` here we when argo-tasks updates its entrypoint there will be no changes required here.


### Modifications

Remove all `command` overrides for `argo-tasks` 

### Verification

run a few testing workflows with and without the `command` ovveride.