### PR TITLE
chore: remove references to linz-workflow-artifacts bucket TDE-1502

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ data.title : "Wellington Urban Aerial Photos (1987-1988) SN8790" and data.url : 
 
 ### Workflow Artifacts
 
-All workflow outputs and logs are stored in the artifacts bucket, in the `linz-workflow-artifacts` bucket on the `li-topo-prod` account.
+All workflow outputs and logs are stored in the artifacts bucket, in the `linz-workflows-scratch` bucket on the `li-topo-prod` account.
 
 All outputs follow the same naming convention:
 
 ```
-s3://linz-workflow-artifacts/YYYY-mm/dd-workflow.name/pod.name/
+s3://linz-workflows-scratch/YYYY-mm/dd-workflow.name/pod.name/
 ```
 
 For each pod the logs are saved as a `main.log` file within the related `pod.name` prefix.
@@ -175,7 +175,7 @@ Once inside the container you can run a number of commands.
 For example, if trouble shooting network issues, you could run the following:
 
 ```bash
-mtr linz-workflow-artifacts.s3.ap-southeast-2.amazonaws.com
+mtr linz-workflows-scratch.s3.ap-southeast-2.amazonaws.com
 ```
 
 ```bash
@@ -183,7 +183,7 @@ mtr sts.ap-southeast-2.amazonaws.com
 ```
 
 ```bash
-watch --errexit nslookup linz-workflow-artifacts.s3.ap-southeast-2.amazonaws.com
+watch --errexit nslookup linz-workflows-scratch.s3.ap-southeast-2.amazonaws.com
 ```
 
 ## Concurrency

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ This document describes the settings that can be applied to Argo Workflows in ge
 
 Argo Workflows allows users to define a series of tasks to be carried out, where each task specifies code to be run, often in parallel. Tasks have inputs and outputs which are managed by Argo so that information can be passed along a workflow between tasks.
 
-Each task runs inside a container, which runs on an Argo “pod”. The Topo Argo Workflows is installed on the AWS Elastic Kubernetes Service (EKS), and pods run on AWS Elastic Computer Cloud (EC2) Spot Instances (providing the best value for money). Multiple pods can run on each EC2 instance at the same time. Output “artifacts” (e.g. processed files, configuration to be used later) and logs are stored in the S3 bucket: `linz-workflow-artifacts`.
+Each task runs inside a container, which runs on an Argo “pod”. The Topo Argo Workflows is installed on the AWS Elastic Kubernetes Service (EKS), and pods run on AWS Elastic Computer Cloud (EC2) Spot Instances (providing the best value for money). Multiple pods can run on each EC2 instance at the same time. Output “artifacts” (e.g. processed files, configuration to be used later) and logs are stored in the S3 bucket: `linz-workflows-scratch`.
 
 Requesting EC2 instances is done by the Karpenter Autoscaler, based on the resource requirements of the workflow.
 

--- a/tools/generate-argo-cli-commands-elevation.py
+++ b/tools/generate-argo-cli-commands-elevation.py
@@ -63,7 +63,7 @@ def _valid_params(params: Dict[str, str]) -> Tuple[bool, str]:
     return (True, "")
 
 def _tmp_target_edit(target: str) -> str:
-    return target.replace("s3://linz-elevation/", "s3://linz-workflow-artifacts/linz-elevation/")
+    return target.replace("s3://linz-elevation/", "s3://linz-workflows-scratch/linz-elevation/")
 
 
 with open(PARAMETERS_CSV, "r") as csv_file:

--- a/workflows/basemaps/README.md
+++ b/workflows/basemaps/README.md
@@ -146,22 +146,22 @@ It is mainly used for the Standardising workflow to provide visual QA for the st
 
 ## Workflow Input Parameters
 
-| Parameter | Type | Default                                    | Description                       |
-| --------- | ---- | ------------------------------------------ | --------------------------------- |
-| location  | str  | s3://linz-workflow-artifacts/path_of_tiffs | the uri (path) to the input tiffs |
+| Parameter | Type | Default                                   | Description                       |
+| --------- | ---- | ----------------------------------------- | --------------------------------- |
+| location  | str  | s3://linz-workflows-scratch/path_of_tiffs | the uri (path) to the input tiffs |
 
 ### Example Input Parameters
 
