### PR TITLE
feat: archive workflow TDE-1484

### DIFF
--- a/templates/argo-tasks/archive-setup.yaml
+++ b/templates/argo-tasks/archive-setup.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from linz/argo-tasks
+  # see https://github.com/linz/argo-tasks#archive-setup
+  name: tpl-at-archive-setup
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: source
+            description: 'S3 path to the files to be archived'
+            default: ''
+          - name: version
+            description: 'argo-task Container version to use'
+            default: 'v4'
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=inputs.parameters.version}}'
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          - 'archive-setup'
+          - '{{inputs.parameters.source}}'
+      outputs:
+        parameters:
+          - name: archive_location
+            description: Location to use to archive the source files
+            valueFrom:
+              path: '/tmp/archive-setup/archive-location'

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -31,6 +31,20 @@ spec:
               - '--force'
               - '--force-no-clobber'
 
+          - name: compress
+            description: Compress the files in their target location
+            default: 'false'
+            enum:
+              - 'true'
+              - 'false'
+
+          - name: delete_source
+            description: Delete the source files after copying
+            default: 'false'
+            enum:
+              - 'true'
+              - 'false'
+
           - name: aws_role_config_path
             description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
             default: 's3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json'
@@ -44,4 +58,9 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: '{{inputs.parameters.aws_role_config_path}},s3://linz-bucket-config/config.json'
-        args: ['copy', '{{inputs.parameters.copy_option}}', '{{inputs.parameters.file}}']
+        args: 
+         - 'copy'
+         - '{{inputs.parameters.copy_option}}'
+         - '{{inputs.parameters.file}}'
+         - '--compress={{inputs.parameters.compress}}'
+         - '--delete-source={{inputs.parameters.delete_source}}'

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -58,9 +58,9 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: '{{inputs.parameters.aws_role_config_path}},s3://linz-bucket-config/config.json'
-        args: 
-         - 'copy'
-         - '{{inputs.parameters.copy_option}}'
-         - '{{inputs.parameters.file}}'
-         - '--compress={{inputs.parameters.compress}}'
-         - '--delete-source={{inputs.parameters.delete_source}}'
+        args:
+          - 'copy'
+          - '{{inputs.parameters.copy_option}}'
+          - '{{inputs.parameters.file}}'
+          - '--compress={{inputs.parameters.compress}}'
+          - '--delete-source={{inputs.parameters.delete_source}}'

--- a/workflows/basemaps/topo-maps-standardising.yml
+++ b/workflows/basemaps/topo-maps-standardising.yml
@@ -160,8 +160,6 @@ spec:
                   value: '\.tiff?$|\.json$'
                 - name: exclude
                   value: ''
-                - name: copy_option
-                  value: '{{ workflow.parameters.copy_option }}'
                 - name: flatten
                   value: 'false'
                 - name: group

--- a/workflows/basemaps/topo-maps-standardising.yml
+++ b/workflows/basemaps/topo-maps-standardising.yml
@@ -160,6 +160,8 @@ spec:
                   value: '\.tiff?$|\.json$'
                 - name: exclude
                   value: ''
