### PR TITLE
feat: add cron workflows for hillshades TDE-1427

### DIFF
--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -27,7 +27,7 @@ It also validate that the [STAC assets](https://github.com/radiantearth/stac-spe
 
 > **_NOTE:_** Due to the parallelism design, this workflow does not validate the root parent `catalog.json` in order to validate each `collection.json` separately. This is not an issue as the `catalog.json` does not contain any `asset` and is already validated by the [cron-stac-validata-fast](#cron-stac-validate-fast) job.
 
-- schedule: **every 1st of the month**
+- schedule: **every 1st of the month at 5am**
 
 ## National Elevation
 
@@ -35,8 +35,8 @@ The two cron workflows `cron-national-dem` and `cron-national-dsm` trigger the `
 
 - [New Zealand LiDAR 1m DEM](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem_1m/2193/collection.json)
 - [New Zealand LiDAR 1m DSM](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm_1m/2193/collection.json)
-
-Schedule: **every day at 6am**
+-
+- schedule: **Monday to Friday at 6am**
 
 ## National Hillshades
 
@@ -47,4 +47,4 @@ The two cron workflows `cron-national-dem-hillshades` and `cron-national-dsm-hil
 - [New Zealand LiDAR 1m DSM Hillshade](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade_1m/2193/collection.json)
 - [New Zealand LiDAR 1m DSM Hillshade - Igor](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade-igor_1m/2193/collection.json)
 
-Schedule: **every day at 12:30pm**
+- schedule: **Monday to Friday at 12:30pm**

--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -3,6 +3,7 @@
 - [cron-stac-validate-fast](#cron-stac-validate-fast)
 - [cron-stac-validate-full](#cron-stac-validate-full)
 - [National Elevation](#national-elevation)
+- [National Hillshades](#national-hillshades)
 
 ## STAC validation
 
@@ -34,3 +35,16 @@ The two cron workflows `cron-national-dem` and `cron-national-dsm` trigger the `
 
 - [New Zealand LiDAR 1m DEM](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem_1m/2193/collection.json)
 - [New Zealand LiDAR 1m DSM](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm_1m/2193/collection.json)
+
+Schedule: **every day at 6am**
+
+## National Hillshades
+
+The two cron workflows `cron-national-dem-hillshades` and `cron-national-dsm-hillshades` trigger the `hillshade-combinations` workflow on a daily (Mon-Fri) basis to amke sure that any update to the national 1m DEM/DSM datasets will be reflected in the respective 1m hillshade datasets:
+
+- [New Zealand LiDAR 1m DEM Hillshade](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem-hillshade_1m/2193/collection.json)
+- [New Zealand LiDAR 1m DEM Hillshade - Igor](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dem-hillshade-igor_1m/2193/collection.json)
+- [New Zealand LiDAR 1m DSM Hillshade](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade_1m/2193/collection.json)
+- [New Zealand LiDAR 1m DSM Hillshade - Igor](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade-igor_1m/2193/collection.json)
+
+Schedule: **every day at 12:30pm**

--- a/workflows/cron/cron-national-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-dem-hillshades.yaml
@@ -2,19 +2,19 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: cron-national-dsm
+  name: cron-national-dem-hillshades
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '0 6 * * 1-5' # At 06:00 AM, Monday through Friday
+  schedule: '30 12 * * 1-5' # At 12:30 PM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   workflowMetadata:
     labels:
-      linz.govt.nz/ticket: 'TDE-1454'
+      linz.govt.nz/ticket: 'TDE-1427'
   workflowSpec:
     podMetadata:
       labels:
@@ -22,18 +22,24 @@ spec:
         linz.govt.nz/data-type: raster
         linz.govt.nz/region: 'new-zealand'
     workflowTemplateRef:
-      name: national-elevation
+      name: hillshade-combinations
     arguments:
       parameters:
-        - name: 'config_file'
-          value: 'https://raw.githubusercontent.com/linz/basemaps-config/master/config/tileset/elevation.dsm.json'
-        - name: 'odr_url'
-          value: 's3://nz-elevation/new-zealand/new-zealand/dsm_1m/2193/'
-        - name: geospatial_category
-          value: 'dsm'
+        - name: version_argo_tasks
+          value: 'v4'
+        - name: version_basemaps_cli
+          value: 'v7'
+        - name: version_topo_imagery
+          value: 'v7'
+        - name: ticket
+          value: 'TDE-1427'
+        - name: source_geospatial_categories
+          value: '["dem"]'
+        - name: gsd
+          value: '1'
+        - name: hillshade_presets
+          value: '["hillshade", "hillshade-igor"]'
         - name: publish_to_odr
           value: 'true'
-        - name: 'copy_option'
+        - name: copy_option
           value: '--force-no-clobber'
-        - name: 'ticket'
-          value: 'TDE-1454'

--- a/workflows/cron/cron-national-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-dem-hillshades.yaml
@@ -14,7 +14,7 @@ spec:
   failedJobsHistoryLimit: 3
   workflowMetadata:
     labels:
-      linz.govt.nz/ticket: 'TDE-1427'
+      linz.govt.nz/ticket: 'TDE-1279'
   workflowSpec:
     podMetadata:
       labels:
@@ -32,7 +32,7 @@ spec:
         - name: version_topo_imagery
           value: 'v7'
         - name: ticket
-          value: 'TDE-1427'
+          value: 'TDE-1279'
         - name: source_geospatial_categories
           value: '["dem"]'
         - name: gsd

--- a/workflows/cron/cron-national-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades.yaml
@@ -2,19 +2,19 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: cron-national-dsm
+  name: cron-national-dsm-hillshades
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '0 6 * * 1-5' # At 06:00 AM, Monday through Friday
+  schedule: '30 12 * * 1-5' # At 12:30 PM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   workflowMetadata:
     labels:
-      linz.govt.nz/ticket: 'TDE-1454'
+      linz.govt.nz/ticket: 'TDE-1427'
   workflowSpec:
     podMetadata:
       labels:
@@ -22,18 +22,24 @@ spec:
         linz.govt.nz/data-type: raster
         linz.govt.nz/region: 'new-zealand'
     workflowTemplateRef:
-      name: national-elevation
+      name: hillshade-combinations
     arguments:
       parameters:
-        - name: 'config_file'
-          value: 'https://raw.githubusercontent.com/linz/basemaps-config/master/config/tileset/elevation.dsm.json'
-        - name: 'odr_url'
-          value: 's3://nz-elevation/new-zealand/new-zealand/dsm_1m/2193/'
-        - name: geospatial_category
-          value: 'dsm'
+        - name: version_argo_tasks
+          value: 'v4'
+        - name: version_basemaps_cli
+          value: 'v7'
+        - name: version_topo_imagery
+          value: 'v7'
+        - name: ticket
+          value: 'TDE-1427'
+        - name: source_geospatial_categories
+          value: '["dsm"]'
+        - name: gsd
+          value: '1'
+        - name: hillshade_presets
+          value: '["hillshade", "hillshade-igor"]'
         - name: publish_to_odr
           value: 'true'
-        - name: 'copy_option'
+        - name: copy_option
           value: '--force-no-clobber'
-        - name: 'ticket'
-          value: 'TDE-1454'

--- a/workflows/cron/cron-national-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades.yaml
@@ -14,7 +14,7 @@ spec:
   failedJobsHistoryLimit: 3
   workflowMetadata:
     labels:
-      linz.govt.nz/ticket: 'TDE-1427'
+      linz.govt.nz/ticket: 'TDE-1455'
   workflowSpec:
     podMetadata:
       labels:
@@ -32,7 +32,7 @@ spec:
         - name: version_topo_imagery
           value: 'v7'
         - name: ticket
-          value: 'TDE-1427'
+          value: 'TDE-1455'
         - name: source_geospatial_categories
           value: '["dsm"]'
         - name: gsd


### PR DESCRIPTION

### Motivation
As a Elevation Data Manager
I want the NZ 1m DEM/DSM Hillshade to be updated automatically when new elevation data is published on the ODR
So that our published data remains in sync


### Modifications
New cron workflows to process both hillshade presets for 1m DEM and 1m DSM each.

### Verification

Manual test runs of workflows
