### PR TITLE
feat: add context to disable some features cluster deploy

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -48,8 +48,17 @@ Then a deployment can be made with `cdk`:
 ci_role="$(aws iam list-roles | jq --raw-output '.Roles[] | select(.RoleName | contains("CiTopo")) | select(.RoleName | contains("-CiRole")).Arn')"
 admin_role="arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/AccountAdminRole"
 workflow_maintainer_role="$(aws cloudformation describe-stacks --stack-name=TopographicSharedResourcesProd | jq --raw-output .Stacks[0].Outputs[0].OutputValue)"
+
 npx cdk deploy --context=maintainer-arns="${ci_role},${admin_role},${workflow_maintainer_role}" Workflows
 ```
+
+### Testing Clusters
+
+Sometimes a simpler cluster can be useful for testing, some deployment steps can be turned off
+
+- `cluster-suffix` - EKS cluster names are unique, use a specific cluster
+- `no-database` - Turn off creating RDS database
+- `no-slack` - Turn off creating slack monitoring alerts for RDS
 
 ### Deploy CDK8s
 

--- a/infra/cdk.ts
+++ b/infra/cdk.ts
@@ -1,6 +1,6 @@
 import { App } from 'aws-cdk-lib';
 
-import { ClusterName, DefaultRegion } from './constants.js';
+import { DefaultRegion, getClusterName } from './constants.js';
 import { tryGetContextArns } from './eks/arn.js';
 import { LinzEksCluster } from './eks/cluster.js';
 import { fetchSsmParameters } from './util/ssm.js';
@@ -9,24 +9,37 @@ const app = new App();
 
 async function main(): Promise<void> {
   const accountId = (app.node.tryGetContext('aws-account-id') as unknown) ?? process.env['CDK_DEFAULT_ACCOUNT'];
-  const maintainerRoleArns = tryGetContextArns(app.node, 'maintainer-arns');
+  const maintainerRoleArns = tryGetContextArns(app.node, 'maintainer-arns') ?? [];
+  const noDatabase = app.node.tryGetContext('no-database') === 'true';
+  const clusterName = getClusterName(app.node.tryGetContext('cluster-suffix'));
+
   const slackSsmConfig = await fetchSsmParameters({
     slackChannelConfigurationName: '/rds/alerts/slack/channel/name',
     slackWorkspaceId: '/rds/alerts/slack/workspace/id',
     slackChannelId: '/rds/alerts/slack/channel/id',
   });
 
-  if (maintainerRoleArns == null) throw new Error('Missing context: maintainer-arns');
   if (typeof accountId !== 'string') {
-    throw new Error("Missing AWS Account information, set with either '-c aws-account-id' or $CDK_DEFAULT_ACCOUNT");
+    throw new Error(
+      "Missing AWS Account information, set with either '--context=aws-account-id=123456789' or $CDK_DEFAULT_ACCOUNT",
+    );
   }
 
-  new LinzEksCluster(app, ClusterName, {
+  if (maintainerRoleArns.length === 0) console.log('No maintainer roles found');
+
+  /** LINZ conventional name for Argo Workflows artifact bucket */
+  const ScratchBucketName = `linz-${clusterName.toLowerCase()}-scratch`;
+
+  new LinzEksCluster(app, clusterName, {
     env: { region: DefaultRegion, account: accountId },
     maintainerRoleArns,
-    slackChannelConfigurationName: slackSsmConfig.slackChannelConfigurationName,
-    slackWorkspaceId: slackSsmConfig.slackWorkspaceId,
-    slackChannelId: slackSsmConfig.slackChannelId,
+    slack: {
+      workspaceId: slackSsmConfig.slackWorkspaceId,
+      channelId: slackSsmConfig.slackChannelId,
+      channelConfigurationName: slackSsmConfig.slackChannelConfigurationName,
+    },
+    tempBucketName: ScratchBucketName,
+    argoDatabaseName: noDatabase ? undefined : 'argo',
   });
 
   app.synth();

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -8,16 +8,19 @@ import { FluentBit } from './charts/fluentbit.js';
 import { Karpenter, KarpenterProvisioner } from './charts/karpenter.js';
 import { CoreDns } from './charts/kube-system.coredns.js';
 import { NodeLocalDns } from './charts/kube-system.node.local.dns.js';
-import { CfnOutputKeys, ClusterName, ScratchBucketName, UseNodeLocalDns, validateKeys } from './constants.js';
+import { CfnOutputKeys, getClusterName, validateKeys } from './constants.js';
 import { describeCluster, getCfnOutputs } from './util/cloud.formation.js';
 import { fetchSsmParameters } from './util/ssm.js';
 
 const app = new App();
 
 async function main(): Promise<void> {
+  const noNodeLocalDns = app.node.tryGetContext('no-node-local-dns') === 'true';
+  const clusterName = getClusterName(app.node.tryGetContext('cluster-suffix'));
+
   // Get cloudformation outputs
   const [cfnOutputs, ssmConfig, clusterConfig] = await Promise.all([
-    getCfnOutputs(ClusterName),
+    getCfnOutputs(clusterName),
     fetchSsmParameters({
       // Config for Cloudflared to access argo-server
       tunnelId: '/eks/cloudflared/argo/tunnelId',
@@ -31,7 +34,7 @@ async function main(): Promise<void> {
       // Argo Database connection password
       argoDbPassword: '/eks/argo/postgres/password',
     }),
-    describeCluster(ClusterName),
+    describeCluster(clusterName),
   ]);
   validateKeys(cfnOutputs);
 
@@ -39,7 +42,8 @@ async function main(): Promise<void> {
 
   // Node localDNS is very expermential in this cluster, it can and will break DNS resolution
   // If there are any issues with DNS, NodeLocalDNS should be disabled first.
-  if (UseNodeLocalDns) {
+  // `--context=no-node-local-dns=true`
+  if (noNodeLocalDns === false) {
     const ipv6Cidr = clusterConfig.kubernetesNetworkConfig?.serviceIpv6Cidr;
     if (ipv6Cidr == null) throw new Error('Unable to use node-local-dns without ipv6Cidr');
     const nodeLocal = new NodeLocalDns(app, 'node-local-dns', { serviceIpv6Cidr: ipv6Cidr });
@@ -48,12 +52,12 @@ async function main(): Promise<void> {
 
   const fluentbit = new FluentBit(app, 'fluentbit', {
     saName: cfnOutputs[CfnOutputKeys.FluentBitServiceAccountName],
-    clusterName: ClusterName,
+    clusterName: clusterName,
   });
   fluentbit.addDependency(coredns);
 
   const karpenter = new Karpenter(app, 'karpenter', {
-    clusterName: ClusterName,
+    clusterName: clusterName,
     clusterEndpoint: cfnOutputs[CfnOutputKeys.ClusterEndpoint],
     saName: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountName],
     saRoleArn: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountRoleArn],
@@ -61,7 +65,7 @@ async function main(): Promise<void> {
   });
 
   const karpenterProvisioner = new KarpenterProvisioner(app, 'karpenter-provisioner', {
-    clusterName: ClusterName,
+    clusterName: clusterName,
     clusterEndpoint: cfnOutputs[CfnOutputKeys.ClusterEndpoint],
     saName: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountName],
     saRoleArn: cfnOutputs[CfnOutputKeys.KarpenterServiceAccountRoleArn],
@@ -72,9 +76,11 @@ async function main(): Promise<void> {
 
   new ArgoWorkflows(app, 'argo-workflows', {
     namespace: 'argo',
-    clusterName: ClusterName,
+    clusterName: clusterName,
     saName: cfnOutputs[CfnOutputKeys.ArgoRunnerServiceAccountName],
-    tempBucketName: ScratchBucketName,
+    tempBucketName: cfnOutputs[CfnOutputKeys.ScratchBucketName],
+    argoDbUsername: cfnOutputs[CfnOutputKeys.ArgoDbUsername],
+    argoDbName: cfnOutputs[CfnOutputKeys.ArgoDbName],
     argoDbEndpoint: cfnOutputs[CfnOutputKeys.ArgoDbEndpoint],
     argoDbPassword: ssmConfig.argoDbPassword,
   });

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -1,28 +1,26 @@
-/** Cluster name */
-export const ClusterName = 'Workflows';
-/** LINZ conventional name for Argo Workflows artifact bucket */
-export const ScratchBucketName = `linz-${ClusterName.toLowerCase()}-scratch`;
-/** Argo Database Instance name */
-export const ArgoDbInstanceName = 'ArgoDb';
-/** Argo Database name */
-export const ArgoDbName = 'argo';
-/** Argo Database user */
-export const ArgoDbUser = 'argo_user';
 /** AWS default region for our stack */
 export const DefaultRegion = 'ap-southeast-2';
 
+const BaseClusterName = 'Workflows';
 /**
- * Should NodeLocal DNS be enabled for the cluster
- *
- * @see ./charts/kube-system.coredns.ts
+ * Using the context generate a cluster name
+ * @returns cluster name of `Workflows`
  */
-export const UseNodeLocalDns = true;
+export function getClusterName(clusterSuffix: unknown): string {
+  if (typeof clusterSuffix !== 'string') return BaseClusterName;
+  // convert `blacha` into `WorkflowsBlacha`
+  return `Workflows` + clusterSuffix.slice(0, 1).toUpperCase() + clusterSuffix.slice(1).toLowerCase();
+}
 
 /** CloudFormation Output to access from CDK8s */
 export const CfnOutputKeys = {
   ClusterEndpoint: 'ClusterEndpoint',
 
+  ScratchBucketName: 'ScratchBucketName',
+
   ArgoDbEndpoint: 'ArgoDbEndpoint',
+  ArgoDbName: 'ArgoDbName',
+  ArgoDbUsername: 'ArgoDbUsername',
 
   KarpenterServiceAccountName: 'KarpenterServiceAccountName',
   KarpenterServiceAccountRoleArn: 'KarpenterServiceAccountRoleArn',
@@ -45,7 +43,5 @@ export type CfnOutputMap = Record<ICfnOutputKeys, string>;
  */
 export function validateKeys(cfnOutputs: Record<string, string>): asserts cfnOutputs is CfnOutputMap {
   const missingKeys = Object.values(CfnOutputKeys).filter((f) => cfnOutputs[f] == null);
-  if (missingKeys.length > 0) {
-    throw new Error(`Missing CloudFormation Outputs for keys ${missingKeys.join(', ')}`);
-  }
+  if (missingKeys.length > 0) throw new Error(`Missing CloudFormation Outputs for keys ${missingKeys.join(', ')}`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@linzjs/topo-workflows",
       "version": "0.0.2",
       "license": "MIT",
+      "dependencies": {
+        "@aws-cdk/lambda-layer-kubectl-v32": "^2.1.0",
+        "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0"
+      },
       "devDependencies": {
         "@aws-cdk/lambda-layer-kubectl-v30": "^2.0.1",
         "@aws-sdk/client-cloudformation": "3.658.1",
@@ -40,20 +44,17 @@
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.204",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.204.tgz",
-      "integrity": "sha512-cm7aZKIubmBAS5IOkGEmh3h8VlKeOsNlLJJ39MnbmGZxXcW7+WaqIS7S4Z3YLKrs6EVQnrP8XQ2kt3cjkqKIJg==",
-      "dev": true
+      "integrity": "sha512-cm7aZKIubmBAS5IOkGEmh3h8VlKeOsNlLJJ39MnbmGZxXcW7+WaqIS7S4Z3YLKrs6EVQnrP8XQ2kt3cjkqKIJg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
-      "dev": true
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
-      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
-      "dev": true
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "38.0.1",
@@ -63,7 +64,6 @@
         "jsonschema",
         "semver"
       ],
-      "dev": true,
       "dependencies": {
         "jsonschema": "^1.4.1",
         "semver": "^7.6.3"
@@ -71,7 +71,6 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -80,7 +79,6 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -98,6 +96,26 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.85.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v32": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v32/-/lambda-layer-kubectl-v32-2.1.0.tgz",
+      "integrity": "sha512-a+zvCLapTg8R0P/Nrecc8mKV+ZgAwvkndn4/zlb43e14zRlc4/ozvmeghUT2eoyyaWJv+PwqgWohEXXec3kpSw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.94.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v33": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v33/-/lambda-layer-kubectl-v33-2.0.0.tgz",
+      "integrity": "sha512-osA3wkwWK2OfpymTcCZKhgaKSca9PQSr+7xi+UevKFRHtMdxHgygC345hdDpCtZlMmX9pKjtFpRUxeRrbGHMEw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.94.0",
         "constructs": "^10.0.5"
       }
     },
@@ -2497,7 +2515,6 @@
         "yaml",
         "mime-types"
       ],
-      "dev": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -2524,13 +2541,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.17.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2546,7 +2561,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2555,7 +2569,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2570,7 +2583,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2579,13 +2591,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2595,7 +2605,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -2604,7 +2613,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2616,37 +2624,31 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2660,13 +2662,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2675,7 +2675,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2684,13 +2683,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2702,7 +2699,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2711,13 +2707,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2726,7 +2720,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2738,7 +2731,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2750,7 +2742,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2759,7 +2750,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2768,7 +2758,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2780,7 +2769,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2797,7 +2785,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2811,7 +2798,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2823,7 +2809,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.8.2",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2839,7 +2824,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2848,7 +2832,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3437,7 +3420,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
       "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
-      "dev": true,
       "engines": {
         "node": ">= 16.14.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
     "constructs": "^10.3.0",
     "tsx": "^4.6.2",
     "yaml": "^2.5.1"
+  },
+  "dependencies": {
+    "@aws-cdk/lambda-layer-kubectl-v32": "^2.1.0",
+    "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0"
   }
 }

--- a/workflows/test/sleep.yml
+++ b/workflows/test/sleep.yml
@@ -7,6 +7,10 @@ metadata:
   labels:
     linz.govt.nz/category: test
 spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
   entrypoint: sleep
   podMetadata:
     labels:
@@ -14,16 +18,18 @@ spec:
   templates:
     - name: sleep
       nodeSelector:
-        karpenter.sh/capacity-type: 'on-demand'
-      tolerations:
-        - key: 'karpenter.sh/capacity-type'
-          operator: 'Equal'
-          value: 'on-demand'
-          effect: 'NoSchedule'
+        kubernetes.io/hostname: ip-10-161-39-85.ap-southeast-2.compute.internal
+      # nodeSelector:
+      #   karpenter.sh/capacity-type: 'on-demand'
+      # tolerations:
+      #   - key: 'karpenter.sh/capacity-type'
+      #     operator: 'Equal'
+      #     value: 'on-demand'
+      #     effect: 'NoSchedule'
       container:
         resources:
           requests:
-            memory: 3.9Gi
-            cpu: 2000m
-        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:latest
+            memory: 100Mi
+            cpu: 10m
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:v4
         command: ['sleep', '3600']


### PR DESCRIPTION
### Motivation

I am deploying a few testing EKS clusters and I need a way to disable some features as I dont need them for the testing clusters,

I would also like to make it easier for myself to deploy clusters with custom names to allow multiple clusters to be running in the same AWS account

### Modifications

adds context variables

##### Add a Suffix to the cluster name and scratch bucket name
```
-c cluster-suffix=blacha
```

##### Disable features
Turn off RDS and slack notifications
```
-c no-database=true
-c no-slack=true
```


### Verification

Deployed into nonprod