-| Parameter | Value                                                                          |
-| --------- | ------------------------------------------------------------------------------ |
-| source    | s3://linz-workflow-artifacts/2022-11/30-imagery-standardising-v0.2.0-60-v9rwq/ |
+| Parameter | Value                                                                         |
+| --------- | ----------------------------------------------------------------------------- |
+| source    | s3://linz-workflows-scratch/2022-11/30-imagery-standardising-v0.2.0-60-v9rwq/ |
 
 ## Workflow Outputs
 
 The S3 path to the processed TIFFs and the Basemaps visualisation URL can be found in the create-config pod outputs.
 for example:
 
-**location:**: `s3://linz-workflow-artifacts/2022-11/30-imagery-standardising-v0.2.0-60-v9rwq/`
+**location:**: `s3://linz-workflows-scratch/2022-11/30-imagery-standardising-v0.2.0-60-v9rwq/`
 
 **uri:** `https://basemaps.linz.govt.nz?config=...`
 
@@ -179,10 +179,10 @@ This is mainly used for the Standardising workflow and Imagery-Import workflow w
 
 ## Workflow Input Parameters
 
-| Parameter | Type | Default                                        | Description                                                                                                    |
-| --------- | ---- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| source    | str  | s3://linz-workflow-artifacts/path_of_tiffs/    | The URIs (paths) to the s3 tiff files.                                                                         |
-| output    | str  | s3://linz-workflow-artifacts/path_of_overview/ | The URIs (paths) to store the output overview.tar.co file which normally uses same location of the tiff files. |
+| Parameter | Type | Default                                       | Description                                                                                                    |
+| --------- | ---- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| source    | str  | s3://linz-workflows-scratch/path_of_tiffs/    | The URIs (paths) to the s3 tiff files.                                                                         |
+| output    | str  | s3://linz-workflows-scratch/path_of_overview/ | The URIs (paths) to store the output overview.tar.co file which normally uses same location of the tiff files. |
 
 ## Examples
 
@@ -190,9 +190,9 @@ Given a standardised imagery path and output the same path for the overview tar 
 
 ### Publish:
 
-**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+**source:** `s3://linz-workflows-scratch/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
 
-**output:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+**output:** `s3://linz-workflows-scratch/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
 
 # Create-Overview-All
 

--- a/workflows/raster/README.md
+++ b/workflows/raster/README.md
@@ -113,7 +113,7 @@ The S3 path to the processed TIFFs and the Basemaps visualisation URL can be fou
 for example:
 
 ```
-location: s3://linz-workflow-artifacts/2022-10/31-imagery-standardising-v0.02-58-df4gf
+location: s3://linz-workflows-scratch/2022-10/31-imagery-standardising-v0.02-58-df4gf
 ```
 
 ```
@@ -208,7 +208,7 @@ Creates a config of the imagery files within the `flat` directory and outputs a 
 
 Copy files from one S3 location to another. This workflow is intended to be used after standardising and QA to copy:
 
-- from `linz-workflow-artifacts` "flattened" directory to `linz-imagery`
+- from `linz-workflows-scratch` "flattened" directory to `linz-imagery`
 - from `linz-imagery-upload` to `linz-imagery-staging` to store a copy of the uploaded RGBI imagery.
 
 ```mermaid
@@ -242,7 +242,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 
 ### Publish:
 
-**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+**source:** `s3://linz-workflows-scratch/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
 
 **target:** `s3://linz-imagery/southland/invercargill_2022_0.1m/rgb/2193/`
 
@@ -291,7 +291,7 @@ graph TD;
 
 ### Publish:
 
-**source:** `s3://linz-workflow-artifacts/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
+**source:** `s3://linz-workflows-scratch/2022-11/15-imagery-standardising-v0.2.0-56-x7699/flat/`
 
 **target_bucket_name:** `nz-imagery`
 


### PR DESCRIPTION
### Motivation

`s3://linz-workflow-artifacts` bucket has been deleted.

### Modifications

- replace `linz-workflow-artifacts` occurrences to `linz-workflows-scratch`

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Search and Replace
