### PR TITLE
feat: add DSM support to hillshade workflow TDE-1455

### DIFF
--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -399,6 +399,18 @@ Publishing to the AWS Registry of Open Data is an optional step [publish-odr](#P
 | publish_to_odr   | str  | false                                                  | Run [publish-odr](#Publish-odr) after standardising has completed successfully                                                                                                                                                                                    |
 | copy_option      | enum | --force-no-clobber                                     | Used only if `publish_to_odr` is true.<dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
 
+# hillshade-combinations
+
+This workflow calls `hillshade` to iterate over a provided list of geospatial elevation categories (DEM / DSM) and hillshade presets (hillshade / hillshade-igor) to easily create hillshades using Cron Workflows.
+
+Key parameters that differ from the `hillshade` workflow are `source_geospatial_categories` and `hillshade_presets`, which be iterated over to create multiple hillshades using each corresponding geospatial category and hillshade preset in the `hillshade` workflow.
+All other parameters will be passed through to the `hillshade` workflow without modification.
+
+| Parameter                    | Type | Default                         | Description                                                                          |
+| ---------------------------- | ---- | ------------------------------- | ------------------------------------------------------------------------------------ |
+| source_geospatial_categories | str  | ["dem", "dsm"]                  | Geospatial categories of the source elevation data as stringified json, e.g. ["dem"] |
+| hillshade_presets            | str  | ["hillshade-igor", "hillshade"] | Hillshade presets to use, as stringified json, e.g. ["hillshade"]                    |
+
 # Tests
 
 ## How To Use the Test Workflow

--- a/workflows/raster/hillshade-combinations.yaml
+++ b/workflows/raster/hillshade-combinations.yaml
@@ -1,0 +1,135 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: hillshade-combinations
+  labels:
+    linz.govt.nz/category: raster
+    linz.govt.nz/data-type: raster
+spec:
+  parallelism: 100
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  onExit: exit-handler
+  workflowMetadata:
+    labels:
+      linz.govt.nz/region: 'new-zealand'
+    labelsFrom:
+      linz.govt.nz/ticket:
+        expression: workflow.parameters.ticket
+  podMetadata:
+    labels:
+      linz.govt.nz/category: raster
+      linz.govt.nz/data-type: raster
+      linz.govt.nz/region: 'new-zealand'
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        description: 'Specify a version of the argo-tasks image to use, e.g. "v4.1" or "latest"'
+        value: 'v4'
+      - name: version_basemaps_cli
+        description: 'Specify a version of the basemaps-cli image to use, e.g. "v7.1" or "latest"'
+        value: 'v7'
+      - name: version_topo_imagery
+        description: 'Specify a version of the topo-imagery image to use, e.g. "v4.8" or "latest"'
+        value: 'v7'
+      - name: ticket
+        description: 'Ticket ID, e.g. "TDE-1130"'
+        value: ''
+      - name: source_geospatial_categories
+        description: 'Geospatial categories of the source elevation data as stringified json, e.g. ["dem"] or ["dem", "dsm"]'
+        value: '["dem", "dsm"]'
+      - name: gsd
+        description: 'Dataset GSD in metres, e.g., "1" for 1 metre'
+        default: '1'
+      - name: hillshade_presets
+        description: 'Hillshade presets to use, as stringified json, e.g. ["hillshade"] or ["hillshade-igor", "hillshade"]'
+        value: '["hillshade-igor", "hillshade"]'
+      - name: group
+        description: 'How many output tiles to process in each standardise-validate task "pod". Change if you have resource or performance issues when standardising a dataset.'
+        value: '4'
+      - name: publish_to_odr
+        description: 'Create a Pull Request for publishing to imagery or elevation ODR bucket'
+        value: 'false'
+        enum:
+          - 'false'
+          - 'true'
+      - name: copy_option
+        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
+        value: '--force-no-clobber'
+        enum:
+          - '--no-clobber'
+          - '--force'
+          - '--force-no-clobber'
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  templates:
+    - name: main
+      retryStrategy:
+        expression: 'false'
+      steps:
+        - - name: elevation-type
+            template: each-elevation-type
+            arguments:
+              parameters:
+                - name: source_geospatial_category
+                  value: '{{item}}'
+            withParam: '{{workflow.parameters.source_geospatial_categories}}'
+
+    - name: each-elevation-type
+      inputs:
+        parameters:
+          - name: source_geospatial_category
+      steps:
+        - - name: hillshade-presets
+            templateRef:
+              name: hillshade
+              template: main
+            arguments:
+              parameters:
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+                - name: version_basemaps_cli
+                  value: '{{workflow.parameters.version_basemaps_cli}}'
+                - name: version_topo_imagery
+                  value: '{{workflow.parameters.version_topo_imagery}}'
+                - name: ticket
+                  value: '{{workflow.parameters.ticket}}'
+                - name: source
+                  value: 's3://nz-elevation/new-zealand/new-zealand/{{inputs.parameters.source_geospatial_category}}_{{workflow.parameters.gsd}}m/2193/'
+                - name: source_geospatial_category
+                  value: '{{inputs.parameters.source_geospatial_category}}'
+                - name: gsd
+                  value: '{{workflow.parameters.gsd}}'
+                - name: odr_url
+                  value: 's3://nz-elevation/new-zealand/new-zealand/{{inputs.parameters.source_geospatial_category}}-{{item}}_{{workflow.parameters.gsd}}m/2193/'
+                - name: hillshade_preset
+                  value: '{{item}}'
+                - name: publish_to_odr
+                  value: '{{workflow.parameters.publish_to_odr}}'
+                - name: copy_option
+                  value: '{{workflow.parameters.copy_option}}'
+            withParam: '{{workflow.parameters.hillshade_presets}}'
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'
+
+  volumes:
+    - name: ephemeral
+      emptyDir: {}

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -81,6 +81,20 @@ spec:
       image: ''
   templates:
     - name: main
+      inputs:
+        parameters:
+          - name: source_geospatial_category
+            description: 'Geospatial category of the source elevation data, e.g. "dem" or "dsm"'
+            value: '{{workflow.parameters.source_geospatial_category}}'
+          - name: hillshade_preset
+            description: 'Hillshade preset to use, must be one of "hillshade" or "hillshade-igor"'
+            value: '{{workflow.parameters.hillshade_preset}}'
+          - name: source
+            description: 'Location of the input elevation data to create hillshade.'
+            value: '{{workflow.parameters.source}}'
+          - name: odr_url
+            description: '(Optional) If an existing dataset add the S3 path to the dataset here to load existing metadata e.g. "s3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/"'
+            value: '{{workflow.parameters.odr_url}}'
       retryStrategy:
         expression: 'false'
       dag:
@@ -105,9 +119,9 @@ spec:
                 - name: region
                   value: 'new-zealand'
                 - name: geospatial_category
-                  value: '{{workflow.parameters.source_geospatial_category}}-{{workflow.parameters.hillshade_preset}}'
+                  value: '{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}'
                 - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                  value: '{{inputs.parameters.odr_url}}'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
 
@@ -118,9 +132,9 @@ spec:
             arguments:
               parameters:
                 - name: targetCollection
-                  value: '{{= workflow.parameters.odr_url == "" ? "" : sprig.trimSuffix("/", workflow.parameters.odr_url) + "/collection.json" }}'
+                  value: '{{= inputs.parameters.odr_url == "" ? "" : sprig.trimSuffix("/", inputs.parameters.odr_url) + "/collection.json" }}'
                 - name: sourceCollections
-                  value: '{{=sprig.trimSuffix("/", workflow.parameters.source)}}/collection.json'
+                  value: '{{=sprig.trimSuffix("/", inputs.parameters.source)}}/collection.json'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
 
@@ -137,7 +151,7 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.group)}}'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
-            depends: 'identify-updated-items.Succeeded'
+            depends: 'identify-updated-items.Succeeded && stac-setup-hillshade.Succeeded && get-location.Succeeded'
 
           - name: generate-hillshade
             templateRef:
