### PR TITLE
fix: odr_url not passed to publish-odr task in national-dem workflow TDE-1463

### DIFF
--- a/workflows/raster/national-dem.yaml
+++ b/workflows/raster/national-dem.yaml
@@ -260,7 +260,7 @@ spec:
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url
-                  value: '{{=sprig.trim(inputs.parameters.odr_url)}}'
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
             depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config.Succeeded'
 
       outputs:


### PR DESCRIPTION
### Motivation

The `national-dem` workflow is not passing the ODR URL properly to the publish-odr task.


### Modifications

Access the ODR URL from the workflow parameters instead of input parameters.


### Verification

<!-- TODO: Say how you tested your changes. -->
