### PR TITLE
feat: allow to keep title of existing Collection TDE-1444

### DIFF
--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -116,6 +116,8 @@ See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/
         value: '{{=sprig.trim(workflow.parameters.licensor_list)}}'
       - name: create_capture_dates
         value: 'false'
+      - name: keep_title
+        value: 'true'
       - name: version_topo_imagery
         value: '{{= workflow.parameters.version_argo_tasks}}'
 ```

--- a/templates/topo-imagery/create-collection.yaml
+++ b/templates/topo-imagery/create-collection.yaml
@@ -92,6 +92,10 @@ spec:
             description: 'Add a capture-dates.geojson.gz file to the collection assets'
             default: 'false'
 
+          - name: keep_title
+            description: 'Keep the title of the existing Collection'
+            default: 'false'
+
       outputs:
         artifacts:
           - name: capture-area
@@ -129,6 +133,8 @@ spec:
           - '{{=sprig.trim(inputs.parameters.lifecycle)}}'
           - '--add-title-suffix'
           - '{{inputs.parameters.add_title_suffix}}'
+          - '--keep-title'
+          - '{{inputs.parameters.keep_title}}'
           - '--capture-dates'
           - '{{inputs.parameters.create_capture_dates}}'
           - '--producer'

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -199,6 +199,8 @@ spec:
                   value: 'Toitū Te Whenua Land Information New Zealand'
                 - name: create_capture_dates
                   value: 'false'
+                - name: keep_title
+                  value: 'true'
                 - name: version_topo_imagery
                   value: '{{= workflow.parameters.version_topo_imagery}}'
             depends: 'generate-hillshade.Succeeded'

--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -190,6 +190,8 @@ spec:
                   value: 'Toitū Te Whenua Land Information New Zealand'
                 - name: create_capture_dates
                   value: 'true'
+                - name: keep_title
+                  value: 'true'
                 - name: version_topo_imagery
                   value: '{{= workflow.parameters.version_topo_imagery}}'
             depends: 'standardise-validate.Succeeded'


### PR DESCRIPTION
### Motivation

Some datasets, such as National DEM and National DEM Hillshades, get updated regularly but need their title to remain the same (for example they don't include dates, which are added by the automatic title generation).

### Modifications

- Pass the [`--keep-tile=true` parameter to the create-collection step](https://github.com/linz/topo-imagery/pull/1313)  when called by the `national-dem` and `hillshade` workflows. Default to `--keep-title=false`.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Manually ran Workflows.
