### PR TITLE
chore: update cron times for hillshade workflows TDE-1477

### DIFF
--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -17,7 +17,7 @@ Workflow that validates the STAC metadata by calling the [`stac-validate` argo-t
 
 It does verify that the [STAC links](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#link-object) are valid.
 
-- schedule: **every day at 5am**
+- schedule: **Monday to Friday at 3pm**
 
 ### cron-stac-validate-full
 

--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -47,7 +47,7 @@ The two cron workflows `cron-national-dem-hillshades` and `cron-national-dsm-hil
 - [New Zealand LiDAR 1m DSM Hillshade](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade_1m/2193/collection.json)
 - [New Zealand LiDAR 1m DSM Hillshade - Igor](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade-igor_1m/2193/collection.json)
 
-- schedule: **Monday to Friday at 12:30pm**
+- schedule: **Monday to Friday at 9:30am**
 
 ## National Merged Hillshades
 
@@ -58,4 +58,4 @@ The two cron workflows `cron-national-merged-[dem/dsm]-hillshades` run on a dail
 - [New Zealand DSM Hillshade](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade/2193/collection.json)
 - [New Zealand DSM Hillshade - Igor](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade-igor/2193/collection.json)
 
-- schedule: **Monday to Friday at 3:00pm**
+- schedule: **Monday to Friday at 12:30pm**

--- a/workflows/cron/cron-national-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-dem-hillshades.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '30 12 * * 1-5' # At 12:30 PM, Monday through Friday
+  schedule: '30 9 * * 1-5' # At 9:30 AM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3

--- a/workflows/cron/cron-national-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '30 12 * * 1-5' # At 12:30 PM, Monday through Friday
+  schedule: '30 9 * * 1-5' # At 9:30 AM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3

--- a/workflows/cron/cron-national-merged-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '0 15 * * 1-5' # At 3:00 PM, Monday through Friday
+  schedule: '30 12 * * 1-5' # At 12:30 PM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3

--- a/workflows/cron/cron-national-merged-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dsm-hillshades.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
 spec:
-  schedule: '0 15 * * 1-5' # At 3:00 PM, Monday through Friday
+  schedule: '30 12 * * 1-5' # At 12:30 PM, Monday through Friday
   timezone: 'NZ'
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3

--- a/workflows/cron/cron-stac-validate-fast.yaml
+++ b/workflows/cron/cron-stac-validate-fast.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linz.govt.nz/category: stac
 spec:
-  schedule: '0 05 * * *' # 5 AM every day
+  schedule: '0 15 * * 1-5' # At 3:00 PM, Monday through Friday
   timezone: 'NZ'
   startingDeadlineSeconds: 3600 # Allow 1 hour delay if the workflow-controller clashes during the starting time.
   concurrencyPolicy: 'Allow'


### PR DESCRIPTION
### Motivation

Run Hillshade workflows and STAC validation closer together.

### Modifications

Set Hillshade Workflows CRON times to 9:30 am and 12:30 pm.
Set fast STAC validation workflow to run at 3:00 pm.

### Verification

Argo linter