### PR TITLE
feat: cleanup empty folders after archiving TDE-1628

### DIFF
--- a/templates/argo-tasks/delete-empty-folders.yaml
+++ b/templates/argo-tasks/delete-empty-folders.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from linz/argo-tasks
+  name: tpl-at-delete-empty-folders
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: location
+            description: Location of the folder to delete
+            default: ''
+
+          - name: dry_run
+            description: Do not delete files, just report what would be deleted
+            default: 'true'
+
+          - name: version
+            description: container version to use
+            default: 'v4'
+
+          - name: aws_role_config_path
+            description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
+            value: 's3://linz-bucket-config/config.json'
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version)}}'
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: '{{inputs.parameters.aws_role_config_path}}'
+        args:
+          - 'delete-empty-folders'
+          - '--dry-run={{inputs.parameters.dry_run}}'
+          - '{{inputs.parameters.location}}'

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -20,7 +20,7 @@ Archive files from a S3 location (for example `s3://linz-*-upload/[provider]/[su
 
 ```mermaid
 graph TD;
-  archive-setup-->create-manifest-->copy;
+  archive-setup-->create-manifest-->copy-->|cleanup == 'true'|cleanup;
 ```
 
 This is a workflow that calls the `copy` workflow with `--compress` and `--delete-source` options, after setting up the archive location by calling the `archive-setup` workflow.
@@ -34,6 +34,7 @@ Access permissions are controlled by the [Bucket Sharing Config](https://github.
 | user_group | enum | none    | Group of users running the workflow                                                                                         |
 | ticket     | str  |         | Ticket ID e.g. 'AIP-55'                                                                                                     |
 | source     | str  |         | The URI (path) to the s3 source location where the files to archive are.                                                    |
+| cleanup    | enum | true    | Cleanup the source directory after archiving                                                                                |
 | group      | int  | 1000    | The maximum number of files for each pod to copy (will use the value of `group` or `group_size` that is reached first).     |
 | group_size | str  | 100Gi   | The maximum group size of files for each pod to copy (will use the value of `group` or `group_size` that is reached first). |
 
@@ -48,7 +49,7 @@ Copy files from one S3 location to another. This workflow is intended to be used
 
 ```mermaid
 graph TD;
-  create-manifest-->copy;
+  create-manifest-->copy-->|set_status == 'true'|copy-status;
 ```
 
 This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks#create-manifest) container `create-manifest` (list of source and target file paths) and `copy` (the actual file copy) commands.

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -74,7 +74,18 @@ spec:
             default: 'v4'
       dag:
         tasks:
+          - name: archive-setup
+            templateRef:
+              name: tpl-at-archive-setup
+              template: main
+            arguments:
+              parameters:
+                - name: source
+                  value: '{{inputs.parameters.source}}'
+                - name: version
+                  value: '{{inputs.parameters.version_argo_tasks}}'
           - name: copy
+            depends: 'archive-setup.Succeeded'
             templateRef:
               name: copy
               template: main

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -38,6 +38,12 @@ spec:
       - name: source
         description: Path where the files to be archived are located
         value: ''
+      - name: cleanup
+        description: Cleanup the source directory after archiving
+        value: 'true'
+        enum:
+          - 'false'
+          - 'true'
       - name: group
         value: '1000'
       - name: group_size
@@ -55,6 +61,8 @@ spec:
         parameters:
           - name: source
             value: '{{=sprig.trim(workflow.parameters.source)}}'
+          - name: cleanup
+            value: '{{workflow.parameters.cleanup}}'
           - name: group
             value: '{{workflow.parameters.group}}'
             default: '1000'
@@ -66,18 +74,7 @@ spec:
             default: 'v4'
       dag:
         tasks:
-          - name: archive-setup
-            templateRef:
-              name: tpl-at-archive-setup
-              template: main
-            arguments:
-              parameters:
-                - name: source
-                  value: '{{inputs.parameters.source}}'
-                - name: version
-                  value: '{{inputs.parameters.version_argo_tasks}}'
           - name: copy
-            depends: 'archive-setup.Succeeded'
             templateRef:
               name: copy
               template: main
@@ -109,6 +106,24 @@ spec:
                   value: 'true'
                 - name: delete_source
                   value: 'true'
+                - name: set_status
+                  value: 'true'
+          - name: cleanup
+            templateRef:
+              name: tpl-at-delete-empty-folders
+              template: main
+            arguments:
+              parameters:
+                - name: location
+                  value: '{{inputs.parameters.source}}'
+                - name: dry_run
+                  value: 'false'
+                - name: version
+                  value: '{{inputs.parameters.version_argo_tasks}}'
+                - name: aws_role_config_path
+                  value: 's3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config-write.hydrographic.json'
+            depends: 'copy.Succeeded'
+            when: '"{{inputs.parameters.cleanup}}" == "true" && "{{tasks.copy.outputs.parameters.status}}" != "Skipped"'
 
     - name: exit-handler
       retryStrategy:

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -201,6 +201,7 @@ spec:
                 - name: status
                   value: '{{tasks.copy.status}}'
             depends: 'copy'
+            when: '"{{inputs.parameters.set_status}}" == "true"'
 
     - name: copy-status
       inputs:

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -139,6 +139,14 @@ spec:
             default: 'false'
           - name: delete_source # This should not be exposed to the user (as a workflow parameter)
             default: 'false'
+          - name: set_status
+            default: 'false'
+      outputs:
+        parameters:
+          - name: status
+            valueFrom:
+              parameter: '{{tasks.copy-status.outputs.parameters.status}}'
+
       dag:
         tasks:
           - name: create-manifest
@@ -186,6 +194,28 @@ spec:
                   value: '{{inputs.parameters.aws_role_config_path}}'
             depends: 'create-manifest'
             withParam: '{{tasks.create-manifest.outputs.parameters.files}}'
+          - name: copy-status
+            template: copy-status
+            arguments:
+              parameters:
+                - name: status
+                  value: '{{tasks.copy.status}}'
+            depends: 'copy'
+
+    - name: copy-status
+      inputs:
+        parameters:
+          - name: status
+      script:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
+        command: [sh]
+        source: |
+          echo "{{inputs.parameters.status}}" > /tmp/copy_status.txt
+      outputs:
+        parameters:
+          - name: status
+            valueFrom:
+              path: /tmp/copy_status.txt
 
     - name: exit-handler
       retryStrategy:


### PR DESCRIPTION
### Motivation

After running the `archive` workflow, some "folders" can remain (if they have been created from the S3 Console) even if the source files have been deleted. This is using https://github.com/linz/argo-tasks/pull/1254.

### Modifications

Add a step in the archive workflow.
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Argo Workflows

<!-- TODO: Say how you tested your changes. -->
