### PR TITLE
feat: use `derived_from` checksum to see if tile needs re-creating TDE-1449

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -9,6 +9,7 @@
 - [Generate Path](##argo-tasks/generate-path)
 - [STAC setup](##argo-tasks/stac-setup)
 - [STAC validate](##argo-tasks/stac-validate)
+- [Identify updated items](##argo-tasks/identify-updated-items)
 
 ## argo-tasks/group - `tpl-at-group`
 
@@ -255,4 +256,45 @@ See (https://github.com/linz/argo-tasks#stac-validate)
         value: '{{workflow.parameters.recursive}}'
       - name: concurrency
         value: '20'
+```
+
+## argo-tasks/identify-updated-items
+
+Template to identify updated items in a STAC collection.
+The output is a `file-list.json` file containing the list of mapsheets/tiles (with all associated `derived_from` files) where at least one source (derived_from) item has been changed/added/removed compared to the optional targetCollection. If targetCollection has not been specified, all items will be considered "new".
+The format of `file-list.json` is equivalent to `mapsheet-coverage` and `tile-index-validate` outputs.
+
+### Template Usage
+
+```yaml
+- name: identify-updated-items
+  templateRef:
+    name: tpl-at-identify-updated-items
+    template: main
+  arguments:
+    parameters:
+      - name: targetCollection
+        value: '{{= inputs.parameters.odr_url == "" ? "" : sprig.trimSuffix("/", inputs.parameters.odr_url) + "/collection.json" }}'
+      - name: sourceCollections
+        value: '{{= inputs.parameters.base_layer_source == "" ? "" : sprig.trimSuffix("/", inputs.parameters.base_layer_source) + "/collection.json;" }}{{=sprig.trimSuffix("/", inputs.parameters.top_layer_source)}}/collection.json'
+      - name: version
+        value: '{{= inputs.parameters.version_argo_tasks}}'
+```
+
+Sample output:
+`file-list.json`
+
+```json
+[
+  {
+    "output": "BD31",
+    "input": ["s3://path/to/dem_8m/BD31.tiff", "s3://path/to/dem_1m/BD31.tiff"],
+    "includeDerived": true
+  },
+  {
+    "output": "BD32",
+    "input": ["s3://path/to/dem_8m/BD32.tiff", "s3://path/to/dem_1m/BD32.tiff"],
+    "includeDerived": true
+  }
+]
 ```

--- a/templates/argo-tasks/identify-updated-items.yaml
+++ b/templates/argo-tasks/identify-updated-items.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from linz/argo-tasks
+  # see https://github.com/linz/argo-tasks#tileindex-validate
+  name: tpl-at-identify-updated-items
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: targetCollection
+            description: collection.json file of the target collection
+            default: ''
+          - name: sourceCollections
+            description: List of source collection.json files (semicolon delimited)
+            default: ''
+          - name: version
+            description: 'Specify a version of the argo-tasks image to use, e.g. "v1.0" or "latest"'
+            default: 'v4'
+
+      outputs:
+        artifacts:
+          # List of tiff files that need to be processed
+          - name: files
+            path: /tmp/identify-updated-items/file-list.json
+            optional: true
+            archive:
+              none: {}
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=inputs.parameters.version}}'
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          - 'identify-updated-items'
+          - '--verbose'
+          - '{{= inputs.parameters.targetCollection == "" ? "" : "--target-collection=" + inputs.parameters.targetCollection }}'
+          - '{{= inputs.parameters.sourceCollections }}'

--- a/templates/argo-tasks/identify-updated-items.yaml
+++ b/templates/argo-tasks/identify-updated-items.yaml
@@ -4,7 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   # Template from linz/argo-tasks
-  # see https://github.com/linz/argo-tasks#tileindex-validate
+  # see https://github.com/linz/argo-tasks?tab=readme-ov-file#identify-updated-items
   name: tpl-at-identify-updated-items
 spec:
   templateDefaults:

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -83,6 +83,10 @@ spec:
             templateRef:
               name: tpl-get-location
               template: main
+            arguments:
+              parameters:
+                - name: version_argo_tasks
+                  value: '{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
 
           - name: stac-setup-hillshade
             templateRef:
@@ -101,30 +105,18 @@ spec:
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
 
-          - name: tile-index-validate
+          - name: identify-updated-items
             templateRef:
-              name: tpl-at-tile-index-validate
+              name: tpl-at-identify-updated-items
               template: main
             arguments:
               parameters:
-                - name: scale
-                  value: '50000'
-                - name: include
-                  value: '.tiff?$'
-                - name: source
-                  value: '{{=sprig.trim(workflow.parameters.source)}}'
-                - name: source_epsg
-                  value: '2193'
-                - name: validate
-                  value: 'false'
-                - name: retile
-                  value: 'true'
-                - name: preset
-                  value: 'dem_lerc'
+                - name: targetCollection
+                  value: '{{= workflow.parameters.odr_url == "" ? "" : sprig.trimSuffix("/", workflow.parameters.odr_url) + "/collection.json" }}'
+                - name: sourceCollections
+                  value: '{{=sprig.trimSuffix("/", workflow.parameters.source)}}/collection.json'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
-                - name: includeDerived
-                  value: 'true'
 
           - name: group
             templateRef:
@@ -133,13 +125,13 @@ spec:
             arguments:
               artifacts:
                 - name: input
-                  from: '{{ tasks.tile-index-validate.outputs.artifacts.files }}'
+                  from: '{{ tasks.identify-updated-items.outputs.artifacts.files }}'
               parameters:
                 - name: size
                   value: '{{=sprig.trim(workflow.parameters.group)}}'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
-            depends: 'tile-index-validate.Succeeded'
+            depends: 'identify-updated-items.Succeeded'
 
           - name: generate-hillshade
             templateRef:

--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -197,31 +197,18 @@ spec:
                 - name: version
                   value: '{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
 
-          - name: tile-index-validate
+          - name: identify-updated-items
             templateRef:
-              name: tpl-at-tile-index-validate
+              name: tpl-at-identify-updated-items
               template: main
             arguments:
               parameters:
-                - name: scale
-                  value: '{{inputs.parameters.scale}}'
-                - name: include
-                  value: '{{inputs.parameters.include}}'
-                - name: source # combine both base_layer_source and top_layer_source
-                  value: '{{= inputs.parameters.base_layer_source == "" ? "" : sprig.trimSuffix("/", inputs.parameters.base_layer_source) + "/;" }}{{=sprig.trimSuffix("/", inputs.parameters.top_layer_source)}}/'
-                - name: source_epsg
-                  value: '{{=sprig.trim(inputs.parameters.source_epsg)}}'
-                - name: validate
-                  value: 'false'
-                - name: retile
-                  value: 'true'
-                - name: preset
-                  value: '{{inputs.parameters.gdal_compression_preset}}'
+                - name: targetCollection
+                  value: '{{= inputs.parameters.odr_url == "" ? "" : sprig.trimSuffix("/", inputs.parameters.odr_url) + "/collection.json" }}'
+                - name: sourceCollections
+                  value: '{{= inputs.parameters.base_layer_source == "" ? "" : sprig.trimSuffix("/", inputs.parameters.base_layer_source) + "/collection.json;" }}{{=sprig.trimSuffix("/", inputs.parameters.top_layer_source)}}/collection.json'
                 - name: version
                   value: '{{= inputs.parameters.version_argo_tasks}}'
-                - name: includeDerived
-                  value: 'true'
-            depends: 'get-location.Succeeded && stac-setup.Succeeded'
 
           - name: group
             templateRef:
@@ -230,13 +217,13 @@ spec:
             arguments:
               artifacts:
                 - name: input
-                  from: '{{ tasks.tile-index-validate.outputs.artifacts.files }}'
+                  from: '{{ tasks.identify-updated-items.outputs.artifacts.files }}'
               parameters:
                 - name: size
                   value: '{{inputs.parameters.group}}'
                 - name: version
                   value: '{{= inputs.parameters.version_argo_tasks}}'
-            depends: 'tile-index-validate.Succeeded'
+            depends: 'identify-updated-items.Succeeded'
 
           - name: standardise-validate
             templateRef:
@@ -273,7 +260,7 @@ spec:
               artifacts:
                 - name: group_data
                   from: '{{ tasks.group.outputs.artifacts.output }}'
-            depends: 'group.Succeeded'
+            depends: 'group.Succeeded && get-location.Succeeded && stac-setup.Succeeded'
             withParam: '{{ tasks.group.outputs.parameters.output }}'
 
           - name: create-collection


### PR DESCRIPTION

#### Motivation

As a data maintainer, when updating a national DEM Hillshade, I would like to recreate the hillshade tiles only for the nationally combined DEM tiles that have changed from the previous update.

#### Modification

Added a workflow template `identify-updated-items` to call a new argo-workflows command (see https://github.com/linz/argo-tasks/pull/1207).

Updated existing workflows in `hillshade.yaml` and `merge-layers.yaml` to use the new template instead of `tile-index-validate`.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tested workflows manually
- [x] Docs updated
- [x] Issue linked in Title
