### PR TITLE
feat: compress and delete source files TDE-1482

### DIFF
--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -31,6 +31,20 @@ spec:
               - '--force'
               - '--force-no-clobber'
 
+          - name: compress
+            description: Compress files during copy
+            default: '--compress'
+            enum:
+              - '--compress'
+              - ''
+
+          - name: delete_source
+            description: Delete source file after successful copy
+            default: ''
+            enum:
+              - '--delete-source'
+              - ''
+
           - name: aws_role_config_path
             description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
             default: 's3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json'
@@ -44,4 +58,11 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: '{{inputs.parameters.aws_role_config_path}},s3://linz-bucket-config/config.json'
-        args: ['copy', '{{inputs.parameters.copy_option}}', '{{inputs.parameters.file}}']
+        args:
+          [
+            'copy',
+            '{{inputs.parameters.copy_option}}',
+            '{{inputs.parameters.compress}}',
+            '{{inputs.parameters.delete_source}}',
+            '{{inputs.parameters.file}}',
+          ]


### PR DESCRIPTION
**Motivation**
The requirement to move data to a designated archive bucket with a Glacier Deep Archive lifecycle policy in order to retain data not frequently accessed for the medium/long term at a lower cost. The source data would be deleted and noncurrent versions expired after a set date.

**Modification**

- Give copy workflow the ability to compress destination data with `--compress` option
- Give copy workflow the ability to delete source data with `--delete-source` option
