### PR TITLE
feat: delete workflow template TDE-1483

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -5,6 +5,7 @@
 - [Group](##argo-tasks/group)
 - [Copy](##argo-tasks/copy)
 - [Create Manifest](##argo-tasks/create-manifest)
+- [Delete](##argo-task/delete)
 - [Push to Github](##argo-tasks/push-to-github)
 - [Generate Path](##argo-tasks/generate-path)
 - [STAC setup](##argo-tasks/stac-setup)
@@ -147,6 +148,32 @@ Create a manifest file for a user specified source and target that includes `.ti
         value: '100Gi'
       - name: version_argo_tasks
         value: '{{workflow.parameters.version_argo_tasks}}'
+```
+
+## argo-tasks/delete - `tpl-delete`
+
+Template for deleting files that are `source` in a manifest
+See https://github.com/linz/argo-tasks#delete
+
+### Template usage
+
+Delete the `source` entries in a manifest file.
+
+```yaml
+- name: delete
+  templateRef:
+    name: tpl-delete
+    template: main
+  arguments:
+    parameters:
+      - name: dry_run
+        value: 'false'
+      - name: file
+        value: '{{item}}'
+      - name: version_argo_tasks
+        value: '{{workflow.parameters.version_argo_tasks}}'
+  depends: 'create-manifest'
+  withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
 ```
 
 ## argo-tasks/push-to-github - `tpl-push-to-github`

--- a/templates/argo-tasks/delete.yaml
+++ b/templates/argo-tasks/delete.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template for deleting files that are `source` in a manifest
+  # See https://github.com/linz/argo-tasks#delete
+  name: tpl-delete
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: file
+            description: Path to the manifest file detailing source to delete
+
+          - name: version_argo_tasks
+            description: version of argo-tasks to use
+            default: 'v4'
+
+          - name: dry_run
+            description: 'If true, the command will not delete any files.'
+            default: false'
+            enum:
+              - 'true'
+              - 'false'
+
+          - name: aws_role_config_path
+            description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
+            default: 's3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json'
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
+        resources:
+          requests:
+            memory: 7.8Gi # TODO: to review
+            cpu: 2000m # TODO: to review
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: '{{inputs.parameters.aws_role_config_path}},s3://linz-bucket-config/config.json'
+        args:
+          - 'delete'
+          - '--dry-run={{inputs.parameters.dry_run}}'
+          - '{{inputs.parameters.file}}'


### PR DESCRIPTION
### Motivation

Some workflow will need to delete files after processing them (for example the coming archive workflow). This `WorkflowTemplate` allow to call [the `linz/argo-task/delete` command](https://github.com/linz/argo-tasks/pull/1214).

### Modifications

- Add a `WorkflowTemplate` `tpl-delete` that can be refered to delete files that are `source` entries in a manifest of file generated by `create-manifest`

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

TODO
