### PR TITLE
feat: add priority class high-priority to cloudflared TDE-1569

### DIFF
--- a/infra/charts/cloudflared.ts
+++ b/infra/charts/cloudflared.ts
@@ -60,7 +60,7 @@ export class Cloudflared extends Chart {
       securityContext: { ensureNonRoot: false },
     });
 
-    // manually overwrite a few configuration options that could not be configured with cdk8s-plus
+    // manually set option that could not be configured with cdk8s-plus
     ApiObject.of(deployment).addJsonPatch(JsonPatch.add('/spec/template/spec/priorityClassName', 'high-priority'));
   }
 }

--- a/infra/charts/cloudflared.ts
+++ b/infra/charts/cloudflared.ts
@@ -1,4 +1,4 @@
-import { Chart, ChartProps, Size } from 'cdk8s';
+import { ApiObject, Chart, ChartProps, JsonPatch, Size } from 'cdk8s';
 import * as kplus from 'cdk8s-plus-32';
 import { Construct } from 'constructs';
 
@@ -40,7 +40,7 @@ export class Cloudflared extends Chart {
       }),
     );
 
-    new kplus.Deployment(this, 'tunnel', {
+    const deployment = new kplus.Deployment(this, 'tunnel', {
       // Ensure two tunnels are active
       replicas: 2,
       containers: [
@@ -59,5 +59,8 @@ export class Cloudflared extends Chart {
       ],
       securityContext: { ensureNonRoot: false },
     });
+
+    // manually overwrite a few configuration options that could not be configured with cdk8s-plus
+    ApiObject.of(deployment).addJsonPatch(JsonPatch.add('/spec/template/spec/priorityClassName', 'high-priority'));
   }
 }


### PR DESCRIPTION
### Motivation

Avoid cloudflared pods to be evicted before workflows runner

### Modifications

- add `high-priority` priorityClass to cloudflared pods
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

add the priorityclass to the pod specs

<!-- TODO: Say how you tested your changes. -->
