### PR TITLE
fix(basemaps): update topo-maps-standardising to use new cli v8 BM-1279

### DIFF
--- a/workflows/basemaps/topo-maps-standardising.yml
+++ b/workflows/basemaps/topo-maps-standardising.yml
@@ -23,7 +23,7 @@ spec:
     parameters:
       - name: version_basemaps_cli
         description: Version of the basemaps CLI docker container to use
-        value: v7
+        value: v8
 
       - name: version_argo_tasks
         description: Version of the argo tasks CLI docker container to use
@@ -38,7 +38,7 @@ spec:
 
       - name: target
         description: s3 directory into which to save the generated directory structure of STAC files and COGs
-        value: 's3://linz-topographic/'
+        value: 's3://linz-workflows-scratch/'
         enum:
           - 's3://linz-basemaps-staging/'
           - 's3://linz-workflows-scratch/'
@@ -166,6 +166,8 @@ spec:
                   value: '1000'
                 - name: group_size
                   value: '100Gi'
+                - name: transform
+                  value: 'f'
             depends: topo-stac-creation && topo-cog-creation
 
           - name: copy-latest
@@ -188,6 +190,8 @@ spec:
                   value: '1000'
                 - name: group_size
                   value: '100Gi'
+                - name: transform
+                  value: 'f'
             depends: topo-stac-creation && topo-cog-creation
 
     # List of the topographic tiles from source and import into target bucket
@@ -200,11 +204,12 @@ spec:
           - name: latest-only
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
+        command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
         args:
+          - 'cogify'
           - 'topo'
           - '--target={{ inputs.parameters.target }}'
           - '--map-series={{ inputs.parameters.map_series }}'
@@ -237,11 +242,12 @@ spec:
             cpu: 15000m # AWS gives 2x cpu cores = memory for most instances
             ephemeral-storage: 98Gi # 2 pods per 200GB of storage
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
+        command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
         args:
+          - 'cogify'
           - 'create'
           - '--from-file={{= inputs.artifacts.grouped.path }}{{inputs.parameters.grouped_id}}.json'
           - '--concurrency=2'
@@ -254,12 +260,13 @@ spec:
             description: Location of the imagery to create config for
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, /app/node_modules/@basemaps/cogify/dist/index.cjs]
+        command: [node, index.cjs]
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
         args:
           - 'config'
+          - 'create-config'
           - '{{ inputs.parameters.location }}'
       outputs:
         parameters:


### PR DESCRIPTION
### Motivation

update to use new cli container v8

### Modifications

* use cli container v8
* fix copy workflow(needed to pass transform arg)

### Verification

https://argo.linzaccess.com/workflows/argo/topo-raster-maps-standardising-l758f?tab=workflow&nodeId=topo-raster-maps-standardising-l758f-3909996927