### PR TITLE
feat: automatically set `copy_option` in publish-odr TDE-1872

### DIFF
--- a/workflows/cron/cron-national-dem-coastal.yaml
+++ b/workflows/cron/cron-national-dem-coastal.yaml
@@ -38,7 +38,5 @@ spec:
           value: 'true'
         - name: 'target_bucket_name'
           value: 'nz-coastal'
-        - name: 'copy_option'
-          value: '--force-no-clobber'
         - name: 'ticket'
           value: 'TDE-1524'

--- a/workflows/cron/cron-national-dem-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-dem-hillshades-coastal.yaml
@@ -48,5 +48,3 @@ spec:
           value: 'nz-coastal'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'

--- a/workflows/cron/cron-national-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-dem-hillshades.yaml
@@ -46,5 +46,3 @@ spec:
           value: '["hillshade", "hillshade-igor"]'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'

--- a/workflows/cron/cron-national-dem.yaml
+++ b/workflows/cron/cron-national-dem.yaml
@@ -36,7 +36,5 @@ spec:
           value: 'dem'
         - name: publish_to_odr
           value: 'true'
-        - name: 'copy_option'
-          value: '--force-no-clobber'
         - name: 'ticket'
           value: 'TDE-1130'

--- a/workflows/cron/cron-national-dsm-coastal.yaml
+++ b/workflows/cron/cron-national-dsm-coastal.yaml
@@ -38,7 +38,5 @@ spec:
           value: 'true'
         - name: 'target_bucket_name'
           value: 'nz-coastal'
-        - name: 'copy_option'
-          value: '--force-no-clobber'
         - name: 'ticket'
           value: 'TDE-1571'

--- a/workflows/cron/cron-national-dsm-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades-coastal.yaml
@@ -48,5 +48,3 @@ spec:
           value: 'nz-coastal'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'

--- a/workflows/cron/cron-national-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades.yaml
@@ -46,5 +46,3 @@ spec:
           value: '["hillshade", "hillshade-igor"]'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'

--- a/workflows/cron/cron-national-dsm.yaml
+++ b/workflows/cron/cron-national-dsm.yaml
@@ -34,7 +34,5 @@ spec:
           value: 'dsm'
         - name: publish_to_odr
           value: 'true'
-        - name: 'copy_option'
-          value: '--force-no-clobber'
         - name: 'ticket'
           value: 'TDE-1454'

--- a/workflows/cron/cron-national-merged-dem-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades-coastal.yaml
@@ -38,8 +38,6 @@ spec:
           value: '4'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'
         - name: create_capture_area
           value: 'false'
         - name: gsd

--- a/workflows/cron/cron-national-merged-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades.yaml
@@ -38,8 +38,6 @@ spec:
           value: '4'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'
         - name: create_capture_area
           value: 'true'
         - name: gsd

--- a/workflows/cron/cron-national-merged-dsm-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-merged-dsm-hillshades-coastal.yaml
@@ -38,8 +38,6 @@ spec:
           value: '4'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'
         - name: create_capture_area
           value: 'false'
         - name: gsd

--- a/workflows/cron/cron-national-merged-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dsm-hillshades.yaml
@@ -38,8 +38,6 @@ spec:
           value: '4'
         - name: publish_to_odr
           value: 'true'
-        - name: copy_option
-          value: '--force-no-clobber'
         - name: create_capture_area
           value: 'false'
         - name: gsd

--- a/workflows/raster/hillshade-combinations.yaml
+++ b/workflows/raster/hillshade-combinations.yaml
@@ -68,13 +68,6 @@ spec:
         enum:
           - 'false'
           - 'true'
-      - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
-        value: '--force-no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -125,8 +118,6 @@ spec:
                   value: '{{item}}'
                 - name: publish_to_odr
                   value: '{{workflow.parameters.publish_to_odr}}'
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
             withParam: '{{workflow.parameters.hillshade_presets}}'
 
     - name: exit-handler

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -74,13 +74,6 @@ spec:
         enum:
           - 'false'
           - 'true'
