### PR TITLE
feat: use existing description for merged DEM hillshades TDE-1498

### DIFF
--- a/templates/topo-imagery/README.md
+++ b/templates/topo-imagery/README.md
@@ -118,6 +118,8 @@ See [collection_from_items.py](https://github.com/linz/topo-imagery/blob/master/
         value: '{{=sprig.trim(workflow.parameters.licensor_list)}}'
       - name: create_capture_dates
         value: 'false'
+      - name: keep_description
+        value: 'true'
       - name: keep_title
         value: 'true'
       - name: version_topo_imagery

--- a/templates/topo-imagery/create-collection.yaml
+++ b/templates/topo-imagery/create-collection.yaml
@@ -106,6 +106,10 @@ spec:
             description: 'Add a capture-dates.geojson.gz file to the collection assets'
             default: 'false'
 
+          - name: keep_description
+            description: 'Keep the description of the existing Collection'
+            default: 'false'
+
           - name: keep_title
             description: 'Keep the title of the existing Collection'
             default: 'false'
@@ -151,6 +155,8 @@ spec:
           - '{{=sprig.trim(inputs.parameters.lifecycle)}}'
           - '--add-title-suffix'
           - '{{inputs.parameters.add_title_suffix}}'
+          - '--keep-description'
+          - '{{inputs.parameters.keep_description}}'
           - '--keep-title'
           - '{{inputs.parameters.keep_title}}'
           - '--capture-dates'

--- a/workflows/cron/cron-national-merged-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: test-af-cron-national-merged-dem-hillshades
+  name: cron-national-merged-dem-hillshades
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster

--- a/workflows/cron/cron-national-merged-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: cron-national-merged-dem-hillshades
+  name: test-af-cron-national-merged-dem-hillshades
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster

--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -288,6 +288,8 @@ spec:
                   value: 'Toitū Te Whenua Land Information New Zealand'
                 - name: create_capture_dates
                   value: 'false'
+                - name: keep_description
+                  value: 'true'
                 - name: keep_title
                   value: 'true'
                 - name: version_topo_imagery


### PR DESCRIPTION
### Motivation

:mega: **Note:** linked to https://github.com/linz/topo-imagery/pull/1338 which should be merged and released before this PR is merged.

The DEM merged hillshades need a custom description in the same way that some datasets need a custom title. Add an option to keep existing descriptions (load them from the ODR URL).

### Modifications

Added a new flag `--keep-description` when updating the collection for the merged hillshades.

### Verification

Tested with a workflow. The collection was created with the existing description.