### PR TITLE
build: use basemaps-cli v8 for basemaps workflows BM-1264

### DIFF
--- a/workflows/basemaps/create-config.yaml
+++ b/workflows/basemaps/create-config.yaml
@@ -14,7 +14,7 @@ spec:
   arguments:
     parameters:
       - name: version_basemaps_cli
-        value: 'v7'
+        value: 'v8'
       - name: location
         value: 's3://bucket/path/to'
   templateDefaults:

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -39,10 +39,10 @@ spec:
     parameters:
       - name: version_basemaps_cli
         description: Version of the basemaps CLI docker container to use
-        value: v7
+        value: v8
 
       - name: version_argo_tasks
-        description: Version of the basemaps CLI docker container to use
+        description: Version of the argo-tasks CLI docker container to use
         value: v4
 
       - name: user_group


### PR DESCRIPTION
### Motivation

As part of the `v8` basemaps release, we have re-homed some of our cli commands and created/renamed some packages. We have also updated the `cli` package to be the primary entry point through which to execute cli commands:

![basemaps-clis](https://github.com/user-attachments/assets/3f5e0a64-df61-44ab-8416-92839d3f35cd)

In `v7`, you would access a `cli` or `cogify` command via its respective package. Now, in `v8`, you can access all of our important commands via the corresponding sub-command of our `cli` package. For example:

| Before (`v7`) | After (`v8`) |
| - | - |
| via `cli` package: `bundle <parameters>` | via `cli` package: `config bundle <parameters>` |
| via `cogify` package: `cover <parameters>` | via `cli` package: `cogify cover <parameters>` |

### Modifications

- Updates the following workflows to access commands by way of the `cli` package:
   - `workflows/basemaps/create-config.yaml`
   - `workflows/basemaps/imagery-import-cogify.yml`

### Verification

I've imported the updated `imagery-import-cogify.yml` into Argo as a new workflow titled:

- `bm-1264-test-basemaps-imagery-import-cogify`

I've submit a [workflow] verifying that the following updated commands execute without issue:

| `cogify cover` | `cogify create` | `config create-config` |
| - | - | - |
| ![][cover] | ![][create] | ![][create-config] |

We don't need to import and test the updated `create-config.yaml` workflow as I've tested the `config create-config` command in the other workflow. Both workflows share the same change.

<!-- external links -->

[workflow]: https://argo.linzaccess.com/workflows/argo/bm-1264-test-basemaps-imagery-import-cogify-hlg67

[cover]: https://github.com/user-attachments/assets/c1eb9d1c-f52e-4e00-8d15-d0683385e07f
[create]: https://github.com/user-attachments/assets/dbb483a3-84cb-4e54-ab2d-d6e570cc0603
[create-config]: https://github.com/user-attachments/assets/d54c0299-7f4c-4ac7-9bc5-94fc3372b999