### PR TITLE
feat: verify restore and copy files TDE-1592

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -5,11 +5,13 @@
 - [Group](##argo-tasks/group)
 - [Copy](##argo-tasks/copy)
 - [Create Manifest](##argo-tasks/create-manifest)
+- [List](##argo-tasks/list)
 - [Push to Github](##argo-tasks/push-to-github)
 - [Generate Path](##argo-tasks/generate-path)
 - [STAC setup](##argo-tasks/stac-setup)
 - [STAC validate](##argo-tasks/stac-validate)
 - [Identify updated items](##argo-tasks/identify-updated-items)
+- [Verify Restore](##argo-tasks/verify-restore)
 
 ## argo-tasks/group - `tpl-at-group`
 
@@ -156,6 +158,30 @@ Create a manifest file for a user specified source and target that includes `.ti
         value: '100Gi'
       - name: version_argo_tasks
         value: '{{workflow.parameters.version_argo_tasks}}'
+```
+
+## argo-tasks/list - `tpl-at-list`
+
+Template for listing and grouping files into a parameter containing a list of a list of files.
+See https://github.com/linz/argo-tasks#list
+
+### Template usage
+
+List files in a location that end with `manifest.json`:
+
+```yaml
+- name: list-manifests
+  templateRef:
+    name: tpl-at-list
+    template: main
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        value: '{{inputs.parameters.version_argo_tasks}}'
+      - name: location
+        value: '{{inputs.parameters.reports_location}}'
+      - name: include
+        value: 'manifest.json$'
 ```
 
 ## argo-tasks/push-to-github - `tpl-push-to-github`
@@ -306,4 +332,26 @@ Sample output:
     "includeDerived": true
   }
 ]
+```
+
+## argo-tasks/verify-restore - `tpl-at-verify-restore`
+
+Template for listing and grouping files into collections of tasks.  
+See https://github.com/linz/argo-tasks/tree/master/src/commands/verify-restore
+
+### Template usage
+
+Verify that all the files requested to be restored with S3 Batch Operations Restore are restored yet. Output a boolean value to indicate if all files are restored.
+
+```yaml
+- name: verify-restore
+  templateRef:
+    name: tpl-at-verify-restore
+    template: main
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        value: '{{inputs.parameters.version_argo_tasks}}'
+      - name: restore_manifest
+        value: '{{inputs.parameters.restore_manifest}}'
 ```

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -38,6 +38,13 @@ spec:
               - 'true'
               - 'false'
 
+          - name: decompress
+            description: Decompress the files in their target location
+            default: 'false'
+            enum:
+              - 'true'
+              - 'false'
+
           - name: delete_source
             description: Delete the source files after copying
             default: 'false'
@@ -66,4 +73,5 @@ spec:
           - '{{inputs.parameters.copy_option}}'
           - '{{inputs.parameters.file}}'
           - '--compress={{inputs.parameters.compress}}'
+          - '--decompress={{inputs.parameters.decompress}}'
           - '--delete-source={{inputs.parameters.delete_source}}'

--- a/templates/argo-tasks/list.yaml
+++ b/templates/argo-tasks/list.yaml
@@ -35,10 +35,6 @@ spec:
             description: Group the files into this size per group (will use the value of `group` or `group_size` that is reached first)
             default: '100Gi'
 
-          - name: aws_role_config_path
-            description: s3 URL or comma-separated list of s3 URLs of roles config files allowing the workflow to read from a location
-            default: ''
-
       outputs:
         parameters:
           - name: files

--- a/templates/argo-tasks/list.yaml
+++ b/templates/argo-tasks/list.yaml
@@ -28,11 +28,11 @@ spec:
             default: ''
 
           - name: group
-            description: Group files by this many files (will use the value of `group` or `group_size` that is reached first)
+            description: Group files by this many files (will use the value of `group` or `group_size` that is reached first). Set to -1 to disable.
             default: '1000'
 
           - name: group_size
-            description: Group the files into this size per group (will use the value of `group` or `group_size` that is reached first)
+            description: Group the files into this size per group (will use the value of `group` or `group_size` that is reached first). Set to -1 to disable.
             default: '100Gi'
 
       outputs:

--- a/templates/argo-tasks/list.yaml
+++ b/templates/argo-tasks/list.yaml
@@ -48,18 +48,16 @@ spec:
           - name: AWS_ROLE_CONFIG_PATH
             value: 's3://linz-bucket-config/config.json'
         args:
-          [
-            'list',
-            '--verbose',
-            '--include',
-            '{{=sprig.trim(inputs.parameters.include)}}',
-            '--exclude',
-            '{{=sprig.trim(inputs.parameters.exclude)}}',
-            '--group',
-            '{{=sprig.trim(inputs.parameters.group)}}',
-            '--group-size',
-            '{{=sprig.trim(inputs.parameters.group_size)}}',
-            '--output',
-            '/tmp/file_list.json',
-            '{{=sprig.trim(inputs.parameters.location)}}',
-          ]
+          - 'list'
+          - '--verbose'
+          - '--include'
+          - '{{=sprig.trim(inputs.parameters.include)}}'
+          - '--exclude'
+          - '{{=sprig.trim(inputs.parameters.exclude)}}'
+          - '--group'
+          - '{{=sprig.trim(inputs.parameters.group)}}'
+          - '--group-size'
+          - '{{=sprig.trim(inputs.parameters.group_size)}}'
+          - '--output'
+          - '/tmp/file_list.json'
+          - '{{=sprig.trim(inputs.parameters.location)}}'

--- a/templates/argo-tasks/list.yaml
+++ b/templates/argo-tasks/list.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template for listing files in a S3 location
+  # See https://github.com/linz/argo-tasks#list
+  name: tpl-at-list
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: location
+            description: location of data to list
+
+          - name: version_argo_tasks
+            description: version of argo-tasks to use
+            default: 'v4'
+
+          - name: include
+            description: A regular expression to match object path(s) or name(s) to include in the list
+            default: ''
+
+          - name: exclude
+            description: A regular expression to match object path(s) or name(s) to exclude from the list
+            default: ''
+
+          - name: group
+            description: Group files by this many files (will use the value of `group` or `group_size` that is reached first)
+            default: '1000'
+
+          - name: group_size
+            description: Group the files into this size per group (will use the value of `group` or `group_size` that is reached first)
+            default: '100Gi'
+
+          - name: aws_role_config_path
+            description: s3 URL or comma-separated list of s3 URLs of roles config files allowing the workflow to read from a location
+            default: ''
+
+      outputs:
+        parameters:
+          - name: files
+            valueFrom:
+              path: /tmp/file_list.json
+
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
+        imagePullPolicy: Always
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: 's3://linz-bucket-config/config.json'
+        args:
+          [
+            'list',
+            '--verbose',
+            '--include',
+            '{{=sprig.trim(inputs.parameters.include)}}',
+            '--exclude',
+            '{{=sprig.trim(inputs.parameters.exclude)}}',
+            '--group',
+            '{{=sprig.trim(inputs.parameters.group)}}',
+            '--group-size',
+            '{{=sprig.trim(inputs.parameters.group_size)}}',
+            '--output',
+            '/tmp/file_list.json',
+            '{{=sprig.trim(inputs.parameters.location)}}',
+          ]

--- a/templates/argo-tasks/verify-restore.yaml
+++ b/templates/argo-tasks/verify-restore.yaml
@@ -21,7 +21,7 @@ spec:
       retryStrategy:
         retryPolicy: 'OnFailure'
         backoff:
-          duration: '2m' # wait in case this has run before the batch restore request has not fully completed
+          duration: '2m' # wait in case this has run before the batch restore request has fully completed
         limit: '2'
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
@@ -35,12 +35,12 @@ spec:
             '--verbose',
             '--mark-done',
             '--output',
-            '/tmp/result.json',
+            '/tmp/all-files-restored-result',
             '{{inputs.parameters.restore_manifest}}',
           ]
       outputs:
         parameters:
-          - name: result
-            description: Result of the restore verification
+          - name: all_files_restored_result
+            description: True if the restore request is complete for all files
             valueFrom:
-              path: /tmp/result.json
+              path: /tmp/all-files-restored-result

--- a/templates/argo-tasks/verify-restore.yaml
+++ b/templates/argo-tasks/verify-restore.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template from linz/argo-tasks
+  # see https://github.com/linz/argo-tasks#verify-restore
+  name: tpl-at-verify-restore
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: version_argo_tasks
+            description: Version of argo-tasks to use
+            default: 'v4'
+          - name: restore_manifest
+            description: S3 path to the restore manifest file
+            default: ''
+      retryStrategy:
+        limit: '2' # force retrying this specific task
+      container:
+        image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
+        imagePullPolicy: Always
+        env:
+          - name: AWS_ROLE_CONFIG_PATH
+            value: s3://linz-bucket-config/config.json
+        args:
+          [
+            'verify-restore',
+            '--verbose',
+            '--mark-done',
+            '--output',
+            '/tmp/result.json',
+            '{{inputs.parameters.restore_manifest}}',
+          ]
+      outputs:
+        parameters:
+          - name: result
+            description: Result of the restore verification
+            valueFrom:
+              path: /tmp/result.json

--- a/templates/argo-tasks/verify-restore.yaml
+++ b/templates/argo-tasks/verify-restore.yaml
@@ -30,14 +30,12 @@ spec:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
         args:
-          [
-            'verify-restore',
-            '--verbose',
-            '--mark-done',
-            '--output',
-            '/tmp/all-files-restored-result',
-            '{{inputs.parameters.restore_manifest}}',
-          ]
+          - 'verify-restore'
+          - '--verbose'
+          - '--mark-done'
+          - '--output'
+          - '/tmp/all-files-restored-result'
+          - '{{inputs.parameters.restore_manifest}}'
       outputs:
         parameters:
           - name: all_files_restored_result

--- a/templates/argo-tasks/verify-restore.yaml
+++ b/templates/argo-tasks/verify-restore.yaml
@@ -19,7 +19,10 @@ spec:
             description: S3 path to the restore manifest file
             default: ''
       retryStrategy:
-        limit: '2' # force retrying this specific task
+        retryPolicy: 'OnFailure'
+        backoff:
+          duration: '2m' # wait in case this has run before the batch restore request has not fully completed
+        limit: '2'
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
         imagePullPolicy: Always

--- a/templates/common/README.md
+++ b/templates/common/README.md
@@ -97,7 +97,7 @@ In some cases, we need this location to write output files by the workflow in a 
 
 ## Read File - `tpl-read-file`
 
-Template to copy a file from an AWS S3 location and output the file contents as a workflow parameter.
+Template to copy a file from an AWS S3 location to the local filesystem and output the file contents as a workflow parameter.
 
 Example usage:
 

--- a/templates/common/README.md
+++ b/templates/common/README.md
@@ -100,6 +100,7 @@ In some cases, we need this location to write output files by the workflow in a 
 Template to copy a file from an AWS S3 location and output the file contents as a workflow parameter.
 
 Example usage:
+
 ```yaml
 - name: read-copy-manifest
   templateRef:
@@ -108,5 +109,5 @@ Example usage:
   arguments:
     parameters:
       - name: location
-        value: "{{inputs.parameters.restore_copy_manifest)}}"
+        value: '{{inputs.parameters.restore_copy_manifest)}}'
 ```

--- a/templates/common/README.md
+++ b/templates/common/README.md
@@ -1,5 +1,9 @@
 # Common Templates
 
+- [Exit Handler](##common/exit-handler)
+- [Get Location](##common/get-location)
+- [Read File](##common/read-file)
+
 ## Exit Handler - `tpl-exit-handler`
 
 Template for handling a workflow `onExit`.

--- a/templates/common/README.md
+++ b/templates/common/README.md
@@ -1,8 +1,8 @@
 # Common Templates
 
-- [Exit Handler](##common/exit-handler)
-- [Get Location](##common/get-location)
-- [Read File](##common/read-file)
+- [Exit Handler](##exit-handler---tpl-exit-handler)
+- [Get Location](##get-location---tpl-get-location)
+- [Read File](##read-file---tpl-read-file)
 
 ## Exit Handler - `tpl-exit-handler`
 

--- a/templates/common/README.md
+++ b/templates/common/README.md
@@ -94,3 +94,19 @@ spec:
 
 Template to output the S3 Archive location for the workflow (example: `s3://linz-workflows-scratch/2024-10/02-my-workflow-29l4x/`).
 In some cases, we need this location to write output files by the workflow in a specific and consistent "folder" within the archive bucket.
+
+## Read File - `tpl-read-file`
+
+Template to copy a file from an AWS S3 location and output the file contents as a workflow parameter.
+
+Example usage:
+```yaml
+- name: read-copy-manifest
+  templateRef:
+    name: tpl-read-file
+    template: main
+  arguments:
+    parameters:
+      - name: location
+        value: "{{inputs.parameters.restore_copy_manifest)}}"
+```

--- a/templates/common/read.file.yaml
+++ b/templates/common/read.file.yaml
@@ -6,10 +6,6 @@ metadata:
   # Template to output the content of a file in S3
   name: tpl-read-file
 spec:
-  templateDefaults:
-    container:
-      imagePullPolicy: Always
-      image: ''
   entrypoint: main
   templates:
     - name: main
@@ -25,7 +21,7 @@ spec:
               path: '/tmp/content'
       script:
         image: 'public.ecr.aws/aws-cli/aws-cli:2.27.62'
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: [sh]
         source: |
           aws s3 cp '{{inputs.parameters.location}}' /tmp/content

--- a/templates/common/read.file.yaml
+++ b/templates/common/read.file.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # Template to output the content of a file in S3
+  name: tpl-read-file
+spec:
+  templateDefaults:
+    container:
+      imagePullPolicy: Always
+      image: ''
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: location
+            description: Location of the file to read
+            default: ''
+      outputs:
+        parameters:
+          - name: content
+            valueFrom:
+              path: '/tmp/content'
+      script:
+        image: 'public.ecr.aws/aws-cli/aws-cli:2.27.62'
+        imagePullPolicy: Always
+        command: [sh]
+        source: |
+          aws s3 cp '{{inputs.parameters.location}}' /tmp/content

--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -4,6 +4,7 @@
 - [cron-stac-validate-full](#cron-stac-validate-full)
 - [National Elevation](#national-elevation)
 - [National Hillshades](#national-hillshades)
+- [Unarchive Copy Restore](#copy-restore)
 
 ## STAC validation
 
@@ -70,3 +71,7 @@ The three cron workflows `cron-national-merged-dem-hillshades-coastal` and `cron
 - [New Zealand DSM Hillshade - Igor](https://github.com/linz/elevation/blob/master/stac/new-zealand/new-zealand/dsm-hillshade-igor/2193/collection.json)
 
 - schedule: **Monday to Friday at 12:30pm**
+
+## Unarchive Copy Restore
+
+The `cron-copy-restore` workflow triggers the [`copy-restore` workflow](https://github.com/linz/topo-workflows/blob/master/workflows/storage/README.md#copy-restore) on a twice daily (7am & 1pm Mon-Sun) basis to check for the status of S3 Glacier Batch Restore jobs, and initiate a file copy of restored files if the batch job has completed.

--- a/workflows/cron/README.md
+++ b/workflows/cron/README.md
@@ -4,7 +4,7 @@
 - [cron-stac-validate-full](#cron-stac-validate-full)
 - [National Elevation](#national-elevation)
 - [National Hillshades](#national-hillshades)
-- [Unarchive Copy Restore](#copy-restore)
+- [Check Restore and Copy](#check-restore-and-copy)
 
 ## STAC validation
 
@@ -72,6 +72,6 @@ The three cron workflows `cron-national-merged-dem-hillshades-coastal` and `cron
 
 - schedule: **Monday to Friday at 12:30pm**
 
-## Unarchive Copy Restore
+## Check Restore and Copy
 
-The `cron-copy-restore` workflow triggers the [`copy-restore` workflow](https://github.com/linz/topo-workflows/blob/master/workflows/storage/README.md#copy-restore) on a twice daily (7am & 1pm Mon-Sun) basis to check for the status of S3 Glacier Batch Restore jobs, and initiate a file copy of restored files if the batch job has completed.
+The `cron-check-restore-copy` workflow triggers the [`check-restore-copy` workflow](https://github.com/linz/topo-workflows/blob/master/workflows/storage/README.md#check-restore-copy) on a twice daily (7am & 1pm Mon-Sun) basis to check for the status of S3 Glacier Batch Restore jobs, and initiate a file copy of restored files if the batch job has completed.

--- a/workflows/cron/cron-copy-restore.yaml
+++ b/workflows/cron/cron-copy-restore.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     linz.govt.nz/category: storage
 spec:
-  schedule: '0 7,10,13,16 * * *' # At 7am, 10am, 1pm, 4pm every day
+  schedule: '0 7,13 * * *' # At 7am and 1pm every day
   timezone: 'NZ'
   startingDeadlineSeconds: 3600 # Allow 1 hour delay if the workflow-controller clashes during the starting time.
   concurrencyPolicy: 'Allow'

--- a/workflows/cron/cron-copy-restore.yaml
+++ b/workflows/cron/cron-copy-restore.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-copy-restore
+  labels:
+    linz.govt.nz/category: storage
+spec:
+  schedule: '0 7,10,13,16 * * *' # At 7am, 10am, 1pm, 4pm every day
+  timezone: 'NZ'
+  startingDeadlineSeconds: 3600 # Allow 1 hour delay if the workflow-controller clashes during the starting time.
+  concurrencyPolicy: 'Allow'
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  suspend: false
+  workflowSpec:
+    entrypoint: main
+    onExit: exit-handler
+    podMetadata:
+      labels:
+        linz.govt.nz/category: storage
+    arguments:
+      parameters:
+        - name: version_argo_tasks
+          value: 'v4'
+        - name: reports_location
+          value: 's3://linz-workflows-scratch/restore/requests/'
+    templates:
+      - name: main
+        retryStrategy:
+          expression: 'false'
+        steps:
+          - - name: copy-restore
+              templateRef:
+                name: copy-restore
+                template: main
+              arguments:
+                parameters:
+                  - name: version_argo_tasks
+                    value: '{{workflow.parameters.version_argo_tasks}}'
+                  - name: reports_location
+                    value: '{{workflow.parameters.reports_location}}'
+      - name: exit-handler
+        retryStrategy:
+          limit: '0' # `tpl-exit-handler` retries itself
+        steps:
+          - - name: exit
+              templateRef:
+                name: tpl-exit-handler
+                template: main
+              arguments:
+                parameters:
+                  - name: workflow_status
+                    value: '{{workflow.status}}'
+                  - name: workflow_parameters
+                    value: '{{workflow.parameters}}'

--- a/workflows/cron/cron-copy-restore.yaml
+++ b/workflows/cron/cron-copy-restore.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: test-cron-copy-restore
+  name: cron-copy-restore
   labels:
     linz.govt.nz/category: storage
 spec:

--- a/workflows/cron/cron-copy-restore.yaml
+++ b/workflows/cron/cron-copy-restore.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: cron-copy-restore
+  name: cron-check-restore-copy
   labels:
     linz.govt.nz/category: storage
 spec:
@@ -30,9 +30,9 @@ spec:
         retryStrategy:
           expression: 'false'
         steps:
-          - - name: copy-restore
+          - - name: check-restore-copy
               templateRef:
-                name: copy-restore
+                name: check-restore-copy
                 template: main
               arguments:
                 parameters:

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -136,6 +136,7 @@ It will copy files from archive buckets to sharing buckets as follows:
 
 - from `linz-topographic-archive` to `linz-topographic-shared`
 - from `linz-hydrographic-archive` to `linz-hydrographic-shared`
+
 ```mermaid
 graph TD
     Start([Start]) --> ListManifests[List Manifests]
@@ -152,5 +153,5 @@ graph TD
 ### Workflow Input Parameters
 
 | Parameter        | Type | Default                                       | Description                                                                |
-|------------------|------|-----------------------------------------------|----------------------------------------------------------------------------|
+| ---------------- | ---- | --------------------------------------------- | -------------------------------------------------------------------------- |
 | reports_location | str  | s3://linz-workflows-scratch/restore/requests/ | Location of S3 Glacier Batch Restore reports and copy manifests references |

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -3,7 +3,7 @@
 - [Archive](##archive)
 - [Unarchive](##unarchive)
 - [Copy](##copy)
-- [Copy Restore](##copy-restore)
+- [Check Restore and Copy](##check-restore-and-copy)
 
 ## Archive
 
@@ -126,7 +126,7 @@ retryStrategy:
 
 **copy_option:** `--no-clobber` |
 
-## Copy Restore
+## Check Restore and Copy
 
 ### Description
 

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -1,9 +1,9 @@
 # Contents
 
-- [Archive](#archive)
-- [Copy](#copy)
-- [Copy Restore](#copy-restore)
-- [Unarchive](#unarchive)
+- [Archive](##archive)
+- [Unarchive](##unarchive)
+- [Copy](##copy)
+- [Copy Restore](##copy-restore)
 
 ## Archive
 

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -2,6 +2,8 @@
 
 - [Archive](#archive)
 - [Copy](#copy)
+- [Copy Restore](#copy-restore)
+- [Unarchive](#unarchive)
 
 ## Archive
 
@@ -123,3 +125,32 @@ retryStrategy:
 **include:** Although only `.tif(f)` and `.tfw` files are required, there should not be any `.json` files in with the uploaded imagery, so this option can be left at the default.
 
 **copy_option:** `--no-clobber` |
+
+## Copy Restore
+
+### Description
+
+Check for the status of S3 Glacier Batch Restore jobs triggered by the [`unarchive` workflow](#unarchive), and initiate a file copy of restored files if the batch job has completed.
+
+It will copy files from archive buckets to sharing buckets as follows:
+
+- from `linz-topographic-archive` to `linz-topographic-shared`
+- from `linz-hydrographic-archive` to `linz-hydrographic-shared`
+```mermaid
+graph TD
+    Start([Start]) --> ListManifests[List Manifests]
+    ListManifests --> FlattenManifests[Flatten Manifests]
+    FlattenManifests --> VerifyAndCopy[For Each Manifest: Verify and Copy]
+    VerifyAndCopy -->|Verify Restore| VerifyRestore[Verify Restore]
+    VerifyRestore -->|If True| ReadCopyManifest[Read Copy Manifest]
+    ReadCopyManifest -->|If Succeeded| Copy[For Each File: Copy]
+    VerifyAndCopy --> ExitHandler[Exit Handler]
+    Copy --> ExitHandler
+    ExitHandler --> End([End])
+```
+
+### Workflow Input Parameters
+
+| Parameter        | Type | Default                                       | Description                                                                |
+|------------------|------|-----------------------------------------------|----------------------------------------------------------------------------|
+| reports_location | str  | s3://linz-workflows-scratch/restore/requests/ | Location of S3 Glacier Batch Restore reports and copy manifests references |

--- a/workflows/storage/check-restore-copy.yaml
+++ b/workflows/storage/check-restore-copy.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: copy-restore
+  name: check-restore-copy
 spec:
   parallelism: 50
   nodeSelector:

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -1,0 +1,141 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/v3.5.5/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: copy-restore
+spec:
+  parallelism: 50
+  nodeSelector:
+    karpenter.sh/capacity-type: 'spot'
+  entrypoint: main
+  onExit: exit-handler
+  podMetadata:
+    labels:
+      linz.govt.nz/category: storage
+  arguments:
+    parameters:
+      - name: version_argo_tasks
+        description: 'Specify a version of the argo-tasks image to use, e.g. "v4.1" or "latest"'
+        value: 'v4'
+      - name: reports_location
+        description: 'Location of the archive restore report manifest files'
+        value: 's3://linz-workflows-scratch/restore/requests/'
+
+  templates:
+    - name: main
+      retryStrategy:
+        expression: 'false'
+      inputs:
+        parameters:
+          - name: version_argo_tasks
+            value: '{{workflow.parameters.version_argo_tasks}}'
+            default: 'v4'
+          - name: reports_location
+            value: '{{workflow.parameters.reports_location}}'
+      dag:
+        tasks:
+          - name: list-manifests
+            templateRef:
+              name: tpl-at-list
+              template: main
+            arguments:
+              parameters:
+                - name: version_argo_tasks
+                  value: '{{inputs.parameters.version_argo_tasks}}'
+                - name: location
+                  value: '{{inputs.parameters.reports_location}}'
+                - name: include
+                  value: 'manifest.json$'
+          - name: flatten-manifests
+            template: flatten-manifests
+            arguments:
+              parameters:
+                - name: manifests_list
+                  value: '{{tasks.list-manifests.outputs.parameters.files}}'
+            depends: 'list-manifests.Succeeded'
+          - name: verify-and-copy
+            template: verify-and-copy
+            arguments:
+              parameters:
+                - name: version_argo_tasks
+                  value: '{{inputs.parameters.version_argo_tasks}}'
+                - name: restore_manifest
+                  value: '{{item}}'
+            withParam: '{{tasks.flatten-manifests.outputs.parameters.flattened_manifests}}'
+            depends: 'flatten-manifests.Succeeded'
+
+    - name: flatten-manifests
+      inputs:
+        parameters:
+          - name: manifests_list
+            description: List of restore manifest files to flatten
+            default: ''
+      outputs:
+        parameters:
+          - name: flattened_manifests
+            valueFrom:
+              path: /tmp/flattened_manifests.json
+      container:
+        image: peterevans/curl-jq:latest
+        imagePullPolicy: Always
+        command: [sh, '-c']
+        args:
+          - echo '{{inputs.parameters.manifests_list}}' | jq -c 'flatten' > /tmp/flattened_manifests.json
+
+    - name: verify-and-copy
+      inputs:
+        parameters:
+          - name: version_argo_tasks
+          - name: restore_manifest
+      steps:
+        - - name: verify-restore
+            templateRef:
+              name: tpl-at-verify-restore
+              template: main
+            arguments:
+              parameters:
+                - name: version_argo_tasks
+                  value: '{{inputs.parameters.version_argo_tasks}}'
+                - name: restore_manifest
+                  value: '{{inputs.parameters.restore_manifest}}'
+        - - name: read-copy-manifest
+            templateRef:
+              name: tpl-read-file
+              template: main
+            arguments:
+              parameters:
+                - name: location
+                  value: "{{= sprig.replace('manifest.json', 'copy-manifests.json', inputs.parameters.restore_manifest)}}"
+            when: '{{steps.verify-restore.outputs.parameters.result}} == true'
+        - - name: copy
+            templateRef:
+              name: tpl-copy
+              template: main
+            arguments:
+              parameters:
+                - name: file
+                  value: '{{item}}'
+                - name: copy_option
+                  value: '--force-no-clobber'
+                - name: decompress
+                  value: 'true'
+                - name: aws_role_config_path
+                  value: 's3://linz-bucket-config/config-write.topographic.json,s3://linz-bucket-config/config-write.hydrographic.json'
+            withParam: '{{steps.read-copy-manifest.outputs.parameters.content}}'
+            when: '{{steps.read-copy-manifest.status}} == Succeeded'
+
+    - name: exit-handler
+      retryStrategy:
+        limit: '0' # `tpl-exit-handler` retries itself
+      steps:
+        - - name: exit
+            templateRef:
+              name: tpl-exit-handler
+              template: main
+            arguments:
+              parameters:
+                - name: workflow_status
+                  value: '{{workflow.status}}'
+                - name: workflow_parameters
+                  value: '{{workflow.parameters}}'

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -33,6 +33,7 @@ spec:
             default: 'v4'
           - name: reports_location
             value: '{{workflow.parameters.reports_location}}'
+            default: 's3://linz-workflows-scratch/restore/requests/'
       dag:
         tasks:
           - name: list-manifests

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -108,7 +108,7 @@ spec:
               parameters:
                 - name: location
                   value: "{{= sprig.replace('manifest.json', 'copy-manifests.json', inputs.parameters.restore_manifest)}}"
-            when: '{{steps.verify-restore.outputs.parameters.all-files-restored-result}} == true'
+            when: '{{steps.verify-restore.outputs.parameters.all_files_restored_result}} == true'
         - - name: copy
             templateRef:
               name: tpl-copy

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -78,7 +78,7 @@ spec:
             valueFrom:
               path: /tmp/flattened_manifests.json
       container:
-        image: peterevans/curl-jq:latest
+        image: peterevans/curl-jq@sha256:f62dbba08fad486a67d323e75dce757efc2ec55b1ddc2e5b78f174c978c3077c
         imagePullPolicy: Always
         command: [sh, '-c']
         args:

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -79,7 +79,7 @@ spec:
               path: /tmp/flattened_manifests.json
       container:
         image: peterevans/curl-jq@sha256:f62dbba08fad486a67d323e75dce757efc2ec55b1ddc2e5b78f174c978c3077c
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: [sh, '-c']
         args:
           - echo '{{inputs.parameters.manifests_list}}' | jq -c 'flatten' > /tmp/flattened_manifests.json

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -47,7 +47,7 @@ spec:
                 - name: location
                   value: '{{inputs.parameters.reports_location}}'
                 - name: include
-                  value: 'manifest.json$'
+                  value: '/manifest.json$'
           - name: flatten-manifests
             template: flatten-manifests
             arguments:

--- a/workflows/storage/copy-restore.yaml
+++ b/workflows/storage/copy-restore.yaml
@@ -108,7 +108,7 @@ spec:
               parameters:
                 - name: location
                   value: "{{= sprig.replace('manifest.json', 'copy-manifests.json', inputs.parameters.restore_manifest)}}"
-            when: '{{steps.verify-restore.outputs.parameters.result}} == true'
+            when: '{{steps.verify-restore.outputs.parameters.all-files-restored-result}} == true'
         - - name: copy
             templateRef:
               name: tpl-copy

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -137,6 +137,8 @@ spec:
             default: 'v4'
           - name: compress # This should not be exposed to the user (as a workflow parameter)
             default: 'false'
+          - name: decompress # This should not be exposed to the user (as a workflow parameter)
+            default: 'false'
           - name: delete_source # This should not be exposed to the user (as a workflow parameter)
             default: 'false'
           - name: delete_empty_folders # This should not be exposed to the user (as a workflow parameter)


### PR DESCRIPTION
### Motivation

As a Data Manager I want to move data from the `linz-topographic-archive` / `linz-hydrographic-archive` bucket to a designated bucket so that I can unarchive data when it is required again

### Modifications

This PR contains a cron job that triggers a copy-restore workflow. This lists outstanding S3 Glacier Batch Restore request manifests (without the suffix `.done`) and uses the Argo Tasks `verify-restore` command to check the status of the files referenced in the restore manifests. Once all the files are restored they are copied to the relevant sharing bucket.

### Verification

Tested on Argo Workflows nonprod and prod environments.
