### PR TITLE
fix: consistent ticket numbers within each workflow

### DIFF
--- a/workflows/cron/cron-national-dem-coastal.yaml
+++ b/workflows/cron/cron-national-dem-coastal.yaml
@@ -41,4 +41,4 @@ spec:
         - name: 'copy_option'
           value: '--force-no-clobber'
         - name: 'ticket'
-          value: ''
+          value: 'TDE-1524'

--- a/workflows/cron/cron-national-dem-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-dem-hillshades-coastal.yaml
@@ -32,7 +32,7 @@ spec:
         - name: version_topo_imagery
           value: 'v7'
         - name: ticket
-          value: 'TDE-1479'
+          value: 'TDE-1525'
         - name: source_geospatial_categories
           value: '["dem"]'
         - name: bucket_name


### PR DESCRIPTION
### Motivation

For consistency across CRON workflows, use the same ticket number in metadata and workflow arguments.

### Modifications

Added ticket number to `cron-national-dem-coastal` and fixed ticket number in `cron-national-dem-hillshades-coastal`.

### Verification

n/a
