### PR TITLE
feat(basemaps): Add stac-validate for shortbread ETL workflow. BM-1307

### DIFF
--- a/templates/argo-tasks/stac-validate.yml
+++ b/templates/argo-tasks/stac-validate.yml
@@ -40,6 +40,10 @@ spec:
             description: container version to use
             default: 'v4'
 
+          - name: aws_role_config_path
+            description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
+            value: 's3://linz-bucket-config/config.json'
+
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version)}}'
         resources:
@@ -48,7 +52,7 @@ spec:
             memory: 7.8Gi
         env:
           - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.json
+            value: '{{inputs.parameters.aws_role_config_path}}'
         args:
           - 'stac'
           - 'validate'

--- a/workflows/basemaps/vector-etl-shortbread.yaml
+++ b/workflows/basemaps/vector-etl-shortbread.yaml
@@ -173,6 +173,23 @@ spec:
                 - name: analyseTarget
                   value: '{{ tasks.tile-join.outputs.parameters.analyseTarget }}'
 
+          - name: stac-validate
+            depends: 'analyse'
+            when: '{{tasks.extract.outputs.parameters.updateRequired}} == true && {{ workflow.parameters.analyse }} == true'
+            templateRef:
+              name: tpl-at-stac-validate
+              template: main
+            arguments:
+              parameters:
+                - name: uri
+                  value: '{{tasks.tile-join.outputs.parameters.analyseTarget}}collection.json'
+                - name: aws_role_config_path
+                  value: s3://linz-bucket-config/config.basemaps.json
+              artifacts:
+                - name: stac-result
+                  raw:
+                    data: '{{tasks.stac-validate.outputs.result}}'
+
       outputs:
         parameters:
           - name: target

--- a/workflows/basemaps/vector-etl-shortbread.yaml
+++ b/workflows/basemaps/vector-etl-shortbread.yaml
@@ -111,6 +111,23 @@ spec:
                 - name: tile_matrix
                   value: '{{ inputs.parameters.tile_matrix }}'
 
+          - name: stac-validate-cache-files
+            depends: 'extract'
+            when: '{{tasks.extract.outputs.parameters.updateRequired}} == true'
+            templateRef:
+              name: tpl-at-stac-validate
+              template: main
+            arguments:
+              parameters:
+                - name: uri
+                  value: "{{workflow.parameters.cache}}{{= inputs.parameters.tile_matrix == 'WebMercatorQuad'? '3857' : '2193'}}/catalog.json"
+                - name: aws_role_config_path
+                  value: s3://linz-bucket-config/config.basemaps.json
+              artifacts:
+                - name: stac-result
+                  raw:
+                    data: '{{tasks.stac-validate.outputs.result}}'
+
           - name: group
             depends: extract
             when: '{{tasks.extract.outputs.parameters.updateRequired}} == true'


### PR DESCRIPTION
### Motivation

1. Support stac validation in the Shortbread ETL workflow to ensure we validate the stac files before publish to ODR.
2. Support stac validation for all the stac file created from extract command in the mbitile cache bucket.

### Modifications

Passing the new created stac collection.json that enable validate the stac collection and stac item recursively. 

### Verification

https://argo.linzaccess.com/workflows/argo/test-basemaps-vector-etl-shortbread-stac-pqvcp?tab=workflow&nodeId=test-basemaps-vector-etl-shortbread-stac-pqvcp-4003221865&nodePanelView=inputs-outputs&uid=870c6422-5dc6-4333-9e22-2ba266fce6c7