-      - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
-        value: '--force-no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -289,8 +282,6 @@ spec:
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.source_geospatial_category}}-{{inputs.parameters.hillshade_preset}}/flat/'
                 - name: target_bucket_name
                   value: '{{= workflow.parameters.domain == "coastal" ? "nz-coastal" : "nz-elevation" }}'
-                - name: copy_option
-                  value: '{{=sprig.trim(workflow.parameters.copy_option)}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url

--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -56,13 +56,6 @@ spec:
         enum:
           - 'false'
           - 'true'
-      - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
-        value: '--force-no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
       - name: geospatial_category
         description: 'Geospatial category of the dataset, e.g. "dem-hillshade"'
         value: 'dem-hillshade-igor'
@@ -159,8 +152,6 @@ spec:
             default: '{{workflow.parameters.group}}'
           - name: publish_to_odr
             default: '{{workflow.parameters.publish_to_odr}}'
-          - name: copy_option
-            default: '{{workflow.parameters.copy_option}}'
           - name: geospatial_category
             default: '{{workflow.parameters.geospatial_category}}'
           - name: create_capture_area
@@ -374,8 +365,6 @@ spec:
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/{{inputs.parameters.geospatial_category}}/flat/'
                 - name: target_bucket_name
                   value: '{{inputs.parameters.target_bucket_name}}'
-                - name: copy_option
-                  value: '{{inputs.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(inputs.parameters.ticket)}}'
                 - name: odr_url

--- a/workflows/raster/national-elevation.yaml
+++ b/workflows/raster/national-elevation.yaml
@@ -71,13 +71,6 @@ spec:
         enum:
           - 'nz-elevation'
           - 'nz-coastal'
-      - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
-        value: '--force-no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -275,8 +268,6 @@ spec:
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: target_bucket_name
                   value: '{{=sprig.trim(workflow.parameters.target_bucket_name)}}'
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -73,13 +73,6 @@ spec:
           - 'nz-imagery'
           - 'nz-elevation'
           - 'nz-coastal'
-      - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", or "force" overwriting files in the target location'
-        value: '--no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
       - name: odr_url
         description: '(Optional) URL of existing dataset to update. If provided, the target_bucket_name will be ignored.'
         value: ''
@@ -93,7 +86,6 @@ spec:
         expression: 'false'
       inputs:
         parameters:
-          - name: copy_option
           - name: source
           - name: target_bucket_name
           - name: ticket
@@ -131,7 +123,7 @@ spec:
                 - name: ticket
                   value: '{{=sprig.trim(inputs.parameters.ticket)}}'
                 - name: copy_option
-                  value: '{{inputs.parameters.copy_option}}'
+                  value: '{{= inputs.parameters.odr_url == "" ? "--no-clobber" : "--force-no-clobber"}}'
             depends: 'generate-path'
 
     - name: exit-handler

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -335,13 +335,6 @@ spec:
           - 'nz-imagery'
           - 'nz-elevation'
           - 'nz-coastal'
-      - name: copy_option
-        description: 'Do not overwrite existing files with "no-clobber", "force" overwriting files in the target location, or "force-no-clobber" overwriting only changed files, skipping unchanged files'
-        value: '--no-clobber'
-        enum:
-          - '--no-clobber'
-          - '--force'
-          - '--force-no-clobber'
   templateDefaults:
     container:
       imagePullPolicy: Always
@@ -602,8 +595,6 @@ spec:
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/flat/'
                 - name: target_bucket_name
                   value: '{{workflow.parameters.target_bucket_name}}'
-                - name: copy_option
-                  value: '{{workflow.parameters.copy_option}}'
                 - name: ticket
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url


### PR DESCRIPTION
### Motivation

`copy_option` can be determined by the fact that the data publishing is a new dataset (`--no-clobber`, as no data is supposed to exist in the target location) or an existing dataset update (`--force-no-clobber`, as we want to override some of the existing data to update it).
<!-- TODO: Say why you made your changes. -->

### Modifications

- Hardcode the `copy_options` based on whether or not the ODR URL is provided
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Test workflow
<!-- TODO: Say how you tested your changes. -->
