### PR TITLE
feat(basemaps): Add base zoom offset for the basemaps imagery import workflow

### DIFF
--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -170,7 +170,7 @@ spec:
       - name: background
         description: 'Background RGBA hexstring to fill empty space in the COG. Format: "#rrggbbaa"'
         value: ''
-      
+
       - name: base_zoom_offset
         description: 'Adjust the base zoom level of the output COGS, "-1" reduce the target output resolution by one zoom level'
         value: ''

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -170,6 +170,10 @@ spec:
       - name: background
         description: 'Background RGBA hexstring to fill empty space in the COG. Format: "#rrggbbaa"'
         value: ''
+      
+      - name: base_zoom_offset
+        description: 'Adjust the base zoom level of the output COGS, "-1" reduce the target output resolution by one zoom level'
+        value: ''
 
   templates:
     # Main entrypoint into the workflow
@@ -186,6 +190,7 @@ spec:
           - name: cutline_blend
           - name: group_size
           - name: require_stac_collection
+          - name: base_zoom_offset
           - name: background
       dag:
         tasks:
@@ -211,6 +216,8 @@ spec:
                   value: '{{ inputs.parameters.group_size }}'
                 - name: require_stac_collection
                   value: '{{ inputs.parameters.require_stac_collection }}'
+                - name: base_zoom_offset
+                  value: '{{ inputs.parameters.base_zoom_offset }}'
                 - name: background
                   value: '{{ inputs.parameters.background }}'
           - name: create-pull-request
@@ -234,6 +241,7 @@ spec:
           - name: group_size
           - name: preset
           - name: require_stac_collection
+          - name: base_zoom_offset
           - name: background
       dag:
         tasks:
@@ -254,6 +262,8 @@ spec:
                   value: '{{ inputs.parameters.cutline }}'
                 - name: cutline_blend
                   value: '{{ inputs.parameters.cutline_blend }}'
+                - name: base_zoom_offset
+                  value: '{{ inputs.parameters.base_zoom_offset }}'
                 - name: require_stac_collection
                   value: '{{ inputs.parameters.require_stac_collection }}'
                 - name: background
@@ -330,6 +340,7 @@ spec:
           - name: cutline_blend
           - name: preset
           - name: require_stac_collection
+          - name: base_zoom_offset
           - name: background
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
@@ -347,6 +358,7 @@ spec:
           - '--require-stac-collection={{ inputs.parameters.require_stac_collection }}'
           - "{{= sprig.empty(inputs.parameters.cutline) ? '' : '--cutline=' + inputs.parameters.cutline }}"
           - '--cutline-blend={{ inputs.parameters.cutline_blend }}'
+          - "{{= sprig.empty(inputs.parameters.base_zoom_offset) ? '' : '--base-zoom-offset=' + inputs.parameters.base_zoom_offset }}"
           - "{{= sprig.empty(inputs.parameters.background) ? '' : '--background=' + inputs.parameters.background }}"
           - '--target={{= sprig.trim(inputs.parameters.target) }}'
           - '{{= sprig.trim(inputs.parameters.source) }}'


### PR DESCRIPTION
### Motivation
We got a `base-zoom-offset` parameter in cogify cover command that help adjusting the base zoom level of the output COGS.
It should be helpful to include that parameter as optional setting for the imagery import workflow

### Modifications
Add optional `base_zoom_offset` workflow paramter

### Verification

Running workflow with the parameter that been used.
https://argo.linzaccess.com/workflows/argo/test-basemaps-imagery-import-cogify-base-zoom-offset-m28dw?tab=workflow&nodeId=test-basemaps-imagery-import-cogify-base-zoom-offset-m28dw-2458250471&nodePanelView=containers&uid=80836cfd-17a9-4da3-9def-3c656a8942ca

