### PR TITLE
ci: share IRSA to pr namespace ServiceAccount

### DIFF
--- a/.github/argo-pr-env/serviceaccount.yaml
+++ b/.github/argo-pr-env/serviceaccount.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: workflow-runner-sa
   namespace: ${NAMESPACE}
+  annotations:
+    eks.amazonaws.com/role-arn: ${AWS_IRSA_ROLE_ARN}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/.github/workflows/argo-pr-env-deploy.yml
+++ b/.github/workflows/argo-pr-env-deploy.yml
@@ -12,6 +12,7 @@ jobs:
       packages: write
     env:
       AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
+      AWS_IRSA_ROLE_ARN: ${{ secrets.AWS_IRSA_ROLE_ARN }}
       CLUSTER_NAME: Workflows
       NAMESPACE: pr-${{ github.event.number }}
     steps:
@@ -42,7 +43,7 @@ jobs:
       - name: Create ServiceAccount
         run: |
           # shellcheck disable=SC2016
-          envsubst '${NAMESPACE}' < .github/argo-pr-env/serviceaccount.yaml | kubectl apply -f -
+          envsubst '${NAMESPACE}', '${AWS_IRSA_ROLE_ARN}' < .github/argo-pr-env/serviceaccount.yaml | kubectl apply -f -
       - name: Deploy Semaphore config
         run: |
           # shellcheck disable=SC2016


### PR DESCRIPTION
### Motivation

The PR namespace Service Account needs a IRSA ([IAM Role for ServiceAccount](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) to be able to do some operations on buckets and assume other shared roles.

### Modifications

- Manually added a GH Secret to share the IRSA. It is the one that is being created for the `argo` namespace ServiceAccount.
- Modify the ServiceAccount creation template to allow passing this IRSA
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
