### PR TITLE
feat: apply priority class TDE-1564

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -110,6 +110,7 @@ export class ArgoWorkflows extends Chart {
       values: {
         server: {
           replicas: 2,
+          priorityClassName: 'high-priority',
           extraEnv: [
             /** Disable the "first time" popups that pop up every time  */
             { name: 'FIRST_TIME_USER_MODAL', value: 'false' },
@@ -133,6 +134,7 @@ export class ArgoWorkflows extends Chart {
           extraEnv: [{ name: 'WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS', value: 'false' }],
           persistence,
           replicas: 2,
+          priorityClassName: 'high-priority',
           workflowDefaults: {
             spec: {
               serviceAccountName: props.saName,

--- a/infra/charts/event.exporter.ts
+++ b/infra/charts/event.exporter.ts
@@ -24,6 +24,7 @@ export class EventExporter extends Chart {
       namespace: 'event-exporter',
       version: chartVersion,
       values: {
+        priorityClassName: 'very-high-priority',
         config: {
           logLevel: 'error',
           logFormat: 'json',

--- a/infra/charts/fluentbit.ts
+++ b/infra/charts/fluentbit.ts
@@ -72,6 +72,7 @@ HC_Period 5
         fullnameOverride: 'fluentbit',
         input: { parser: FluentParserName, dockerMode: 'Off' },
         serviceAccount: { name: props.saName, create: false },
+        priorityClassName: 'very-high-priority',
         cloudWatchLogs: {
           enabled: true,
           region: DefaultRegion,

--- a/infra/charts/karpenter.ts
+++ b/infra/charts/karpenter.ts
@@ -84,6 +84,7 @@ export class Karpenter extends Chart {
       namespace: 'karpenter',
       version,
       values: {
+        priorityClassName: 'very-high-priority',
         serviceAccount: {
           create: false,
           name: props.saName,


### PR DESCRIPTION
### Motivation

Add PriorityClass to the Argo server / controller and other components to keep them from getting evicted in favour of workflow runners.

### Modifications

Set Argo Workflows Server and Workflow Controller to priorityClass `high-priority`
Set Karpenter, Fluentbit, Event Exporter to priorityClass `very-high-priority`

### Verification
Successfully synth'd yaml.
Manual testing on Dev cluster.