@@ -148,11 +162,11 @@ spec:
                 - name: group_id
                   value: '{{item}}'
                 - name: hillshade_preset
-                  value: '{{=sprig.trim(workflow.parameters.hillshade_preset)}}'
+                  value: '{{inputs.parameters.hillshade_preset}}'
                 - name: version_topo_imagery
                   value: '{{= workflow.parameters.version_topo_imagery}}'
                 - name: target # not using flat/ here, but {{workflow.parameters.hillshade_preset}}/ to keep temporary HS output separate
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{workflow.parameters.hillshade_preset}}/flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
                 - name: collection_id
                   value: '{{tasks.stac-setup-hillshade.outputs.parameters.collection_id}}'
                 - name: gsd
@@ -160,7 +174,7 @@ spec:
                 - name: current_datetime
                   value: '{{tasks.stac-setup-hillshade.finishedAt}}'
                 - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                  value: '{{inputs.parameters.odr_url}}'
               artifacts:
                 - name: group_data
                   from: '{{tasks.group.outputs.artifacts.output}}'
@@ -178,13 +192,13 @@ spec:
                 - name: linz_slug
                   value: '{{tasks.stac-setup-hillshade.outputs.parameters.linz_slug}}'
                 - name: location
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{=sprig.trim(workflow.parameters.hillshade_preset)}}/flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
                 - name: current_datetime
                   value: '{{tasks.stac-setup-hillshade.finishedAt}}' # not stac-setup
                 - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                  value: '{{inputs.parameters.odr_url}}'
                 - name: category
