### PR TITLE
fix: improve Elastic Agent stability TDE-1855

### DIFF
--- a/docs/infrastructure/components/elastic.agent.md
+++ b/docs/infrastructure/components/elastic.agent.md
@@ -2,7 +2,7 @@
 
 The agent runs as a DaemonSet and collects:
 
-- Kubernetes logs
+- Kubernetes logs (not collected in this setup)
 - Container metrics
 - Node metrics
 - System metrics
@@ -20,9 +20,18 @@ flowchart LR
     C --> D[Kibana<br>Search / Dashboards]
 ```
 
-## Installation
+## Fleet
+
+### Installation
 
 [The official documentation](https://www.elastic.co/docs/reference/fleet/example-kubernetes-fleet-managed-agent-helm#agent-fleet-managed-helm-example-install-agent) has been followed to create the Fleet policy.
+
+### Configuration
+
+From the standard configuration, the following changes have been made:
+
+- Collect Kubernetes container logs has been de-activated. We already collect these logs using Fluent Bit and we want to avoid duplication.
+- Collect Kubernetes events from Kubernetes API Server has been de-activated. We already collect these events using Event exporter and we want to avoid duplication.
 
 ## Investigating the metrics
 

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -4,6 +4,7 @@ import { ArgoEvents } from './charts/argo.events.ts';
 import { ArgoExtras } from './charts/argo.extras.ts';
 import { ArgoWorkflows } from './charts/argo.workflows.ts';
 import { Cloudflared } from './charts/cloudflared.ts';
+import { ElasticAgent } from './charts/elastic.agent.ts';
 import { EventExporter } from './charts/event.exporter.ts';
 import { FluentBit } from './charts/fluentbit.ts';
 import { Karpenter, KarpenterNodePool } from './charts/karpenter.ts';
@@ -135,10 +136,10 @@ async function main(): Promise<void> {
 
   new EventExporter(app, 'event-exporter', { namespace: 'event-exporter' });
 
-  // new ElasticAgent(app, 'elastic-agent', {
-  //   fleetUrl: ssmConfig.elasticFleetUrl,
-  //   fleetToken: ssmConfig.elasticFleetToken,
-  // });
+  new ElasticAgent(app, 'elastic-agent', {
+    fleetUrl: ssmConfig.elasticFleetUrl,
+    fleetToken: ssmConfig.elasticFleetToken,
+  });
 
   app.synth();
 }

--- a/infra/charts/elastic.agent.ts
+++ b/infra/charts/elastic.agent.ts
@@ -26,39 +26,73 @@ export class ElasticAgent extends Chart {
     });
 
     // https://www.elastic.co/docs/reference/fleet/example-kubernetes-fleet-managed-agent-helm
+    // Most of the values taken from https://github.com/elastic/elastic-agent/blob/v9.3.1/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
     new Elasticagent(this, 'elastic-agent', {
       namespace: monitoringNamespace.name,
       values: {
         agent: {
-          fleet: { enabled: true, url: props.fleetUrl, token: props.fleetToken },
+          fleet: {
+            enabled: true,
+            url: props.fleetUrl,
+            token: props.fleetToken,
+            insecure: false,
+          },
           version: appVersion,
           presets: {
-            // Need to override the default perNode preset in order to set the tolerations. Everything else is taken from https://github.com/elastic/elastic-agent/blob/671f3a2f795516f4fdb34998b5b9a82532c8b5ae/deploy/helm/elastic-agent/values.yaml
             perNode: {
               mode: AgentPresetMode.DAEMONSET,
               serviceAccount: { create: true },
               clusterRole: { create: true },
               hostNetwork: true,
               resources: {
-                limits: { memory: '1000Mi' },
-                requests: { cpu: '100m', memory: '400Mi' },
+                limits: { memory: '1200Mi' },
+                requests: { cpu: '100m', memory: '500Mi' },
               },
-              nodeSelector: { 'kubernetes.io/os': 'linux' },
-              statePersistence: AgentPresetStatePersistence.EMPTY_DIR,
-              extraEnvs: [{ name: 'ELASTIC_NETINFO', value: 'false' }],
-              agent: {
-                monitoring: {
-                  namespace: 'default',
-                  useOutput: 'default',
-                  enabled: true,
-                  logs: true,
-                  metrics: true,
-                },
+              securityContext: {
+                runAsUser: 0,
               },
-              providers: { kubernetes: { node: '${NODE_NAME}', scope: 'node' } },
+              extraEnvs: [
+                { name: 'ELASTIC_NETINFO', value: 'false' },
+                { name: 'NODE_NAME', valueFrom: { fieldRef: { fieldPath: 'spec.nodeName' } } },
+                { name: 'POD_NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+              ],
+              providers: {
+                kubernetes: { node: '${NODE_NAME}', scope: 'node' },
+              },
+              statePersistence: AgentPresetStatePersistence.HOST_PATH,
               tolerations: [
+                { key: 'node-role.kubernetes.io/control-plane', effect: 'NoSchedule' },
+                { key: 'node-role.kubernetes.io/master', effect: 'NoSchedule' },
                 { key: 'karpenter.sh/capacity-type', operator: 'Equal', value: 'spot', effect: 'NoSchedule' },
-                { key: 'karpenter.sh/disrupted', operator: 'Exists', effect: 'NoSchedule' },
+              ],
+              extraVolumes: [
+                { name: 'proc', hostPath: { path: '/proc' } },
+                { name: 'cgroup', hostPath: { path: '/sys/fs/cgroup' } },
+                { name: 'varlibdockercontainers', hostPath: { path: '/var/lib/docker/containers' } },
+                { name: 'varlog', hostPath: { path: '/var/log' } },
+                { name: 'etc-full', hostPath: { path: '/etc' } },
+                { name: 'var-lib', hostPath: { path: '/var/lib' } },
+                { name: 'etc-mid', hostPath: { path: '/etc/machine-id', type: 'File' } },
+                { name: 'sys-kernel-debug', hostPath: { path: '/sys/kernel/debug' } },
+                // Needed for the mount that automatically adds the Helm
+                {
+                  name: 'agent-data',
+                  hostPath: {
+                    path: `/var/lib/elastic-agent-managed/${monitoringNamespace.name}/state`,
+                    type: 'DirectoryOrCreate',
+                  },
+                },
+              ],
+
+              extraVolumeMounts: [
+                { name: 'proc', mountPath: '/hostfs/proc', readOnly: true },
+                { name: 'cgroup', mountPath: '/hostfs/sys/fs/cgroup', readOnly: true },
+                { name: 'varlibdockercontainers', mountPath: '/var/lib/docker/containers', readOnly: true },
+                { name: 'varlog', mountPath: '/var/log', readOnly: true },
+                { name: 'etc-full', mountPath: '/hostfs/etc', readOnly: true },
+                { name: 'var-lib', mountPath: '/hostfs/var/lib', readOnly: true },
+                { name: 'etc-mid', mountPath: '/etc/machine-id', readOnly: true },
+                { name: 'sys-kernel-debug', mountPath: '/sys/kernel/debug' },
               ],
             },
           },


### PR DESCRIPTION
### Motivation

Elastic Agent was previously disabled as it made the EKS cluster instable. We want it enabled again, but with a more robust “fleet-managed” configuration to improve stability. Most of the configuration has been taken from the official documentation "out of the box" deployment and applied to the Helm Chart.
<!-- TODO: Say why you made your changes. -->

### Modifications

Apply configuration found in the "out of the box" deployment.
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
