### PR TITLE
revert: feat: timeout copy workflow after 15 minutes TDE-1593

### DIFF
--- a/templates/argo-tasks/README.md
+++ b/templates/argo-tasks/README.md
@@ -93,17 +93,8 @@ steps:
 
 ## argo-tasks/copy - `tpl-copy`
 
-Template for copying a manifest of files between two locations.
+Template for copying a manifest of files between two locations.  
 See https://github.com/linz/argo-tasks#copy
-
-Note: In order to mitigate stuck copy workflows the `tpl-copy` template now times out after 15 minutes (using `activeDeadlineSeconds`) and will retry up to 10 times. This is a measure to avoid having to manually interact with the workflows while we investigate the root cause of this issue.
-
-```yaml
-activeDeadlineSeconds: '900' # Run up to 900 secs / 15 minutes
-retryStrategy:
-  limit: '10' # Retry up to 10 times
-  retryPolicy: 'Always'
-```
 
 ### Template usage
 

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -55,10 +55,7 @@ spec:
           - name: aws_role_config_path
             description: s3 URL or comma-separated list of s3 URLs allowing the workflow to write to a target(s)
             default: 's3://linz-bucket-config/config-write.imagery.json,s3://linz-bucket-config/config-write.elevation.json,s3://linz-bucket-config/config-write.topographic.json'
-      activeDeadlineSeconds: '900' # Run up to 900 secs / 15 minutes
-      retryStrategy:
-        limit: '10' # Retry up to 10 times
-        retryPolicy: 'Always'
+
       container:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(workflow.parameters.version_argo_tasks)}}'
         resources:

--- a/workflows/storage/README.md
+++ b/workflows/storage/README.md
@@ -75,15 +75,6 @@ This is a workflow that uses the [argo-tasks](https://github.com/linz/argo-tasks
 
 Access permissions are controlled by the [Bucket Sharing Config](https://github.com/linz/topo-aws-infrastructure/blob/master/src/stacks/bucket.sharing.ts) which gives Argo Workflows access to the S3 buckets we use.
 
-Note: In order to mitigate stuck copy workflows the `tpl-copy` [template](https://github.com/linz/topo-workflows/blob/master/templates/argo-tasks/README.md#argo-taskscopy---tpl-copy) now times out after 15 minutes (using `activeDeadlineSeconds`) and will retry up to 10 times. This is a measure to avoid having to manually interact with the workflows while we investigate the root cause of this issue.
-
-```yaml
-activeDeadlineSeconds: '900' # Run up to 900 secs / 15 minutes
-retryStrategy:
-  limit: '10' # Retry up to 10 times
-  retryPolicy: 'Always'
-```
-
 ### Workflow Input Parameters
 
 | Parameter            | Type  | Default                                                                                                                                                       | Description                                                                                                                                                                                                                 |


### PR DESCRIPTION
Reverts linz/topo-workflows#1054 as the underlying issue should now be resolved since chunkd has been upgraded.