-                  value: 'dem-{{=sprig.trim(workflow.parameters.hillshade_preset)}}'
+                  value: '{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}'
                 - name: region
                   value: 'new-zealand'
                 - name: gsd
@@ -210,13 +224,13 @@ spec:
             arguments:
               parameters:
                 - name: uri
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{=sprig.trim(workflow.parameters.hillshade_preset)}}/flat/collection.json'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/collection.json'
               artifacts:
                 - name: stac-result
                   raw:
                     data: '{{tasks.stac-validate-all.outputs.result}}'
             depends: 'create-collection.Succeeded'
-            when: "'{{workflow.parameters.odr_url}}' == ''"
+            when: "'{{inputs.parameters.odr_url}}' == ''"
 
           - name: stac-validate-only-updated
             templateRef:
@@ -225,7 +239,7 @@ spec:
             arguments:
               parameters:
                 - name: uri
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{=sprig.trim(workflow.parameters.hillshade_preset)}}/flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
                 - name: recursive
                   value: 'false' # The Collection might have some Items that are only in the published location
                 - name: checksum_links
@@ -237,17 +251,17 @@ spec:
                 - name: concurrency
                   value: '50'
             depends: 'create-collection.Succeeded'
-            when: "'{{workflow.parameters.odr_url}}' != ''"
+            when: "'{{inputs.parameters.odr_url}}' != ''"
 
           - name: create-config
             arguments:
               parameters:
                 - name: location
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{=sprig.trim(workflow.parameters.hillshade_preset)}}/flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
                 - name: bucket
                   value: '{{tasks.get-location.outputs.parameters.bucket}}'
                 - name: key
-                  value: '{{tasks.get-location.outputs.parameters.key}}/{{=sprig.trim(workflow.parameters.hillshade_preset)}}/flat/'
+                  value: '{{tasks.get-location.outputs.parameters.key}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
             template: create-config
             depends: 'generate-hillshade.Succeeded'
 
@@ -259,7 +273,7 @@ spec:
             arguments:
               parameters:
                 - name: source
-                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{=sprig.trim(workflow.parameters.hillshade_preset)}}/flat/'
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
                 - name: target_bucket_name
                   value: 'nz-elevation'
                 - name: copy_option
@@ -267,7 +281,7 @@ spec:
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                  value: '{{inputs.parameters.odr_url}}'
             depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config.Succeeded'
 
       outputs:

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -41,6 +41,12 @@ spec:
       - name: source
         description: 'Location of the input elevation data to create hillshade.'
         value: 's3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/'
+      - name: source_geospatial_category
+        description: 'Geospatial category of the source elevation data, e.g. "dem" or "dsm"'
+        value: 'dem'
+        enum:
+          - 'dem'
+          - 'dsm'
       - name: gsd
         description: 'Dataset GSD in metres, e.g., "1" for 1 metre'
         default: '1'
@@ -99,7 +105,7 @@ spec:
                 - name: region
                   value: 'new-zealand'
                 - name: geospatial_category
-                  value: 'dem-{{=sprig.trim(workflow.parameters.hillshade_preset)}}'
+                  value: '{{workflow.parameters.source_geospatial_category}}-{{workflow.parameters.hillshade_preset}}'
                 - name: odr_url
                   value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: version


### PR DESCRIPTION
### Motivation

As a Basemaps user
I want national DSM hillshades (1m and unspecified resolution, standard and igor)
So that I can view/accentuate terrain detail in a variety of basemaps.

### Modifications

- added `hillshade-combinations` workflow template to iterate over preset and DEM/DSM as needed.
- modified `hillshade` workflow template to work with both DEM and DSM datasets

### Verification

Manual workflow runs