### PR TITLE
feat: upgrade cloudflared TDE-1560

### DIFF
--- a/docs/infrastructure/components/cloudflared.md
+++ b/docs/infrastructure/components/cloudflared.md
@@ -1,0 +1,14 @@
+# Cloudflare
+
+Cloudflare provides Zero Trust Network (ZTN) access to the Argo Workflow service. Cloudflared is the daemon that is part of Cloudflare's Tunnel feature.
+
+All of the cloudflare configuration is managed by a web control pane [https://dash.teams.cloudflare.com](https://dash.teams.cloudflare.com).
+
+## Tunnel configuration
+
+The configuration for the Cloudflare Application and Tunnel is in a LINZ internal document.
+
+
+## Resources
+
+- [Argo Tunnel Examples](https://github.com/cloudflare/argo-tunnel-examples/)

--- a/docs/infrastructure/components/cloudflared.md
+++ b/docs/infrastructure/components/cloudflared.md
@@ -8,7 +8,6 @@ All of the cloudflare configuration is managed by a web control pane [https://da
 
 The configuration for the Cloudflare Application and Tunnel is in a LINZ internal document.
 
-
 ## Resources
 
 - [Argo Tunnel Examples](https://github.com/cloudflare/argo-tunnel-examples/)

--- a/infra/charts/cloudflared.ts
+++ b/infra/charts/cloudflared.ts
@@ -1,18 +1,19 @@
 import { Chart, ChartProps, Helm } from 'cdk8s';
+import { Namespace } from 'cdk8s-plus-32';
 import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.js';
 
 /**
- * This is the version of the Helm chart for Argo Workflows https://github.com/argoproj/argo-helm/blob/25d7b519bc7fc37d2820721cd648f3a3403d0e38/charts/argo-workflows/Chart.yaml#L6
+ * This is the version of the Helm chart for cloudflared https://github.com/cloudflare/helm-charts/blob/76f20fe9ca41d8c40fb138635cf23e545df8d45b/charts/cloudflare-tunnel/Chart.yaml#L13
  *
- * (Do not mix up with Argo Workflows application version)
+ * (Do not mix up with cloudflared application version)
  */
 const chartVersion = '0.3.2';
 
 /**
- * This is the version of Argo Workflows for the `chartVersion` we're using
- * https://github.com/argoproj/argo-helm/blob/2730dc24c7ad69b98d3206705a5ebf5cb34dd96b/charts/argo-workflows/Chart.yaml#L2
+ * This is the version of cloudflared for the `chartVersion` we're using
+ * https://github.com/cloudflare/helm-charts/blob/76f20fe9ca41d8c40fb138635cf23e545df8d45b/charts/cloudflare-tunnel/Chart.yaml#L19
  *
  */
 const appVersion = '2024.8.3';
@@ -25,11 +26,16 @@ export class Cloudflared extends Chart {
   ) {
     super(scope, id, applyDefaultLabels(props, 'cloudflared', appVersion, 'tunnel', 'workflows'));
 
+    // The helm chart does not create the namespace
+    new Namespace(this, 'namespace', {
+      metadata: { name: props.namespace },
+    });
+
     new Helm(this, 'cloudflared', {
       chart: 'cloudflare-tunnel',
       releaseName: 'cloudflare-tunnel',
       repo: 'https://cloudflare.github.io/helm-charts',
-      namespace: 'argo',
+      namespace: 'cloudflared',
       version: chartVersion,
       values: {
         cloudflare: {


### PR DESCRIPTION
### Motivation

The current version of `cloudflared` used in production is not working correctly with the version of `karpenter` we want to use (https://github.com/linz/topo-workflows/pull/1036). Also, Cloudflare has release [a Helm chart](https://github.com/cloudflare/helm-charts/) since the last time we deployed the cloudflare-tunnel.

### Modifications

- Create a CDK8S deployment of `cloudflared` using the Helm chart that uses `2024.8.3` of cloudflare-tunnel. (This is not the latest version, the latest is not available from the Helm chart yet - https://github.com/cloudflare/helm-charts/issues/102)

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Deployed in NonProd

<!-- TODO: Say how you tested your changes. -->
