### PR TITLE
fix: national-dem-coastal name should start with cron-

### DIFF
--- a/workflows/cron/cron-national-dem-coastal.yaml
+++ b/workflows/cron/cron-national-dem-coastal.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: national-dem-coastal
+  name: cron-national-dem-coastal
   labels:
     linz.govt.nz/category: raster
     linz.govt.nz/data-type: raster


### PR DESCRIPTION
### Motivation

The national DEM coastal cron workflow is not following the naming convention of our cron workflows.

### Modifications

rename to `cron-national-dem-coastal`
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
