### PR TITLE
fix: stac-setup is failing when survey_id has no value TDE-1509

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+## Known issues
+
+### Passing optional parameters to `linz/argo-tasks` CLI
+
+[linz/argo-tasks](https://github.com/linz/argo-tasks/) uses [`cmd-ts`](https://github.com/Schniz/cmd-ts) which has an issue when an optional parameter is passed without value at the end of the command.
+
+For example:
+
+```yaml
+-   name: main
+    [...]
+    container:
+    image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=inputs.parameters.version}}'
+    args:
+        - 'stac'
+        - 'setup'
+        - '--start-year={{=sprig.trunc(4, inputs.parameters.start_datetime)}}'
+        - '--end-year={{=sprig.trunc(4, inputs.parameters.end_datetime)}}'
+        - '--region={{inputs.parameters.region}}'
+        - '--geographic-description={{inputs.parameters.geographic_description}}'
+        - '--odr-url={{inputs.parameters.odr_url}}'
+        - '--geospatial-category={{inputs.parameters.geospatial_category}}'
+        - '--gsd={{inputs.parameters.gsd}}'
+        - '--survey-id={{inputs.parameters.survey_id}}' # optional parameter
+```
+
+will generate the following error:
+
+```shell
+  stac setup --start-year= --end-year= --region=new-zealand --geographic-description= --odr-url=s3://nz-elevation/new-zealand/new-zealand/dem-hillshade_1m/2193/ --geospatial-category=dem-hillshade --gsd=1 --survey-id
+                                                                                                                                                                                                             ^ No value provided for --survey-id
+```
+
+To workaround this issue, place the optional parameters before any mandatory parameter (that will have a value):
+
+```yaml
+args:
+  - 'stac'
+  - 'setup'
+  - '--start-year={{=sprig.trunc(4, inputs.parameters.start_datetime)}}'
+  - '--end-year={{=sprig.trunc(4, inputs.parameters.end_datetime)}}'
+  - '--region={{inputs.parameters.region}}'
+  - '--geographic-description={{inputs.parameters.geographic_description}}'
+  - '--survey-id={{inputs.parameters.survey_id}}' # optional parameter
+  - '--odr-url={{inputs.parameters.odr_url}}'
+  - '--geospatial-category={{inputs.parameters.geospatial_category}}'
+  - '--gsd={{inputs.parameters.gsd}}'
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ args:
   - "{{= sprig.empty(inputs.parameters.start_datetime) ? '' : '--start-year=' + sprig.trunc(4, inputs.parameters.start_datetime) }}"
 ```
 
-Will result to not passing `--start-year` at all if `inputs.parameters.start_datetime` is empty
+Will result to not passing `--start-year` at all if `inputs.parameters.start_datetime` is empty.
 
 #### Bad
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,50 +1,25 @@
 # Contributing
 
-## Known issues
+## Workflows
 
-### Passing optional parameters to `linz/argo-tasks` CLI
+### Optional arguments
 
-[linz/argo-tasks](https://github.com/linz/argo-tasks/) uses [`cmd-ts`](https://github.com/Schniz/cmd-ts) which has an issue when an optional parameter is passed without value at the end of the command.
+To deal with optional arguments in a template, prioritize conditionally passing the argument rather than passing it with no value.
 
-For example:
-
-```yaml
--   name: main
-    [...]
-    container:
-    image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=inputs.parameters.version}}'
-    args:
-        - 'stac'
-        - 'setup'
-        - '--start-year={{=sprig.trunc(4, inputs.parameters.start_datetime)}}'
-        - '--end-year={{=sprig.trunc(4, inputs.parameters.end_datetime)}}'
-        - '--region={{inputs.parameters.region}}'
-        - '--geographic-description={{inputs.parameters.geographic_description}}'
-        - '--odr-url={{inputs.parameters.odr_url}}'
-        - '--geospatial-category={{inputs.parameters.geospatial_category}}'
-        - '--gsd={{inputs.parameters.gsd}}'
-        - '--survey-id={{inputs.parameters.survey_id}}' # optional parameter
-```
-
-will generate the following error:
-
-```shell
-  stac setup --start-year= --end-year= --region=new-zealand --geographic-description= --odr-url=s3://nz-elevation/new-zealand/new-zealand/dem-hillshade_1m/2193/ --geospatial-category=dem-hillshade --gsd=1 --survey-id
-                                                                                                                                                                                                             ^ No value provided for --survey-id
-```
-
-To workaround this issue, place the optional parameters before any mandatory parameter (that will have a value):
+#### Good
 
 ```yaml
 args:
-  - 'stac'
-  - 'setup'
-  - '--start-year={{=sprig.trunc(4, inputs.parameters.start_datetime)}}'
-  - '--end-year={{=sprig.trunc(4, inputs.parameters.end_datetime)}}'
-  - '--region={{inputs.parameters.region}}'
-  - '--geographic-description={{inputs.parameters.geographic_description}}'
-  - '--survey-id={{inputs.parameters.survey_id}}' # optional parameter
-  - '--odr-url={{inputs.parameters.odr_url}}'
-  - '--geospatial-category={{inputs.parameters.geospatial_category}}'
-  - '--gsd={{inputs.parameters.gsd}}'
+  - "{{= sprig.empty(inputs.parameters.start_datetime) ? '' : '--start-year=' + sprig.trunc(4, inputs.parameters.start_datetime) }}"
 ```
+
+Will result to not passing `--start-year` at all if `inputs.parameters.start_datetime` is empty
+
+#### Bad
+
+```yaml
+args:
+  - '--start-year={{=sprig.trunc(4, inputs.parameters.start_datetime)}}
+```
+
+Will result to pass `--start-year=` (empty value). **This can cause an issue with some CLI tools.**

--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -53,10 +53,10 @@ spec:
           - '--end-year={{=sprig.trunc(4, inputs.parameters.end_datetime)}}'
           - '--region={{inputs.parameters.region}}'
           - '--geographic-description={{inputs.parameters.geographic_description}}'
+          - '--survey-id={{inputs.parameters.survey_id}}'
           - '--odr-url={{inputs.parameters.odr_url}}'
           - '--geospatial-category={{inputs.parameters.geospatial_category}}'
           - '--gsd={{inputs.parameters.gsd}}'
-          - '--survey-id={{inputs.parameters.survey_id}}'
       outputs:
         parameters:
           - name: collection_id

--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -49,14 +49,15 @@ spec:
         args:
           - 'stac'
           - 'setup'
-          - '--start-year={{=sprig.trunc(4, inputs.parameters.start_datetime)}}'
-          - '--end-year={{=sprig.trunc(4, inputs.parameters.end_datetime)}}'
           - '--region={{inputs.parameters.region}}'
-          - '--geographic-description={{inputs.parameters.geographic_description}}'
-          - '--survey-id={{inputs.parameters.survey_id}}'
-          - '--odr-url={{inputs.parameters.odr_url}}'
           - '--geospatial-category={{inputs.parameters.geospatial_category}}'
           - '--gsd={{inputs.parameters.gsd}}'
+          - "{{= sprig.empty(inputs.parameters.start_datetime) ? '' : '--start-year=' + sprig.trunc(4, inputs.parameters.start_datetime) }}"
+          - "{{= sprig.empty(inputs.parameters.end_datetime) ? '' : '--end-year=' + sprig.trunc(4, inputs.parameters.end_datetime) }}"
+          - "{{= sprig.empty(inputs.parameters.geographic_description) ? '' : '--geographic-description=' + inputs.parameters.geographic_description }}"
+          - "{{= sprig.empty(inputs.parameters.survey_id) ? '' : '--survey-id=' + inputs.parameters.survey_id }}"
+          - "{{= sprig.empty(inputs.parameters.odr_url) ? '' : '--odr-url=' + inputs.parameters.odr_url }}"
+
       outputs:
         parameters:
           - name: collection_id


### PR DESCRIPTION
### Motivation

[linz/argo-tasks](https://github.com/linz/argo-tasks) uses [`cmd-ts`](https://github.com/Schniz/cmd-ts/) which seems to have an issue when an optional parameter is passed with no value at the end of the command.

### Modifications

- conditionally pass the argument
- add documentation for best practices

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Argo Workflows run
