### PR TITLE
fix: add permissions, remove space in configs and trim inputs TDE-1605

### DIFF
--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -54,7 +54,7 @@ spec:
       inputs:
         parameters:
           - name: source
-            value: '{{workflow.parameters.source}}'
+            value: '{{=sprig.trim(workflow.parameters.source)}}'
           - name: group
             value: '{{workflow.parameters.group}}'
             default: '1000'
@@ -104,7 +104,7 @@ spec:
                 - name: version_argo_tasks
                   value: '{{inputs.parameters.version_argo_tasks}}'
                 - name: aws_role_config_path
-                  value: 's3://linz-bucket-config/config-write.topographic.json, s3://linz-bucket-config/config-write.hydrographic.json'
+                  value: 's3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config-write.hydrographic.json'
                 - name: compress
                   value: 'true'
                 - name: delete_source

--- a/workflows/storage/temp-archive-custom-target.yaml
+++ b/workflows/storage/temp-archive-custom-target.yaml
@@ -57,9 +57,9 @@ spec:
       inputs:
         parameters:
           - name: source
-            value: '{{workflow.parameters.source}}'
+            value: '{{=sprig.trim(workflow.parameters.source)}}'
           - name: target
-            value: '{{workflow.parameters.target}}'
+            value: '{{=sprig.trim(workflow.parameters.target)}}'
           - name: group
             value: '{{workflow.parameters.group}}'
             default: '1000'
@@ -107,7 +107,7 @@ spec:
                 - name: version_argo_tasks
                   value: '{{inputs.parameters.version_argo_tasks}}'
                 - name: aws_role_config_path
-                  value: 's3://linz-bucket-config/config-write.topographic.json, s3://linz-bucket-config/config-write.hydrographic.json'
+                  value: 's3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config-write.hydrographic.json'
                 - name: compress
                   value: 'true'
                 - name: delete_source


### PR DESCRIPTION
### Motivation and modifications

Added imagery and elevation staging permissions to the temp archive command.
Removed a space between the config paths that caused a failure when reading the config files.
Also trimmed white space in source and target to prevent potential copy and paste issues.

### Verification

Tested on a workflowTemplate in Argo Workflows.
