### PR TITLE
fix: ODR URL is not passed to publish-odr task TDE-1459

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -568,7 +568,7 @@ spec:
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url
-                  value: '{{=sprig.trim(inputs.parameters.odr_url)}}'
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
             depends: '(stac-validate-all || stac-validate-only-updated) && create-config'
 
       outputs:


### PR DESCRIPTION
### Motivation

The `imagery-standardising` workflow is not passing the ODR URL properly to the `publish-odr` task. 

### Modifications

- pass the ODR URL from the workflow parameters.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
