### PR TITLE
fix: event-exporter config

### DIFF
--- a/infra/charts/event.exporter.ts
+++ b/infra/charts/event.exporter.ts
@@ -2,6 +2,7 @@ import { Chart, ChartProps, Helm } from 'cdk8s';
 import { Namespace } from 'cdk8s-plus-32';
 import { Construct } from 'constructs';
 
+import { ClusterName } from '../constants.js';
 import { applyDefaultLabels } from '../util/labels.js';
 
 /** This is the chart version vs app version which is 1.7.0
@@ -28,7 +29,7 @@ export class EventExporter extends Chart {
         config: {
           logLevel: 'error',
           logFormat: 'json',
-          clusterName: '',
+          clusterName: ClusterName,
           receivers: [
             {
               name: 'dump',

--- a/infra/charts/event.exporter.ts
+++ b/infra/charts/event.exporter.ts
@@ -28,6 +28,22 @@ export class EventExporter extends Chart {
         config: {
           logLevel: 'error',
           logFormat: 'json',
+          clusterName: '',
+          receivers: [
+            {
+              name: 'dump',
+              file: {
+                path: '/dev/stdout',
+              },
+            },
+          ],
+          route: {
+            routes: [
+              {
+                match: [{ receiver: 'dump' }],
+              },
+            ],
+          },
         },
         serviceAccount: {
           automountServiceAccountToken: true,


### PR DESCRIPTION
### Motivation

Since the deployment of https://github.com/linz/topo-workflows/pull/1037, event exporter is not loading its config properly. Seems to be an issue with the helm chart default `layout: {}`

### Modifications

- apply the entire configuration

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

deployed
![image](https://github.com/user-attachments/assets/d6c5865c-e09d-4692-8e67-110ad6959b08)


<!-- TODO: Say how you tested your changes. -->
