### PR TITLE
feat: use GSD from tileindex validate and remove user input TDE-1653

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -237,7 +237,7 @@ arguments:
 
 ## argo-tasks/stac-setup
 
-Template to set up STAC metadata; outputs `collection-id` and `linz-slug`.
+Template to set up STAC metadata; outputs `collection-id` and `linz-slug` and optionally verifies the GSD matches any existing data.
 See (https://github.com/linz/argo-tasks#stac-setup)
 
 ### Template Usage
@@ -255,6 +255,8 @@ See (https://github.com/linz/argo-tasks#stac-setup)
         value: '{{workflow.parameters.end_datetime}}'
       - name: gsd
         value: '{{workflow.parameters.gsd}}'
+      - name: validate
+        value: '{{workflow.parameters.validate}}'
       - name: region
         value: '{{workflow.parameters.region}}'
       - name: geographic_description

--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -24,6 +24,9 @@ spec:
             default: ''
           - name: gsd
             description: 'Dataset GSD in metres'
+          - name: validate
+            description: 'Validate input GSD against the existing ODR_URL (collection.json or first tiff asset)'
+            default: 'true'
           - name: region
             description: 'Region of the dataset'
           - name: geographic_description
@@ -57,6 +60,7 @@ spec:
           - "{{= sprig.empty(inputs.parameters.geographic_description) ? '' : '--geographic-description=' + inputs.parameters.geographic_description }}"
           - "{{= sprig.empty(inputs.parameters.survey_id) ? '' : '--survey-id=' + inputs.parameters.survey_id }}"
           - "{{= sprig.empty(inputs.parameters.odr_url) ? '' : '--odr-url=' + inputs.parameters.odr_url }}"
+          - '--validate={{inputs.parameters.validate}}'
 
       outputs:
         parameters:

--- a/templates/argo-tasks/stac-setup.yml
+++ b/templates/argo-tasks/stac-setup.yml
@@ -25,7 +25,7 @@ spec:
           - name: gsd
             description: 'Dataset GSD in metres'
           - name: validate
-            description: 'Validate input GSD against the existing ODR_URL (collection.json or first tiff asset)'
+            description: 'Validate input GSD against the dataset at (optional) odr_url'
             default: 'true'
           - name: region
             description: 'Region of the dataset'

--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -59,10 +59,6 @@ spec:
               path: /tmp/tile-index-validate/gsd
 
         artifacts:
-          # GSD of the input tiffs
-          - name: gsd
-            path: /tmp/tile-index-validate/gsd
-
           # List of tiff files that need to be processed
           - name: files
             path: /tmp/tile-index-validate/file-list.json

--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -52,7 +52,17 @@ spec:
             default: 'v4'
 
       outputs:
+        parameters:
+          - name: gsd
+            description: 'GSD of the input tiffs'
+            valueFrom:
+              path: /tmp/tile-index-validate/gsd
+
         artifacts:
+          # GSD of the input tiffs
+          - name: gsd
+            path: /tmp/tile-index-validate/gsd
+
           # List of tiff files that need to be processed
           - name: files
             path: /tmp/tile-index-validate/file-list.json

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -126,6 +126,8 @@ spec:
               parameters:
                 - name: gsd
                   value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+                - name: validate
+                  value: 'true'
                 - name: region
                   value: 'new-zealand'
                 - name: geospatial_category

--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -184,6 +184,8 @@ spec:
               parameters:
                 - name: gsd
                   value: '{{=sprig.trim(inputs.parameters.gsd)}}'
+                - name: validate
+                  value: 'true'
                 - name: region
                   value: '{{=sprig.trim(inputs.parameters.region)}}'
                 - name: geospatial_category

--- a/workflows/raster/national-elevation.yaml
+++ b/workflows/raster/national-elevation.yaml
@@ -132,6 +132,8 @@ spec:
               parameters:
                 - name: gsd
                   value: '1'
+                - name: validate
+                  value: 'true'
                 - name: region
                   value: 'new zealand'
                 - name: geospatial_category

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -96,13 +96,13 @@ spec:
           - '50000'
           - 'None'
       - name: validate
-        description: 'Validate the tiles match LINZ map sheet tile index and there are no duplicate tiles'
+        description: 'Validate the tiles match LINZ map sheet tile index and there are no duplicate tiles, and that the TIFF resolution (GSD) matches across all files'
         value: 'true'
         enum:
           - 'false'
           - 'true'
       - name: retile
-        description: 'Retile the dataset to the output scale specified in the "scale" parameter'
+        description: 'Retile the dataset to the output scale specified in the "scale" parameter and GSD of the source imagery'
         value: 'false'
         enum:
           - 'true'
@@ -161,8 +161,6 @@ spec:
         enum:
           - 'land'
           - 'coastal'
-      - name: gsd
-        description: 'Dataset GSD in metres, e.g., "0.3" for 30 centimetres'
       - name: producer
         description: 'The producer of the source dataset, e.g. aerial or bathymetric survey company'
         value: 'Unknown'
@@ -361,31 +359,6 @@ spec:
           - name: source
       dag:
         tasks:
-          - name: stac-setup
-            templateRef:
-              name: tpl-at-stac-setup
-              template: main
-            arguments:
-              parameters:
-                - name: start_datetime
-                  value: '{{=sprig.trim(workflow.parameters.start_datetime)}}'
-                - name: end_datetime
-                  value: '{{=sprig.trim(workflow.parameters.end_datetime)}}'
-                - name: gsd
-                  value: '{{=sprig.trim(workflow.parameters.gsd)}}'
-                - name: region
-                  value: '{{=sprig.trim(workflow.parameters.region)}}'
-                - name: geographic_description
-                  value: '{{=sprig.trim(workflow.parameters.geographic_description)}}'
-                - name: geospatial_category
-                  value: '{{=sprig.trim(workflow.parameters.category)}}'
-                - name: survey_id
-                  value: '{{=sprig.trim(workflow.parameters.historic_survey_number)}}'
-                - name: odr_url
-                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
-                - name: version
-                  value: '{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
-
           - name: tile-index-validate
             templateRef:
               name: tpl-at-tile-index-validate
@@ -408,6 +381,34 @@ spec:
                   value: '{{= workflow.parameters.compression}}'
                 - name: version
                   value: '{{= workflow.parameters.version_argo_tasks}}'
+
+          - name: stac-setup
+            templateRef:
+              name: tpl-at-stac-setup
+              template: main
+            arguments:
+              parameters:
+                - name: start_datetime
+                  value: '{{=sprig.trim(workflow.parameters.start_datetime)}}'
+                - name: end_datetime
+                  value: '{{=sprig.trim(workflow.parameters.end_datetime)}}'
+                - name: gsd
+                  value: '{{ tasks.tile-index-validate.outputs.parameters.gsd }}'
+                - name: validate
+                  value: '{{= workflow.parameters.validate}}'
+                - name: region
+                  value: '{{=sprig.trim(workflow.parameters.region)}}'
+                - name: geographic_description
+                  value: '{{=sprig.trim(workflow.parameters.geographic_description)}}'
+                - name: geospatial_category
+                  value: '{{=sprig.trim(workflow.parameters.category)}}'
+                - name: survey_id
+                  value: '{{=sprig.trim(workflow.parameters.historic_survey_number)}}'
+                - name: odr_url
+                  value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
+                - name: version
+                  value: '{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
+            depends: tile-index-validate
 
           - name: group
             templateRef:
@@ -451,7 +452,7 @@ spec:
                 - name: cutline
                   value: '{{=sprig.trim(workflow.parameters.cutline)}}'
                 - name: gsd
-                  value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+                  value: '{{ tasks.tile-index-validate.outputs.parameters.gsd }}'
                 - name: source_epsg
                   value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
                 - name: target_epsg
@@ -491,7 +492,7 @@ spec:
                 - name: region
                   value: '{{=sprig.trim(workflow.parameters.region)}}'
                 - name: gsd
-                  value: '{{=sprig.trim(workflow.parameters.gsd)}}'
+                  value: '{{ tasks.tile-index-validate.outputs.parameters.gsd }}'
                 - name: geographic_description
                   value: '{{=sprig.trim(workflow.parameters.geographic_description)}}'
                 - name: event


### PR DESCRIPTION
### Motivation

As an imagery maintainer
I want to make sure the GSD specified in metadata is consistent with the resolution of all TIFF images of a survey
### Modifications
`standardising` workflow uses GSD as determined by `tile-index-validate` (`stac-setup` step now depends on `tile-index-validate`). 
`stac-setup` validates GSD against existing data.

Updated all workflows to include new `validate` parameter for `stac-setup`.
Updated readme files.
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Argo linter and manual standardising workflow runs with imagery and DEM.