### PR TITLE
fix: bucket-events sensor parameters indent & service account TDE-1879

### DIFF
--- a/events/sensors/bucket-events.yml
+++ b/events/sensors/bucket-events.yml
@@ -5,6 +5,8 @@ kind: Sensor
 metadata:
   name: 'wf-bucket-events'
 spec:
+  template:
+    serviceAccountName: 'operate-workflow-sa'
   dependencies:
     - name: 'bucket-events'
       eventSourceName: 'aws-sqs-bucket-events'

--- a/events/sensors/bucket-events.yml
+++ b/events/sensors/bucket-events.yml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-events/v1.9.10/api/jsonschema/schema.json
+
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
@@ -27,8 +28,8 @@ spec:
                       value: ''
                 workflowTemplateRef:
                   name: 'test-print'
-                  parameters:
-                    - src:
-                        dependencyName: 'bucket-events'
-                        dataKey: 'body'
-                      dest: 'spec.arguments.parameters.0.value'
+        parameters:
+          - src:
+              dependencyName: 'bucket-events'
+              dataKey: 'body'
+            dest: 'spec.arguments.parameters.0.value'


### PR DESCRIPTION
### Motivation

#### Triggers `parameters`
The Argo Events sensor trigger was failing to create workflows due to an invalid Workflow specification.
The `triggers.template.parameters` were incorrectly defined (under `workflowTemplateRef`), which is not supported by Argo Workflows and caused a strict decoding error at runtime:
``` bash
│ {"level":"error","ts":"2026-04-07T02:35:48.356028899Z","logger":"argo-events.sensor","caller":"sensors/listener.go:380","msg":"Failed to execute a trigger","sensorName":"wf-bucket-events","error":"failed to execute trigger, failed to execute │
│ time="2026-04-07T02:35:48.359Z" level=fatal msg="Failed to parse workflow: strict decoding error: unknown field \"spec.workflowTemplateRef.parameters\""   
```

This resulted in the sensor failing to execute triggers when processing events from the EventBus.

#### Service Account

A cross namespace (Cluster scope) service account needs to be used by the sensor to trigger the workflow on the `argo` namespace.

### Modifications

<!-- TODO: Say what changes you made. -->
Indent correctly `parameters`
Specify service account

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
