### PR TITLE
feat: add read permissions to new ODR buckets from Argo TDE-1456

### DIFF
--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -294,9 +294,9 @@ export class LinzEksCluster extends Stack {
      * While those are public buckets, we still need to give permission to Argo
      * as the `--no-sign-request` is not handled in the code.
      */
-    Bucket.fromBucketName(this, 'OdrNzImagery', 'nz-imagery').grantRead(argoRunnerSa.role);
-    Bucket.fromBucketName(this, 'OdrNzElevation', 'nz-elevation').grantRead(argoRunnerSa.role);
     Bucket.fromBucketName(this, 'OdrNzCoastal', 'nz-coastal').grantRead(argoRunnerSa.role);
+    Bucket.fromBucketName(this, 'OdrNzElevation', 'nz-elevation').grantRead(argoRunnerSa.role);
+    Bucket.fromBucketName(this, 'OdrNzImagery', 'nz-imagery').grantRead(argoRunnerSa.role);
     Bucket.fromBucketName(this, 'OdrNzTopography', 'nz-topography').grantRead(argoRunnerSa.role);
   }
 }

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -296,5 +296,7 @@ export class LinzEksCluster extends Stack {
      */
     Bucket.fromBucketName(this, 'OdrNzImagery', 'nz-imagery').grantRead(argoRunnerSa.role);
     Bucket.fromBucketName(this, 'OdrNzElevation', 'nz-elevation').grantRead(argoRunnerSa.role);
+    Bucket.fromBucketName(this, 'OdrNzCoastal', 'nz-coastal').grantRead(argoRunnerSa.role);
+    Bucket.fromBucketName(this, 'OdrNzTopography', 'nz-topography').grantRead(argoRunnerSa.role);
   }
 }


### PR DESCRIPTION
### Motivation

Give Argo Workflows read access to the two new ODR buckets `nz-coastal` and `nz-topography` in the same way as for `nz-elevation` and `nz-imagery`.
