### PR TITLE
feat: give S3BatchRestore role RW access to scratch bucket TDE-1553

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         if: steps.get-infra-changes.outputs.run_infra == 'true'
         run: |
           npx cdk deploy ${{ env.CLUSTER_NAME }} \
-            -c maintainer-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }} \
+            -c maintainer-arns=${{ secrets.AWS_CI_ROLE }},${{ secrets.AWS_ADMIN_ROLE }},${{ secrets.AWS_WFMAINTAINER_ROLE }},${{ secrets.AWS_S3BATCHRESTORE_ROLE }} \
             -c aws-account-id=${{ secrets.AWS_ACCOUNT_ID }} \
             --require-approval never
       - name: Login to EKS


### PR DESCRIPTION
### Motivation

The CSV files to use S3 Batch Operations for restoring archived data will be stored in the workflow scratch bucket. S3BatchRestore role needs read and write access to this bucket.

### Modifications

- Added a GitHub Actions secret containing the S3BatchResore ARN role
- Give S3BatchRestore role r&w permission to the workflow scratch bucket

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
