### PR TITLE
feat(basemaps): Move the cogify and create-pull-requests into workflow template. BM-1335

### DIFF
--- a/templates/basemaps/cogify.yml
+++ b/templates/basemaps/cogify.yml
@@ -21,10 +21,6 @@ spec:
         description: Version of the argo-tasks CLI docker container to use
         value: v4
 
-      - name: ticket
-        description: Ticket ID e.g. 'BM-55'
-        value: ''
-
       - name: preset
         description: Import preset configuration, WebP for 4 band RGBA LERC for 1 band DEM/DSM
         value: 'webp'

--- a/templates/basemaps/cogify.yml
+++ b/templates/basemaps/cogify.yml
@@ -1,0 +1,341 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tpl-bm-cogify
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+
+  arguments:
+    parameters:
+      - name: version_basemaps_cli
+        description: Version of the basemaps CLI docker container to use
+        value: v8
+
+      - name: version_argo_tasks
+        description: Version of the argo-tasks CLI docker container to use
+        value: v4
+
+      - name: ticket
+        description: Ticket ID e.g. 'BM-55'
+        value: ''
+
+      - name: preset
+        description: Import preset configuration, WebP for 4 band RGBA LERC for 1 band DEM/DSM
+        value: 'webp'
+        enum:
+          - 'webp'
+          - 'lerc_10mm'
+          - 'lerc_1mm'
+
+      - name: region
+        description: Region of the dataset
+        value: 'new-zealand'
+        enum:
+          - 'antarctica'
+          - 'auckland'
+          - 'bay-of-plenty'
+          - 'canterbury'
+          - 'gisborne'
+          - 'global'
+          - 'hawkes-bay'
+          - 'manawatu-whanganui'
+          - 'marlborough'
+          - 'nelson'
+          - 'new-zealand'
+          - 'northland'
+          - 'otago'
+          - 'pacific-islands'
+          - 'southland'
+          - 'taranaki'
+          - 'tasman'
+          - 'waikato'
+          - 'wellington'
+          - 'west-coast'
+
+      - name: source
+        description: Source imagery location "s3://linz-imagery"
+        value: 's3://linz-imagery-staging/test/sample/'
+
+      - name: require_stac_collection
+        description: Validate that a STAC collection.json exists with the source
+        value: 'true'
+        enum:
+          - 'true'
+          - 'false'
+
+      - name: target
+        description: Target location for output COGs
+        value: 's3://linz-basemaps/'
+        enum:
+          - 's3://linz-basemaps/'
+          - 's3://linz-basemaps-staging/'
+          - 's3://linz-workflowsnp-scratch/'
+
+      - name: tile_matrix
+        description: Output tile matrix, ";" separated list
+        value: 'WebMercatorQuad'
+        enum:
+          - 'NZTM2000Quad'
+          - 'WebMercatorQuad'
+
+      - name: cutline
+        description: Path to cutline to apply
+        value: 's3://linz-basemaps-source/cutline/2025-04-30-cutline-nz-coasts-rural-and-urban.geojson'
+
+      - name: cutline_blend
+        description: Blending to use for cutline see gdal_translate#cblend
+        value: '20'
+
+      - name: group_size
+        description: How many items to pass to each create-cog job
+        value: '20'
+
+      - name: create_overview
+        description: 'Create overview after importing imagery.'
+        value: 'true'
+        enum:
+          - 'true'
+          - 'false'
+
+      - name: background
+        description: 'Background RGBA hexstring to fill empty space in the COG. Format: "#rrggbbaa"'
+        value: ''
+
+      - name: base_zoom_offset
+        description: 'Adjust the base zoom level of the output COGS, "-1" reduce the target output resolution by one zoom level'
+        value: ''
+
+  templates:
+    # Generate COGs for a specific tile matrix from a given collection of source imagery
+    - name: main
+      inputs:
+        parameters:
+          - name: source
+          - name: target
+          - name: tile_matrix
+          - name: cutline
+          - name: cutline_blend
+          - name: group_size
+          - name: preset
+          - name: require_stac_collection
+          - name: base_zoom_offset
+          - name: background
+      dag:
+        tasks:
+          # generate a tile covering from the source imagery
+          - name: create-covering
+            template: create-covering
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{ inputs.parameters.source }}'
+                - name: target
+                  value: '{{ inputs.parameters.target }}'
+                - name: preset
+                  value: '{{ inputs.parameters.preset }}'
+                - name: tile_matrix
+                  value: '{{ inputs.parameters.tile_matrix }}'
+                - name: cutline
+                  value: '{{ inputs.parameters.cutline }}'
+                - name: cutline_blend
+                  value: '{{ inputs.parameters.cutline_blend }}'
+                - name: base_zoom_offset
+                  value: '{{ inputs.parameters.base_zoom_offset }}'
+                - name: require_stac_collection
+                  value: '{{ inputs.parameters.require_stac_collection }}'
+                - name: background
+                  value: '{{ inputs.parameters.background }}'
+
+          # Group covering output into chunks to pass to create-cog
+          - name: group
+            arguments:
+              parameters:
+                - name: size
+                  value: '{{ inputs.parameters.group_size }}'
+                - name: version
+                  value: '{{= workflow.parameters.version_argo_tasks }}'
+              artifacts:
+                - name: input
+                  from: '{{ tasks.create-covering.outputs.artifacts.tiles }}'
+            templateRef:
+              name: tpl-at-group
+              template: main
+            depends: create-covering
+
+          # Create COGS from the grouped output of create-covering
+          - name: create-cog
+            depends: group
+            template: create-cog
+            withParam: '{{ tasks.group.outputs.parameters.output }}'
+            arguments:
+              parameters:
+                - name: covering_grouped_id
+                  value: '{{ item }}'
+              artifacts:
+                - name: covering_grouped
+                  from: '{{ tasks.group.outputs.artifacts.output }}'
+
+          # TODO: overviews are only supported in RGBA pipelines
+          # once all COGs are created generate a more overviews to increase tile rendering performance
+          - name: create-overview
+            template: create-overview
+            when: '{{workflow.parameters.create_overview}} == true'
+            depends: create-cog
+            arguments:
+              parameters:
+                - name: path
+                  value: '{{ tasks.create-covering.outputs.parameters.target }}'
+
+          # Create a basemaps config to view the imagery directly
+          - name: create-config
+            template: create-config
+            depends: create-overview
+            arguments:
+              parameters:
+                - name: path
+                  value: '{{ tasks.create-covering.outputs.parameters.target }}'
+                - name: title
+                  value: '{{ tasks.create-covering.outputs.parameters.title }}'
+
+      outputs:
+        parameters:
+          - name: target
+            description: location of where the output tiffs were created
+            valueFrom:
+              parameter: '{{ tasks.create-covering.outputs.parameters.target }}'
+
+    # Generate a tile covering for input imagery
+    - name: create-covering
+      nodeSelector:
+        karpenter.sh/capacity-type: 'spot'
+      inputs:
+        parameters:
+          - name: source
+          - name: target
+          - name: tile_matrix
+          - name: cutline
+          - name: cutline_blend
+          - name: preset
+          - name: require_stac_collection
+          - name: base_zoom_offset
+          - name: background
+      container:
+        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
+        resources:
+          requests:
+            memory: 2Gi
+        command: [node, index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.basemaps.json
+        args:
+          - 'cogify'
+          - 'cover'
+          - '--preset={{ inputs.parameters.preset }}'
+          - '--tile-matrix={{ inputs.parameters.tile_matrix }}'
+          - '--require-stac-collection={{ inputs.parameters.require_stac_collection }}'
+          - "{{= sprig.empty(inputs.parameters.cutline) ? '' : '--cutline=' + inputs.parameters.cutline }}"
+          - '--cutline-blend={{ inputs.parameters.cutline_blend }}'
+          - "{{= sprig.empty(inputs.parameters.base_zoom_offset) ? '' : '--base-zoom-offset=' + inputs.parameters.base_zoom_offset }}"
+          - "{{= sprig.empty(inputs.parameters.background) ? '' : '--background=' + inputs.parameters.background }}"
+          - '--target={{= sprig.trim(inputs.parameters.target) }}'
+          - '{{= sprig.trim(inputs.parameters.source) }}'
+      outputs:
+        parameters:
+          - name: target
+            description: output path for where the covering was written
+            valueFrom:
+              path: /tmp/cogify/cover-target
+
+          - name: title
+            description: Title for the covering
+            valueFrom:
+              path: /tmp/cogify/cover-title
+
+        artifacts:
+          - name: tiles
+            path: /tmp/cogify/cover-items.json
+
+    # Actually create COGs using gdal_translate on a large spot instances
+    - name: create-cog
+      nodeSelector:
+        karpenter.sh/capacity-type: 'spot'
+      inputs:
+        artifacts:
+          - name: covering_grouped
+            path: /tmp/cogify/covering_grouped/
+        parameters:
+          - name: covering_grouped_id
+      container:
+        resources:
+          requests:
+            memory: 30Gi
+            cpu: 15000m # AWS gives 2x cpu cores = memory for most instances
+            ephemeral-storage: 98Gi # 2 pods per 200GB of storage
+        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
+        command: [node, index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.basemaps.json
+        args:
+          - 'cogify'
+          - 'create'
+          - '--from-file={{= inputs.artifacts.covering_grouped.path }}{{inputs.parameters.covering_grouped_id}}.json'
+          - '--concurrency=2'
+
+    # Create a basemaps configuration file to view the imagery
+    - name: create-config
+      inputs:
+        parameters:
+          - name: path
+            description: Location of the imagery to create config for
+      container:
+        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
+        command: [node, index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.basemaps.json
+        args:
+          - 'config'
+          - 'create-config'
+          - '{{ inputs.parameters.path }}'
+      outputs:
+        parameters:
+          - name: url
+            description: Basemaps URL to view the imagery
+            valueFrom:
+              path: '/tmp/cogify/config-url'
+          - name: config
+            description: Location of the config file
+            valueFrom:
+              path: '/tmp/cogify/config-path'
+
+    # create additional overviews for any COGs found in the path
+    - name: create-overview
+      nodeSelector:
+        karpenter.sh/capacity-type: 'spot'
+      inputs:
+        parameters:
+          - name: path
+            description: Location of the imagery to create overviews for
+      container:
+        resources:
+          requests:
+            memory: 7.8Gi
+            cpu: 15000m
+        image: ghcr.io/linz/basemaps/cli:v6
+        command: [node, index.cjs]
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.basemaps.json
+        args:
+          - '-V'
+          - 'create-overview'
+          - '--source={{= sprig.trim(inputs.parameters.path) }}'
+          - '--output={{= sprig.trim(inputs.parameters.path) }}'

--- a/templates/basemaps/create-pull-request.yml
+++ b/templates/basemaps/create-pull-request.yml
@@ -16,40 +16,39 @@ spec:
         description: Version of the argo-tasks CLI docker container to use
         value: v4
 
-      - name: ticket
-        description: Ticket ID e.g. 'BM-55'
-        value: ''
-
-      - name: config_type
-        description: 'Type of Basemaps Config file to create in pull requests'
-        value: 'raster'
-        enum:
-          - 'raster'
-          - 'elevation'
-
-      - name: individual
-        description: 'Individual Config or Combined Config'
-        value: 'combined'
-        enum:
-          - 'individual'
-          - 'combined'
-
-      - name: category
-        value: 'Rural Aerial Photos'
-        enum:
-          - 'Rural Aerial Photos'
-          - 'Urban Aerial Photos'
-          - 'Scanned Aerial Imagery'
-          - 'Satellite Imagery'
-          - 'Event'
-          - 'Elevation'
-
   templates:
     # Main entrypoint into the workflow
     - name: main
       inputs:
         parameters:
           - name: target
+          - name: ticket
+            description: Ticket ID e.g. 'BM-55'
+            value: ''
+          - name: config_type
+            description: 'Type of Basemaps Config file to create in pull requests'
+            value: 'raster'
+            enum:
+              - 'raster'
+              - 'elevation'
+              - 'vector'
+          - name: individual
+            description: 'Individual Config or Combined Config'
+            value: 'combined'
+            enum:
+              - 'individual'
+              - 'combined'
+          - name: category
+            description: 'Category of the Basemaps Config file'
+            value: 'Rural Aerial Photos'
+            enum:
+              - 'Rural Aerial Photos'
+              - 'Urban Aerial Photos'
+              - 'Scanned Aerial Imagery'
+              - 'Satellite Imagery'
+              - 'Event'
+              - 'Elevation'
+
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
         env:
@@ -64,7 +63,7 @@ spec:
           - 'bmc'
           - 'create-pr'
           - '--target={{inputs.parameters.target}}'
-          - '--ticket={{workflow.parameters.ticket}}'
-          - '--config-type={{workflow.parameters.config_type}}'
-          - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
-          - '--category={{workflow.parameters.category}}'
+          - '--ticket={{inputs.parameters.ticket}}'
+          - '--config-type={{inputs.parameters.config_type}}'
+          - "--individual={{= inputs.parameters.individual == 'individual'? 'true' : 'false' }}"
+          - '--category={{inputs.parameters.category}}'

--- a/templates/basemaps/create-pull-request.yml
+++ b/templates/basemaps/create-pull-request.yml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tpl-bm-create-pull-request
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+
+  templates:
+    # Main entrypoint into the workflow
+    - name: main
+      inputs:
+      parameters:
+        - name: version_argo_tasks
+          description: Version of the argo-tasks CLI docker container to use
+          value: v4
+
+        - name: ticket
+          description: Ticket ID e.g. 'BM-55'
+          value: ''
+
+        - name: config_type
+          description: 'Type of Basemaps Config file to create in pull requests'
+          value: 'raster'
+          enum:
+            - 'raster'
+            - 'elevation'
+
+        - name: individual
+          description: 'Individual Config or Combined Config'
+          value: 'combined'
+          enum:
+            - 'individual'
+            - 'combined'
+
+        - name: category
+          value: 'Rural Aerial Photos'
+          enum:
+            - 'Rural Aerial Photos'
+            - 'Urban Aerial Photos'
+            - 'Scanned Aerial Imagery'
+            - 'Satellite Imagery'
+            - 'Event'
+            - 'Elevation'
+
+        - name: target
+          description: Target location for output COGs in array format
+
+      container:
+        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.basemaps.json
+          - name: GITHUB_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-linz-li-bot-pat
+                key: pat
+        args:
+          - 'bmc'
+          - 'create-pr'
+          - '--target={{workflow.parameters.target}}'
+          - '--ticket={{workflow.parameters.ticket}}'
+          - '--config-type={{workflow.parameters.config_type}}'
+          - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
+          - '--category={{workflow.parameters.category}}'

--- a/templates/basemaps/create-pull-request.yml
+++ b/templates/basemaps/create-pull-request.yml
@@ -16,9 +16,6 @@ spec:
         description: Version of the argo-tasks CLI docker container to use
         value: v4
 
-      - name: target
-        description: Target location for output COGs in array format
-
       - name: ticket
         description: Ticket ID e.g. 'BM-55'
         value: ''
@@ -50,6 +47,9 @@ spec:
   templates:
     # Main entrypoint into the workflow
     - name: main
+      inputs:
+        parameters:
+          - name: target
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
         env:
@@ -63,7 +63,7 @@ spec:
         args:
           - 'bmc'
           - 'create-pr'
-          - '--target={{workflow.parameters.target}}'
+          - '--target={{inputs.parameters.target}}'
           - '--ticket={{workflow.parameters.ticket}}'
           - '--config-type={{workflow.parameters.config_type}}'
           - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"

--- a/templates/basemaps/create-pull-request.yml
+++ b/templates/basemaps/create-pull-request.yml
@@ -10,47 +10,46 @@ spec:
       imagePullPolicy: Always
       image: ''
   entrypoint: main
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        description: Version of the argo-tasks CLI docker container to use
+        value: v4
+
+      - name: target
+        description: Target location for output COGs in array format
+
+      - name: ticket
+        description: Ticket ID e.g. 'BM-55'
+        value: ''
+
+      - name: config_type
+        description: 'Type of Basemaps Config file to create in pull requests'
+        value: 'raster'
+        enum:
+          - 'raster'
+          - 'elevation'
+
+      - name: individual
+        description: 'Individual Config or Combined Config'
+        value: 'combined'
+        enum:
+          - 'individual'
+          - 'combined'
+
+      - name: category
+        value: 'Rural Aerial Photos'
+        enum:
+          - 'Rural Aerial Photos'
+          - 'Urban Aerial Photos'
+          - 'Scanned Aerial Imagery'
+          - 'Satellite Imagery'
+          - 'Event'
+          - 'Elevation'
 
   templates:
     # Main entrypoint into the workflow
     - name: main
-      inputs:
-      parameters:
-        - name: version_argo_tasks
-          description: Version of the argo-tasks CLI docker container to use
-          value: v4
-
-        - name: ticket
-          description: Ticket ID e.g. 'BM-55'
-          value: ''
-
-        - name: config_type
-          description: 'Type of Basemaps Config file to create in pull requests'
-          value: 'raster'
-          enum:
-            - 'raster'
-            - 'elevation'
-
-        - name: individual
-          description: 'Individual Config or Combined Config'
-          value: 'combined'
-          enum:
-            - 'individual'
-            - 'combined'
-
-        - name: category
-          value: 'Rural Aerial Photos'
-          enum:
-            - 'Rural Aerial Photos'
-            - 'Urban Aerial Photos'
-            - 'Scanned Aerial Imagery'
-            - 'Satellite Imagery'
-            - 'Event'
-            - 'Elevation'
-
-        - name: target
-          description: Target location for output COGs in array format
-
       container:
         image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
         env:

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -230,6 +230,14 @@ spec:
               parameters:
                 - name: target
                   value: '{{ tasks.cogify.outputs.parameters.target }}'
+                - name: ticket
+                  value: '{{ workflow.parameters.ticket }}'
+                - name: config_type
+                  value: '{{ workflow.parameters.config_type }}'
+                - name: individual
+                  value: '{{ workflow.parameters.individual }}'
+                - name: category
+                  value: '{{ workflow.parameters.category }}'
             when: '{{workflow.parameters.create_pull_request}} == true'
             depends: 'cogify'
 

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: basemaps-imagery-import-cogify
+  name: test-basemaps-imagery-import-cogify
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: raster
@@ -196,7 +196,9 @@ spec:
         tasks:
           # For each tile matrix specified run the "cogify" template
           - name: cogify
-            template: cogify
+            templateRef:
+              name: tpl-bm-cogify
+              template: main
             withParam: "{{= toJson(sprig.splitList(';', inputs.parameters.tile_matrix)) }}"
             arguments:
               parameters:
@@ -221,264 +223,15 @@ spec:
                 - name: background
                   value: '{{ inputs.parameters.background }}'
           - name: create-pull-request
-            template: create-pull-request
+            templateRef:
+              name: tpl-bm-create-pull-request
+              template: main
             arguments:
               parameters:
                 - name: target
                   value: '{{ tasks.cogify.outputs.parameters.target }}'
             when: '{{workflow.parameters.create_pull_request}} == true'
             depends: 'cogify'
-
-    # Generate COGs for a specific tile matrix from a given collection of source imagery
-    - name: cogify
-      inputs:
-        parameters:
-          - name: source
-          - name: target
-          - name: tile_matrix
-          - name: cutline
-          - name: cutline_blend
-          - name: group_size
-          - name: preset
-          - name: require_stac_collection
-          - name: base_zoom_offset
-          - name: background
-      dag:
-        tasks:
-          # generate a tile covering from the source imagery
-          - name: create-covering
-            template: create-covering
-            arguments:
-              parameters:
-                - name: source
-                  value: '{{ inputs.parameters.source }}'
-                - name: target
-                  value: '{{ inputs.parameters.target }}'
-                - name: preset
-                  value: '{{ inputs.parameters.preset }}'
-                - name: tile_matrix
-                  value: '{{ inputs.parameters.tile_matrix }}'
-                - name: cutline
-                  value: '{{ inputs.parameters.cutline }}'
-                - name: cutline_blend
-                  value: '{{ inputs.parameters.cutline_blend }}'
-                - name: base_zoom_offset
-                  value: '{{ inputs.parameters.base_zoom_offset }}'
-                - name: require_stac_collection
-                  value: '{{ inputs.parameters.require_stac_collection }}'
-                - name: background
-                  value: '{{ inputs.parameters.background }}'
-
-          # Group covering output into chunks to pass to create-cog
-          - name: group
-            arguments:
-              parameters:
-                - name: size
-                  value: '{{ inputs.parameters.group_size }}'
-                - name: version
-                  value: '{{= workflow.parameters.version_argo_tasks }}'
-              artifacts:
-                - name: input
-                  from: '{{ tasks.create-covering.outputs.artifacts.tiles }}'
-            templateRef:
-              name: tpl-at-group
-              template: main
-            depends: create-covering
-
-          # Create COGS from the grouped output of create-covering
-          - name: create-cog
-            depends: group
-            template: create-cog
-            withParam: '{{ tasks.group.outputs.parameters.output }}'
-            arguments:
-              parameters:
-                - name: covering_grouped_id
-                  value: '{{ item }}'
-              artifacts:
-                - name: covering_grouped
-                  from: '{{ tasks.group.outputs.artifacts.output }}'
-
-          # TODO: overviews are only supported in RGBA pipelines
-          # once all COGs are created generate a more overviews to increase tile rendering performance
-          - name: create-overview
-            template: create-overview
-            when: '{{workflow.parameters.create_overview}} == true'
-            depends: create-cog
-            arguments:
-              parameters:
-                - name: path
-                  value: '{{ tasks.create-covering.outputs.parameters.target }}'
-
-          # Create a basemaps config to view the imagery directly
-          - name: create-config
-            template: create-config
-            depends: create-overview
-            arguments:
-              parameters:
-                - name: path
-                  value: '{{ tasks.create-covering.outputs.parameters.target }}'
-                - name: title
-                  value: '{{ tasks.create-covering.outputs.parameters.title }}'
-
-      outputs:
-        parameters:
-          - name: target
-            description: location of where the output tiffs were created
-            valueFrom:
-              parameter: '{{ tasks.create-covering.outputs.parameters.target }}'
-
-    # Generate a tile covering for input imagery
-    - name: create-covering
-      nodeSelector:
-        karpenter.sh/capacity-type: 'spot'
-      inputs:
-        parameters:
-          - name: source
-          - name: target
-          - name: tile_matrix
-          - name: cutline
-          - name: cutline_blend
-          - name: preset
-          - name: require_stac_collection
-          - name: base_zoom_offset
-          - name: background
-      container:
-        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        resources:
-          requests:
-            memory: 2Gi
-        command: [node, index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-        args:
-          - 'cogify'
-          - 'cover'
-          - '--preset={{ inputs.parameters.preset }}'
-          - '--tile-matrix={{ inputs.parameters.tile_matrix }}'
-          - '--require-stac-collection={{ inputs.parameters.require_stac_collection }}'
-          - "{{= sprig.empty(inputs.parameters.cutline) ? '' : '--cutline=' + inputs.parameters.cutline }}"
-          - '--cutline-blend={{ inputs.parameters.cutline_blend }}'
-          - "{{= sprig.empty(inputs.parameters.base_zoom_offset) ? '' : '--base-zoom-offset=' + inputs.parameters.base_zoom_offset }}"
-          - "{{= sprig.empty(inputs.parameters.background) ? '' : '--background=' + inputs.parameters.background }}"
-          - '--target={{= sprig.trim(inputs.parameters.target) }}'
-          - '{{= sprig.trim(inputs.parameters.source) }}'
-      outputs:
-        parameters:
-          - name: target
-            description: output path for where the covering was written
-            valueFrom:
-              path: /tmp/cogify/cover-target
-
-          - name: title
-            description: Title for the covering
-            valueFrom:
-              path: /tmp/cogify/cover-title
-
-        artifacts:
-          - name: tiles
-            path: /tmp/cogify/cover-items.json
-
-    # Actually create COGs using gdal_translate on a large spot instances
-    - name: create-cog
-      nodeSelector:
-        karpenter.sh/capacity-type: 'spot'
-      inputs:
-        artifacts:
-          - name: covering_grouped
-            path: /tmp/cogify/covering_grouped/
-        parameters:
-          - name: covering_grouped_id
-      container:
-        resources:
-          requests:
-            memory: 30Gi
-            cpu: 15000m # AWS gives 2x cpu cores = memory for most instances
-            ephemeral-storage: 98Gi # 2 pods per 200GB of storage
-        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-        args:
-          - 'cogify'
-          - 'create'
-          - '--from-file={{= inputs.artifacts.covering_grouped.path }}{{inputs.parameters.covering_grouped_id}}.json'
-          - '--concurrency=2'
-
-    # Create a basemaps configuration file to view the imagery
-    - name: create-config
-      inputs:
-        parameters:
-          - name: path
-            description: Location of the imagery to create config for
-      container:
-        image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
-        command: [node, index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-        args:
-          - 'config'
-          - 'create-config'
-          - '{{ inputs.parameters.path }}'
-      outputs:
-        parameters:
-          - name: url
-            description: Basemaps URL to view the imagery
-            valueFrom:
-              path: '/tmp/cogify/config-url'
-          - name: config
-            description: Location of the config file
-            valueFrom:
-              path: '/tmp/cogify/config-path'
-
-    # create additional overviews for any COGs found in the path
-    - name: create-overview
-      nodeSelector:
-        karpenter.sh/capacity-type: 'spot'
-      inputs:
-        parameters:
-          - name: path
-            description: Location of the imagery to create overviews for
-      container:
-        resources:
-          requests:
-            memory: 7.8Gi
-            cpu: 15000m
-        image: ghcr.io/linz/basemaps/cli:v6
-        command: [node, index.cjs]
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-        args:
-          - '-V'
-          - 'create-overview'
-          - '--source={{= sprig.trim(inputs.parameters.path) }}'
-          - '--output={{= sprig.trim(inputs.parameters.path) }}'
-
-    - name: create-pull-request
-      inputs:
-        parameters:
-          - name: target
-      container:
-        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{workflow.parameters.version_argo_tasks}}
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-          - name: GITHUB_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: github-linz-li-bot-pat
-                key: pat
-        args:
-          - 'bmc'
-          - 'create-pr'
-          - '--target={{inputs.parameters.target}}'
-          - '--ticket={{workflow.parameters.ticket}}'
-          - '--config-type={{workflow.parameters.config_type}}'
-          - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
-          - '--category={{workflow.parameters.category}}'
 
     - name: exit-handler
       retryStrategy:

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-basemaps-imagery-import-cogify
+  name: basemaps-imagery-import-cogify
   labels:
     linz.govt.nz/category: basemaps
     linz.govt.nz/data-type: raster

--- a/workflows/basemaps/vector-etl-shortbread.yaml
+++ b/workflows/basemaps/vector-etl-shortbread.yaml
@@ -90,7 +90,9 @@ spec:
             withParam: "{{= toJson(sprig.splitList(';', workflow.parameters.tile_matrix)) }}"
 
           - name: create-pull-request
-            template: create-pull-request
+            templateRef:
+              name: tpl-bm-create-pull-request
+              template: main
             arguments:
               parameters:
                 - name: target
@@ -350,26 +352,6 @@ spec:
           - 'analyse'
           - '--path={{ inputs.parameters.mbTilesTarget }}'
           - '--target={{ inputs.parameters.analyseTarget }}'
-
-    - name: create-pull-request
-      inputs:
-        parameters:
-          - name: target
-      container:
-        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{ workflow.parameters.version_argo_tasks }}
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-          - name: GITHUB_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: github-linz-li-bot-pat
-                key: pat
-        args:
-          - 'bmc'
-          - 'create-pr'
-          - '--target={{ inputs.parameters.target }}'
-          - '--config-type=vector'
 
     - name: exit-handler
       retryStrategy:

--- a/workflows/basemaps/vector-etl-shortbread.yaml
+++ b/workflows/basemaps/vector-etl-shortbread.yaml
@@ -97,6 +97,9 @@ spec:
               parameters:
                 - name: target
                   value: '{{ tasks.etl.outputs.parameters.target }}'
+                - name: config_type
+                  value: 'vector'
+
             when: '{{ workflow.parameters.create_pull_request }} == true'
             depends: 'etl'
 

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -81,7 +81,9 @@ spec:
             when: '{{tasks.check-updates.outputs.parameters.updatesRequired}} == true'
 
           - name: create-pull-request
-            template: create-pull-request
+            templateRef:
+              name: tpl-bm-create-pull-request
+              template: main
             arguments:
               parameters:
                 - name: target
@@ -139,27 +141,6 @@ spec:
           - name: target
             valueFrom:
               path: '/tmp/target'
-
-    - name: create-pull-request
-      inputs:
-        parameters:
-          - name: target
-      container:
-        image: 019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{ workflow.parameters.version_argo_tasks }}
-        env:
-          - name: AWS_ROLE_CONFIG_PATH
-            value: s3://linz-bucket-config/config.basemaps.json
-          - name: GITHUB_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: github-linz-li-bot-pat
-                key: pat
-        args:
-          - 'bmc'
-          - 'create-pr'
-          - '--target={{ inputs.parameters.target }}'
-          - '--config-type=vector'
-          - "--individual={{= workflow.parameters.individual == 'individual'? 'true' : 'false' }}"
 
     - name: exit-handler
       retryStrategy:

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -46,13 +46,6 @@ spec:
           - 'true'
           - 'false'
 
-      - name: individual
-        description: 'Individual Config or Combined Config'
-        value: 'combined'
-        enum:
-          - 'individual'
-          - 'combined'
-
       - name: retry
         description: Number of retry on failure vector-etl task
         value: '1'
@@ -88,6 +81,8 @@ spec:
               parameters:
                 - name: target
                   value: '{{ tasks.vector-etl.outputs.parameters.target }}'
+                - name: config_type
+                  value: 'vector'
             when: '{{ workflow.parameters.create_pull_request }} == true && {{tasks.check-updates.outputs.parameters.updatesRequired}} == true'
             depends: 'vector-etl'
 


### PR DESCRIPTION
### Motivation

Move the cogify and create-pull requests as template, so that we can reuse them in other workflows.
The main reasons to move these are enable reuse of cogify for topo-raster and the new charts import workflow.
So that we don't need to trigger another workflow after topo-raster workflow, we can directly import into basemaps in one workflow.

### Modifications
Existing [topo raster import](https://toitutewhenua.atlassian.net/wiki/spaces/LTS/pages/1119879649/Basemaps+Topo+Raster+NZ+Topo+50k+250k) steps. 
We will need to triger at least three workflows for the import, and it going to be much more if we support pacific islands.
<img width="944" height="553" alt="image" src="https://github.com/user-attachments/assets/273c596f-d018-447c-a10c-f84f91b02a88" />

We could refactoring this into a new workflow, and just trigger single workflow and do the full import.
<img width="1084" height="597" alt="image" src="https://github.com/user-attachments/assets/c1f34fd5-4719-4451-8eb5-e6c439882e0f" />

### Verification
Test on [imagery import workflow](https://argo.linzaccess.com/workflows/argo/test-basemaps-imagery-import-cogify-9k4vq?tab=workflow&nodeId=test-basemaps-imagery-import-cogify-9k4vq-2432336618&nodePanelView=containers&uid=c49f907c-c3e0-4869-88b5-c476d64fc333)
Test on [opentilemaps workflow](https://argo.linzaccess.com/workflows/argo/test-basemaps-vector-etl-98z4x?tab=workflow&nodeId=test-basemaps-vector-etl-98z4x-2865744413&uid=345139d7-328e-4981-a0e2-65e813693176)
Test on [shortbread workflow](https://argo.linzaccess.com/workflows/argo/test-basemaps-vector-etl-shortbread-dhwcm?tab=workflow&nodeId=test-basemaps-vector-etl-shortbread-dhwcm-2476992806&uid=9ec7f636-0ab3-4090-8a2c-fddebe2ebad0)