### PR TITLE
fix: split STAC validate workflow TDE-1475

### DIFF
--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -293,7 +293,7 @@ spec:
                   value: '{{= inputs.parameters.version_topo_imagery}}'
             depends: 'standardise-validate.Succeeded'
 
-          - name: stac-validate
+          - name: stac-validate-all
             templateRef:
               name: tpl-at-stac-validate
               template: main
@@ -304,8 +304,30 @@ spec:
               artifacts:
                 - name: stac-result
                   raw:
-                    data: '{{tasks.stac-validate.outputs.result}}'
-            depends: 'create-collection'
+                    data: '{{tasks.stac-validate-all.outputs.result}}'
+            depends: 'create-collection.Succeeded'
+            when: "'{{inputs.parameters.odr_url}}' == ''"
+
+          - name: stac-validate-only-updated
+            templateRef:
+              name: stac-validate-parallel # Needs to validate a list of STAC documents
+              template: main
+            arguments:
+              parameters:
+                - name: uri
+                  value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.geospatial_category}}/flat/'
+                - name: recursive
+                  value: 'false' # The Collection might have some Items that are only in the published location
+                - name: checksum_links
+                  value: 'false'
+                - name: checksum_assets
+                  value: 'true'
+                - name: include
+                  value: '\.json$' # FIXME: For now, assuming we have only STAC as JSON files in the scratch location
+                - name: concurrency
+                  value: '50'
+            depends: 'create-collection.Succeeded'
+            when: "'{{inputs.parameters.odr_url}}' != ''"
 
           - name: create-config
             when: "'{{inputs.parameters.target_epsg}}' =~ '2193|3857'"
@@ -337,7 +359,7 @@ spec:
                   value: '{{=sprig.trim(inputs.parameters.ticket)}}'
                 - name: odr_url
                   value: '{{=sprig.trim(inputs.parameters.odr_url)}}'
-            depends: 'stac-validate.Succeeded && create-config.Succeeded'
+            depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config.Succeeded'
 
       outputs:
         parameters:


### PR DESCRIPTION
### Motivation

Merge workflow was now failing on partially updated datasets.

### Modifications

Split STAC validate workflow step into two depending on whether an ODR URL was supplied or not.

### Verification

Manual WF run