+                - name: copy_option
+                  value: '{{ workflow.parameters.copy_option }}'
                 - name: flatten
                   value: 'false'
                 - name: group

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -1,7 +1,6 @@
 # Contents:
 
 - [Standardising](#Standardising)
-- [copy](#copy)
 - [publish-odr](#Publish-odr)
 - [National Elevation](#national-elevation)
 - [Merge Layers](#merge-layers)
@@ -201,66 +200,6 @@ Validates the collection.json and all associated items.
 ### [create-config](https://github.com/linz/basemaps/blob/59a3e7fa847f64f5c83fc876b071db947407d14d/packages/cli/src/cli/config/action.imagery.config.ts)
 
 Creates a config of the imagery files within the `flat` directory and outputs a Basemaps link for Visual QA. Currently Aerial Imagery only; not Elevation.
-
-# copy
-
-## Workflow Description
-
-Copy files from one S3 location to another. This workflow is intended to be used after standardising and QA to copy:
-
-- from `linz-workflow-artifacts` "flattened" directory to `linz-imagery`
-- from `linz-imagery-upload` to `linz-imagery-staging` to store a copy of the uploaded RGBI imagery.
-
-```mermaid
-graph TD;
-  create-manifest-->copy;
-```
-
-This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks#create-manifest) container `create-manifest` (list of source and target file paths) and `copy` (the actual file copy) commands.
-
-Access permissions are controlled by the [Bucket Sharing Config](https://github.com/linz/topo-aws-infrastructure/blob/master/src/stacks/bucket.sharing.ts) which gives Argo Workflows access to the S3 buckets we use.
-
-## Workflow Input Parameters
-
-| Parameter            | Type  | Default                                                                                                                                                       | Description                                                                                                                                                                                                                 |
-| -------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| user_group           | enum  | none                                                                                                                                                          | Group of users running the workflow                                                                                                                                                                                         |
-| ticket               | str   |                                                                                                                                                               | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
-| region               | enum  |                                                                                                                                                               | Region of the dataset                                                                                                                                                                                                       |
-| source               | str   | s3://linz-imagery-staging/test/sample/                                                                                                                        | The URIs (paths) to the s3 source location. Separate multiple source paths with `;`                                                                                                                                         |
-| target               | str   | s3://linz-imagery-staging/test/sample_target/                                                                                                                 | The URIs (paths) to the s3 target location                                                                                                                                                                                  |
-| include              | regex | \\.tiff?\$\|\\.json\$\|\\.tfw\$\|/capture-area\\.geojson\$\|/capture-area\\.geojson\$                                                                         | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                                                                                 |
-| exclude              | regex |                                                                                                                                                               | A regular expression to match object path(s) or name(s) from within the source path to exclude from the copy.                                                                                                               |
-| copy_option          | enum  | --no-clobber                                                                                                                                                  | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
-| flatten              | enum  | false                                                                                                                                                         | Flatten the files in the target location (useful for multiple source locations)                                                                                                                                             |
-| group                | int   | 1000                                                                                                                                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                     |
-| group_size           | str   | 100Gi                                                                                                                                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                 |
-| transform            | str   | `f`                                                                                                                                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation.                                                            |
-| aws_role_config_path | str   | `s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json` | s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s).                                                                                                                                    |
-
-## Examples
-
-### Publish:
-
-**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
-
-**target:** `s3://linz-imagery/southland/invercargill_2022_0.1m/rgb/2193/`
-
-**include:** Although only `.tiff` and `.json` files are required, there should not be any `.tfw` files in with the standardised imagery, so this option can be left at the default.
-
-**copy_option:** `--no-clobber`
-
-**Target path naming convention:** `s3://linz-imagery/<region>/<city-or-sub-region>_<year>_<resolution>/<product>/<crs>/`
-
-### Backup RGBI:
-
-**source:** `s3://linz-imagery-upload/Invercargill2022_Pgrm3016/OutputPGRM3016-InvercargillRural2022/tifs-RGBI/`
-
-**target:** `s3://linz-imagery-staging/RGBi4/invercargill_urban_2022_0.1m/`
-
-**include:** Although only `.tif(f)` and `.tfw` files are required, there should not be any `.json` files in with the uploaded imagery, so this option can be left at the default.
-
-**copy_option:** `--no-clobber`
 
 # Publish-odr
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -1,4 +1,4 @@
-# Contents:
+# Contents
 
 - [Standardising](#Standardising)
 - [publish-odr](#Publish-odr)

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -1,43 +1,43 @@
-# Storage
+# Contents
+
+- [Archive](#archive)
+- [Copy](#copy)
 
 ## Archive
 
 ### Workflow Description
 
-Archive files from one of the S3 buckets (for example `linz-*-upload`) to a long term archive bucket (S3 Glacier Deep Archive). This workflow is intended to be used after files in a source folder have been processed and not needed for any future update.
+Archive files from a S3 location (for example `s3://linz-*-upload/[provider]/[survey]/[supply]/`) to a long term archive location (on a bucket where the files are stored as S3 Glacier Deep Archive storage class). This workflow is intended to be used after files in a source folder (for example, supplied by external provider) have been processed and not needed for any future update.
 
+1. Verify the path of the files to archive. Restricted to some buckets only (TODO: link to `argo-task` command) and set the archive location.
 1. Create a manifest of file to be archived from the source location (example: `s3://linz-topographic-upload/[PROVIDER]/[SURVEY]/`)
-2. Compress each file listed in the manifest and check if the compression is worthwhile (very small files may have a bigger size after compression)
-3. Copy the compressed (or original if smaller) file to the archive bucket (example: `s3://topographic-archive/[PROVIDER]/[SURVEY]/`)
-4. Ensure a new version is stored if a file already exists in the archive (this is managed by AWS S3 versioning)
-5. Delete the original files that have been archived. The original files will be still available for retrieval for the next 90 days after deletion.
+1. Compress each file listed in the manifest and check if the compression is worthwhile (very small files may have a bigger size after compression)
+1. Copy the compressed (or original if smaller) file to the archive bucket (example: `s3://linz-topographic-archive/[PROVIDER]/[SURVEY]/`)
+1. Ensure a new version is stored if a file already exists in the archive (this is managed by AWS S3 versioning)
+1. Delete the original files that have been archived. The original files will be still available for retrieval for the next 90 days after deletion.
 
 ### Flow
 
 ```mermaid
 graph TD;
-  create-manifest-->copy;
+  archive-setup-->create-manifest-->copy;
 ```
 
-This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks#create-manifest) container `create-manifest` (list of source and target file paths) and `copy` (the actual file copy) commands with `--compress` and `--delete-source` options.
+This is a workflow that calls the `copy` workflow with `--compress` and `--delete-source` options, after setting up the archive location by calling the `archive-setup` workflow.
 
 Access permissions are controlled by the [Bucket Sharing Config](https://github.com/linz/topo-aws-infrastructure/blob/master/src/stacks/bucket.sharing.ts) which gives Argo Workflows access to the S3 buckets we use.
 
 ### Workflow Input Parameters
 
-| Parameter            | Type  | Default                                                                                                                                                       | Description                                                                                                                                                      |
-| -------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| user_group           | enum  | none                                                                                                                                                          | Group of users running the workflow                                                                                                                              |
-| ticket               | str   |                                                                                                                                                               | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
-| source               | str   | s3://linz-imagery-staging/test/sample/                                                                                                                        | The URIs (paths) to the s3 source location. Separate multiple source paths with `;`                                                                              |
-| include              | regex | \\.tiff?\$\|\\.json\$\|\\.tfw\$\|/capture-area\\.geojson\$\|/capture-area\\.geojson\$                                                                         | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                      |
-| exclude              | regex |                                                                                                                                                               | A regular expression to match object path(s) or name(s) from within the source path to exclude from the copy.                                                    |
-| group                | int   | 1000                                                                                                                                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                          |
-| group_size           | str   | 100Gi                                                                                                                                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                      |
-| transform            | str   | `f`                                                                                                                                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
-| aws_role_config_path | str   | `s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json` | s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s).                                                                         |
+| Parameter  | Type | Default | Description                                                                                                                 |
+| ---------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
+| user_group | enum | none    | Group of users running the workflow                                                                                         |
+| ticket     | str  |         | Ticket ID e.g. 'AIP-55'                                                                                                     |
+| source     | str  |         | The URI (path) to the s3 source location where the files to archive are.                                                    |
+| group      | int  | 1000    | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).     |
+| group_size | str  | 100Gi   | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first). |
 
-## copy
+## Copy
 
 ### Workflow Description
 
@@ -75,7 +75,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ### Examples
 
-#### Publish:
+#### Publish
 
 **source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
 
@@ -87,7 +87,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 **Target path naming convention:** `s3://linz-imagery/<region>/<city-or-sub-region>_<year>_<resolution>/<product>/<crs>/`
 
-#### Backup RGBI:
+#### Backup RGBI
 
 **source:** `s3://linz-imagery-upload/Invercargill2022_Pgrm3016/OutputPGRM3016-InvercargillRural2022/tifs-RGBI/`
 

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -36,3 +36,63 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 | group_size           | str   | 100Gi                                                                                                                                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                      |
 | transform            | str   | `f`                                                                                                                                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
 | aws_role_config_path | str   | `s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json` | s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s).                                                                         |
+
+## copy
+
+### Workflow Description
+
+Copy files from one S3 location to another. This workflow is intended to be used after standardising and QA to copy:
+
+- from `linz-workflow-artifacts` "flattened" directory to `linz-imagery`
+- from `linz-imagery-upload` to `linz-imagery-staging` to store a copy of the uploaded RGBI imagery.
+
+```mermaid
+graph TD;
+  create-manifest-->copy;
+```
+
+This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks#create-manifest) container `create-manifest` (list of source and target file paths) and `copy` (the actual file copy) commands.
+
+Access permissions are controlled by the [Bucket Sharing Config](https://github.com/linz/topo-aws-infrastructure/blob/master/src/stacks/bucket.sharing.ts) which gives Argo Workflows access to the S3 buckets we use.
+
+### Workflow Input Parameters
+
+| Parameter            | Type  | Default                                                                                                                                                       | Description                                                                                                                                                                                                                 |
+| -------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| user_group           | enum  | none                                                                                                                                                          | Group of users running the workflow                                                                                                                                                                                         |
+| ticket               | str   |                                                                                                                                                               | Ticket ID e.g. 'AIP-55'                                                                                                                                                                                                     |
+| region               | enum  |                                                                                                                                                               | Region of the dataset                                                                                                                                                                                                       |
+| source               | str   | s3://linz-imagery-staging/test/sample/                                                                                                                        | The URIs (paths) to the s3 source location. Separate multiple source paths with `;`                                                                                                                                         |
+| target               | str   | s3://linz-imagery-staging/test/sample_target/                                                                                                                 | The URIs (paths) to the s3 target location                                                                                                                                                                                  |
+| include              | regex | \\.tiff?\$\|\\.json\$\|\\.tfw\$\|/capture-area\\.geojson\$\|/capture-area\\.geojson\$                                                                         | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                                                                                 |
+| exclude              | regex |                                                                                                                                                               | A regular expression to match object path(s) or name(s) from within the source path to exclude from the copy.                                                                                                               |
+| copy_option          | enum  | --no-clobber                                                                                                                                                  | <dl><dt>`--no-clobber` </dt><dd> Skip overwriting existing files.</dd><dt> `--force` </dt><dd> Overwrite all files. </dd><dt> `--force-no-clobber` </dt><dd> Overwrite only changed files, skip unchanged files. </dd></dl> |
+| flatten              | enum  | false                                                                                                                                                         | Flatten the files in the target location (useful for multiple source locations)                                                                                                                                             |
+| group                | int   | 1000                                                                                                                                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                     |
+| group_size           | str   | 100Gi                                                                                                                                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                                                                                 |
+| transform            | str   | `f`                                                                                                                                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation.                                                            |
+| aws_role_config_path | str   | `s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json` | s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s).                                                                                                                                    |
+
+### Examples
+
+#### Publish:
+
+**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+
+**target:** `s3://linz-imagery/southland/invercargill_2022_0.1m/rgb/2193/`
+
+**include:** Although only `.tiff` and `.json` files are required, there should not be any `.tfw` files in with the standardised imagery, so this option can be left at the default.
+
+**copy_option:** `--no-clobber`
+
+**Target path naming convention:** `s3://linz-imagery/<region>/<city-or-sub-region>_<year>_<resolution>/<product>/<crs>/`
+
+#### Backup RGBI:
+
+**source:** `s3://linz-imagery-upload/Invercargill2022_Pgrm3016/OutputPGRM3016-InvercargillRural2022/tifs-RGBI/`
+
+**target:** `s3://linz-imagery-staging/RGBi4/invercargill_urban_2022_0.1m/`
+
+**include:** Although only `.tif(f)` and `.tfw` files are required, there should not be any `.json` files in with the uploaded imagery, so this option can be left at the default.
+
+**copy_option:** `--no-clobber` |

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -1,0 +1,38 @@
+# Storage
+
+## Archive
+
+### Workflow Description
+
+Archive files from one of the S3 buckets (for example `linz-*-upload`) to a long term archive bucket (S3 Glacier Deep Archive). This workflow is intended to be used after files in a source folder have been processed and not needed for any future update.
+
+1. Create a manifest of file to be archived from the source location (example: `s3://linz-topographic-upload/[PROVIDER]/[SURVEY]/`)
+2. Compress each file listed in the manifest and check if the compression is worthwhile (very small files may have a bigger size after compression)
+3. Copy the compressed (or original if smaller) file to the archive bucket (example: `s3://topographic-archive/[PROVIDER]/[SURVEY]/`)
+4. Ensure a new version is stored if a file already exists in the archive (this is managed by AWS S3 versioning)
+5. Delete the original files that have been archived. The original files will be still available for retrieval for the next 90 days after deletion.
+
+### Flow
+
+```mermaid
+graph TD;
+  create-manifest-->copy;
+```
+
+This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks#create-manifest) container `create-manifest` (list of source and target file paths) and `copy` (the actual file copy) commands with `--compress` and `--delete-source` options.
+
+Access permissions are controlled by the [Bucket Sharing Config](https://github.com/linz/topo-aws-infrastructure/blob/master/src/stacks/bucket.sharing.ts) which gives Argo Workflows access to the S3 buckets we use.
+
+### Workflow Input Parameters
+
+| Parameter            | Type  | Default                                                                                                                                                       | Description                                                                                                                                                      |
+| -------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| user_group           | enum  | none                                                                                                                                                          | Group of users running the workflow                                                                                                                              |
+| ticket               | str   |                                                                                                                                                               | Ticket ID e.g. 'AIP-55'                                                                                                                                          |
+| source               | str   | s3://linz-imagery-staging/test/sample/                                                                                                                        | The URIs (paths) to the s3 source location. Separate multiple source paths with `;`                                                                              |
+| include              | regex | \\.tiff?\$\|\\.json\$\|\\.tfw\$\|/capture-area\\.geojson\$\|/capture-area\\.geojson\$                                                                         | A regular expression to match object path(s) or name(s) from within the source path to include in the copy.                                                      |
+| exclude              | regex |                                                                                                                                                               | A regular expression to match object path(s) or name(s) from within the source path to exclude from the copy.                                                    |
+| group                | int   | 1000                                                                                                                                                          | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                          |
+| group_size           | str   | 100Gi                                                                                                                                                         | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).                                      |
+| transform            | str   | `f`                                                                                                                                                           | String to be transformed from source to target to renamed filenames, e.g. `f.replace("text to replace", "new_text_to_use")`. Leave as `f` for no transformation. |
+| aws_role_config_path | str   | `s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json` | s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s).                                                                         |

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -56,8 +56,14 @@ spec:
           - name: source
             value: '{{workflow.parameters.source}}'
           - name: group
+            value: '{{workflow.parameters.group}}'
+            default: '1000'
           - name: group_size
+            value: '{{workflow.parameters.group_size}}'
+            default: '100Gi'
           - name: version_argo_tasks
+            value: '{{workflow.parameters.version_argo_tasks}}'
+            default: 'v4'
       dag:
         tasks:
           - name: archive-setup

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -37,9 +37,8 @@ spec:
         description: Ticket ID e.g. 'AIP-55'
         value: ''
       - name: source
-        value: 's3://linz-imagery-staging/test/sample/'
-      - name: target
-        value: 's3://linz-imagery-staging/test/sample_target/'
+        description: Path where the files to be archived are located
+        value: ''
       - name: include
         value: '\.tiff?$|\.json$|\.tfw$|/capture-area\.geojson$|/capture-dates\.geojson$'
       - name: exclude
@@ -71,56 +70,53 @@ spec:
       inputs:
         parameters:
           - name: source
-          - name: target
           - name: include
           - name: exclude
           - name: group
           - name: group_size
+          - name: version_argo_tasks
       dag:
         tasks:
-          - name: create-manifest
+          - name: archive-setup
             templateRef:
-              name: tpl-create-manifest
+              name: tpl-archive-setup
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{inputs.parameters.source}}'
+          - name: copy
+            dependencies:
+              - archive-setup
+            templateRef:
+              name: copy
               template: main
             arguments:
               parameters:
                 - name: source
                   value: '{{inputs.parameters.source}}'
                 - name: target
-                  value: '{{inputs.parameters.target}}'
+                  value: '{{workflow.parameters.aws_role_config_path}}'
                 - name: include
                   value: '{{inputs.parameters.include}}'
                 - name: exclude
                   value: '{{inputs.parameters.exclude}}'
+                - name: copy_option
+                  value: '{{workflow.parameters.copy_option}}'
                 - name: flatten
-                  value: '{{inputs.parameters.flatten}}'
+                  value: 'false'
                 - name: group
                   value: '{{inputs.parameters.group}}'
                 - name: group_size
                   value: '{{inputs.parameters.group_size}}'
+                - name: transform
+                  value: '{{workflow.parameters.transform}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
-
-          - name: archive
-            templateRef:
-              name: tpl-copy
-              template: main
-            arguments:
-              parameters:
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
-                - name: file
-                  value: '{{item}}'
                 - name: compress
                   value: 'true'
                 - name: delete_source
-                  value: 'true
-                - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
-                - name: aws_role_config_path
-                  value: '{{workflow.parameters.aws_role_config_path}}'
-            depends: 'create-manifest'
-            withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
+                  value: 'true'
 
     - name: exit-handler
       retryStrategy:

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -1,0 +1,138 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: archive
+
+spec:
+  parallelism: 50
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  onExit: exit-handler
+  workflowMetadata:
+    labelsFrom:
+      linz.govt.nz/user-group:
+        expression: workflow.parameters.user_group
+      linz.govt.nz/ticket:
+        expression: workflow.parameters.ticket
+  podMetadata:
+    labels:
+      linz.govt.nz/user-group: '{{workflow.parameters.user_group}}'
+      linz.govt.nz/category: storage
+      linz.govt.nz/ticket: '{{workflow.parameters.ticket}}'
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        value: 'v4'
+      - name: user_group
+        description: Group of users running the workflow
+        value: 'none'
+        enum:
+          - 'land'
+          - 'sea'
+          - 'none'
+      - name: ticket
+        description: Ticket ID e.g. 'AIP-55'
+        value: ''
+      - name: source
+        value: 's3://linz-imagery-staging/test/sample/'
+      - name: target
+        value: 's3://linz-imagery-staging/test/sample_target/'
+      - name: include
+        value: '\.tiff?$|\.json$|\.tfw$|/capture-area\.geojson$|/capture-dates\.geojson$'
+      - name: exclude
+        value: ''
+      - name: copy_option
+        value: '--no-clobber'
+        enum:
+          - '--no-clobber'
+          - '--force'
+          - '--force-no-clobber'
+      - name: group
+        value: '1000'
+      - name: group_size
+        value: '100Gi'
+      - name: transform
+        value: 'f'
+      - name: aws_role_config_path
+        description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
+        value: 's3://linz-bucket-config/config-write.topographic.json, s3://linz-bucket-config/config-write.hydrographic.json'
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+
+  templates:
+    - name: main
+      retryStrategy:
+        expression: 'false'
+      inputs:
+        parameters:
+          - name: source
+          - name: target
+          - name: include
+          - name: exclude
+          - name: group
+          - name: group_size
+      dag:
+        tasks:
+          - name: create-manifest
+            templateRef:
+              name: tpl-create-manifest
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{inputs.parameters.source}}'
+                - name: target
+                  value: '{{inputs.parameters.target}}'
+                - name: include
+                  value: '{{inputs.parameters.include}}'
+                - name: exclude
+                  value: '{{inputs.parameters.exclude}}'
+                - name: flatten
+                  value: '{{inputs.parameters.flatten}}'
+                - name: group
+                  value: '{{inputs.parameters.group}}'
+                - name: group_size
+                  value: '{{inputs.parameters.group_size}}'
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+
+          - name: archive
+            templateRef:
+              name: tpl-copy
+              template: main
+            arguments:
+              parameters:
+                - name: copy_option
+                  value: '{{workflow.parameters.copy_option}}'
+                - name: file
+                  value: '{{item}}'
+                - name: compress
+                  value: 'true'
+                - name: delete_source
+                  value: 'true
+                - name: version_argo_tasks
+                  value: '{{workflow.parameters.version_argo_tasks}}'
+                - name: aws_role_config_path
+                  value: '{{workflow.parameters.aws_role_config_path}}'
+            depends: 'create-manifest'
+            withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -54,6 +54,7 @@ spec:
       inputs:
         parameters:
           - name: source
+            value: '{{workflow.parameters.source}}'
           - name: group
           - name: group_size
           - name: version_argo_tasks

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -4,7 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: archive
-
 spec:
   parallelism: 50
   nodeSelector:
@@ -39,25 +38,10 @@ spec:
       - name: source
         description: Path where the files to be archived are located
         value: ''
-      - name: include
-        value: '\.tiff?$|\.json$|\.tfw$|/capture-area\.geojson$|/capture-dates\.geojson$'
-      - name: exclude
-        value: ''
-      - name: copy_option
-        value: '--no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
       - name: group
         value: '1000'
       - name: group_size
         value: '100Gi'
-      - name: transform
-        value: 'f'
-      - name: aws_role_config_path
-        description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
-        value: 's3://linz-bucket-config/config-write.topographic.json, s3://linz-bucket-config/config-write.hydrographic.json'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -70,8 +54,6 @@ spec:
       inputs:
         parameters:
           - name: source
-          - name: include
-          - name: exclude
           - name: group
           - name: group_size
           - name: version_argo_tasks
@@ -79,30 +61,31 @@ spec:
         tasks:
           - name: archive-setup
             templateRef:
-              name: tpl-archive-setup
+              name: tpl-at-archive-setup
               template: main
             arguments:
               parameters:
                 - name: source
                   value: '{{inputs.parameters.source}}'
+                - name: version
+                  value: '{{inputs.parameters.version_argo_tasks}}'
           - name: copy
-            dependencies:
-              - archive-setup
+            depends: 'archive-setup.Succeeded'
             templateRef:
               name: copy
               template: main
             arguments:
-              parameters:
+              parameters: # hardcode some values as they are specific for archiving
                 - name: source
                   value: '{{inputs.parameters.source}}'
                 - name: target
-                  value: '{{workflow.parameters.aws_role_config_path}}'
+                  value: '{{tasks.archive-setup.outputs.parameters.archive_location}}'
                 - name: include
-                  value: '{{inputs.parameters.include}}'
+                  value: ''
                 - name: exclude
-                  value: '{{inputs.parameters.exclude}}'
+                  value: ''
                 - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
+                  value: '--force-no-clobber' # TODO: verify how this is handled by `copy` with `--compress`
                 - name: flatten
                   value: 'false'
                 - name: group
@@ -110,9 +93,11 @@ spec:
                 - name: group_size
                   value: '{{inputs.parameters.group_size}}'
                 - name: transform
-                  value: '{{workflow.parameters.transform}}'
+                  value: 'f'
                 - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
+                  value: '{{inputs.parameters.version_argo_tasks}}'
+                - name: aws_role_config_path
+                  value: 's3://linz-bucket-config/config-write.topographic.json, s3://linz-bucket-config/config-write.hydrographic.json'
                 - name: compress
                   value: 'true'
                 - name: delete_source

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -111,6 +111,7 @@ spec:
           - name: include
           - name: exclude
           - name: copy_option
+            default: '--no-clobber'
           - name: aws_role_config_path
             default: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json'
           - name: flatten

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -117,6 +117,7 @@ spec:
           - name: group
           - name: group_size
           - name: version_argo_tasks
+            default: 'v4'
           - name: compress # This should not be exposed to the user (as a workflow parameter)
             default: 'false'
           - name: delete_source # This should not be exposed to the user (as a workflow parameter)

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -110,6 +110,8 @@ spec:
           - name: target
           - name: include
           - name: exclude
+          - name: copy_option
+          - name: aws_role_config_path
           - name: flatten
           - name: group
           - name: group_size
@@ -141,7 +143,7 @@ spec:
                 - name: group_size
                   value: '{{inputs.parameters.group_size}}'
                 - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
+                  value: '{{inputs.parameters.version_argo_tasks}}'
 
           - name: copy
             templateRef:
@@ -150,7 +152,7 @@ spec:
             arguments:
               parameters:
                 - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
+                  value: '{{inputs.parameters.copy_option}}'
                 - name: file
                   value: '{{item}}'
                 - name: compress
@@ -158,9 +160,9 @@ spec:
                 - name: delete_source
                   value: '{{inputs.parameters.delete_source}}'
                 - name: version_argo_tasks
-                  value: '{{workflow.parameters.version_argo_tasks}}'
+                  value: '{{inputs.parameters.version_argo_tasks}}'
                 - name: aws_role_config_path
-                  value: '{{workflow.parameters.aws_role_config_path}}'
+                  value: '{{inputs.parameters.aws_role_config_path}}'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
 

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -157,6 +157,8 @@ spec:
                   value: '{{inputs.parameters.exclude}}'
                 - name: flatten
                   value: '{{inputs.parameters.flatten}}'
+                - name: transform
+                  value: '{{inputs.parameters.transform}}'
                 - name: group
                   value: '{{inputs.parameters.group}}'
                 - name: group_size

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -4,9 +4,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: copy
-  labels:
-    linz.govt.nz/category: raster
-    linz.govt.nz/data-type: raster
 spec:
   parallelism: 50
   nodeSelector:
@@ -29,8 +26,6 @@ spec:
   podMetadata:
     labels:
       linz.govt.nz/user-group: '{{workflow.parameters.user_group}}'
-      linz.govt.nz/category: raster
-      linz.govt.nz/data-type: raster
       linz.govt.nz/ticket: '{{workflow.parameters.ticket}}'
       linz.govt.nz/region: '{{workflow.parameters.region}}'
   arguments:
@@ -118,6 +113,11 @@ spec:
           - name: flatten
           - name: group
           - name: group_size
+          - name: version_argo_tasks
+          - name: compress # This should not be exposed to the user (as a workflow parameter)
+            default: 'false'
+          - name: delete_source # This should not be exposed to the user (as a workflow parameter)
+            default: 'false'
       dag:
         tasks:
           - name: create-manifest
@@ -153,6 +153,10 @@ spec:
                   value: '{{workflow.parameters.copy_option}}'
                 - name: file
                   value: '{{item}}'
+                - name: compress
+                  value: '{{inputs.parameters.compress}}'
+                - name: delete_source
+                  value: '{{inputs.parameters.delete_source}}'
                 - name: version_argo_tasks
                   value: '{{workflow.parameters.version_argo_tasks}}'
                 - name: aws_role_config_path

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -112,6 +112,7 @@ spec:
           - name: exclude
           - name: copy_option
           - name: aws_role_config_path
+            default: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json'
           - name: flatten
           - name: group
           - name: group_size

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -107,17 +107,33 @@ spec:
       inputs:
         parameters:
           - name: source
+            value: '{{workflow.parameters.source}}'
           - name: target
+            value: '{{workflow.parameters.target}}'
           - name: include
+            value: '{{workflow.parameters.include}}'
           - name: exclude
+            value: '{{workflow.parameters.exclude}}'
           - name: copy_option
+            value: '{{workflow.parameters.copy_option}}'
             default: '--no-clobber'
           - name: aws_role_config_path
+            value: '{{workflow.parameters.aws_role_config_path}}'
             default: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json'
           - name: flatten
+            value: '{{workflow.parameters.flatten}}'
+            default: 'false'
+          - name: transform
+            value: '{{workflow.parameters.transform}}'
+            default: 'f'
           - name: group
+            value: '{{workflow.parameters.group}}'
+            default: '1000'
           - name: group_size
+            value: '{{workflow.parameters.group_size}}'
+            default: '100Gi'
           - name: version_argo_tasks
+            value: '{{workflow.parameters.version_argo_tasks}}'
             default: 'v4'
           - name: compress # This should not be exposed to the user (as a workflow parameter)
             default: 'false'


### PR DESCRIPTION
### Motivation
In order to save cloud storage costs, the Data Managers should be able to move source data that have already been processed to a designated archive bucket with a Glacier Deep Archive lifecycle policy. The source data would be deleted and non-current versions expired after a set date (as per source bucket configuration).

### Modification

#### Features
- Add a `workflowTemplate` `tpl-at-archive-setup` to call the [`linz/argo-tasks/archive-setup`](https://github.com/linz/argo-tasks/pull/1218) command
- Add a `archive` `workflowTemplate` to allow the Data Managers to archive files.
- Give `tpl-at-copy` `workflowTemplate` the ability to compress destination data with `--compress=false/true` option
- Give `tpl-at-copy` `workflowTemplate` the ability to delete source data with `--delete-source=false/true` option

#### Refactor
- Move `copy` workflow into `storage` folder
- Expose all `copy` workflow parameters to its `main` template inputs parameters

### Verification

Argo Workflows ran