### PR TITLE
feat: optionally scale resolution of TIFFs to GSD TDE-1658

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -453,6 +453,10 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.cutline)}}'
                 - name: gsd
                   value: '{{ tasks.tile-index-validate.outputs.parameters.gsd }}'
+                - name: scale_to_resolution
+                  value: '{{=sprig.trim(workflow.parameters.retile) == "true" ?
+                    sprig.trim(tasks["tile-index-validate"].outputs.parameters.gsd) + "," + sprig.trim(tasks["tile-index-validate"].outputs.parameters.gsd)
+                    : ""}}'
                 - name: source_epsg
                   value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
                 - name: target_epsg


### PR DESCRIPTION
### Motivation

To make sure GSD is consistent across all TIFFs of a dataset, let users scale TIFF resolutions to be consistent.

### Modifications

Added existing `scale_to_resolution` parameter to `standardising` workflow (optional - based on `retile` flag).

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Argo linter and manual workflow runs.