### PR TITLE
feat(basemaps): update topo-raster workflow to support gridded maps BM-1375

### DIFF
--- a/workflows/basemaps/topo-maps-standardising.yml
+++ b/workflows/basemaps/topo-maps-standardising.yml
@@ -49,6 +49,13 @@ spec:
           - 'topo50'
           - 'topo250'
 
+      - name: format
+        description: gridded or gridless
+        value: 'gridless'
+        enum:
+          - 'gridded'
+          - 'gridless'
+
       - name: latest_only
         description: Only process the latest version of each map sheet
         value: 'false'
@@ -105,6 +112,7 @@ spec:
           - name: source
           - name: target
           - name: map_series
+          - name: format
           - name: latest_only
           - name: group_size
       dag:
@@ -125,6 +133,8 @@ spec:
                   value: '{{ tasks.get-location.outputs.parameters.location }}'
                 - name: map_series
                   value: '{{ inputs.parameters.map_series }}'
+                - name: format
+                  value: '{{ inputs.parameters.format }}'
                 - name: latest-only
                   value: '{{ inputs.parameters.latest_only }}'
             depends: get-location
@@ -261,6 +271,7 @@ spec:
           - name: source
           - name: target
           - name: map_series
+          - name: format
           - name: latest-only
       container:
         image: ghcr.io/linz/basemaps/cli:{{ workflow.parameters.version_basemaps_cli }}
@@ -273,6 +284,7 @@ spec:
           - 'topo'
           - '--target={{ inputs.parameters.target }}'
           - '--map-series={{ inputs.parameters.map_series }}'
+          - '--format={{ inputs.parameters.format }}'
           - '--latest-only={{ inputs.parameters.latest-only }}'
           - '{{ inputs.parameters.source }}'
       outputs:


### PR DESCRIPTION
### Motivation

We need to update our Topo Raster workflow to support the new `format` parameter for our `topo` CLI command added in [this piece of work].

[this piece of work]: https://github.com/linz/basemaps/pull/3532

### Modifications

- **workflows/basemaps**

  - **`topo-maps-standardising`**

    Updated the workflow to support the new `format` parameter of our `topo` CLI command, which supports the following values:

    - `gridded`
    - `gridless`

### Verification

1. Created a test version of our Topo Raster Argo workflow called `test-topo-raster-maps-standardising-bm-1375` that supports the new `format` parameter.
2. Ran some tests.

#### Gridless - NZOI Topo50 (Auckland Islands)

| Argo | Notes |
| - | - |
| [29-09-2025][argo_1] | Processed the 300DPI map sheets by mistake. |
| [29-09-2025][argo_2] | Re-attempt. Slight gaps between map sheets. |
| [29-09-2025][argo_3] | Re-attempt. Trim white lines only (no stretch factor). |

#### Gridded - NZOI Topo50 (Auckland Islands)

| Argo | Notes |
| - | - |
| [29-09-2025][argo_4] | Trim white lines only (no stretch factor). |

[argo_1]: https://argo.linzaccess.com/workflows/argo/test-topo-raster-maps-standardising-bm-1375-fhdwt
[argo_2]: https://argo.linzaccess.com/workflows/argo/test-topo-raster-maps-standardising-bm-1375-7bdbz
[argo_3]: https://argo.linzaccess.com/workflows/argo/test-topo-raster-maps-standardising-bm-1375-s5grn
[argo_4]: https://argo.linzaccess.com/workflows/argo/test-topo-raster-maps-standardising-bm-1375-z9qnm