### PR TITLE
fix: survey id is not passed to stac-setup TDE-1503

### DIFF
--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -31,6 +31,9 @@ spec:
             default: ''
           - name: geospatial_category
             description: 'Geospatial category of the dataset'
+          - name: survey_id
+            description: '(Optional) Survey Number associated with historical datasets, e.g. "SN8844"'
+            default: ''
           - name: odr_url
             description: '(Optional) S3 path to existing dataset collection.json'
             default: ''
@@ -53,6 +56,7 @@ spec:
           - '--odr-url={{inputs.parameters.odr_url}}'
           - '--geospatial-category={{inputs.parameters.geospatial_category}}'
           - '--gsd={{inputs.parameters.gsd}}'
+          - '--survey-id={{inputs.parameters.survey_id}}'
       outputs:
         parameters:
           - name: collection_id

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: imagery-standardising
+  name: test-historical-is
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster
@@ -368,6 +368,8 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.geographic_description)}}'
                 - name: geospatial_category
                   value: '{{=sprig.trim(workflow.parameters.category)}}'
+                - name: survey_id
+                  value: '{{=sprig.trim(workflow.parameters.historic_survey_number)}}'
                 - name: odr_url
                   value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
                 - name: version

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-historical-is
+  name: imagery-standardising
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster


### PR DESCRIPTION
### Motivation

Historical imagery dataset have a Historical Survey Number. `stac-setup` needs this information to run when processing a historical dataset. 

### Modifications

- Allow `stac-setup` workflowTemplate to receive the survey ID and pass it to the `linz/argo-tasks` `stac-setup` command
- Pass the Historical Survey Number from the `imagery-standardising` workflow to the `stac-setup` template

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Argo Workflows test
