### PR TITLE
fix: remove SQSQueues dependencies

### DIFF
--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -16,7 +16,6 @@ import {
   CfnOutputKeys,
   ClusterName,
   ScratchBucketName,
-  SqsQueuesName,
   UseNodeLocalDns,
   validateKeys,
 } from './constants.ts';
@@ -27,10 +26,9 @@ const app = new App();
 
 async function main(): Promise<void> {
   // Get cloudformation outputs
-  const [clusterCfnOutputs, argoDbCfnOutputs, sqsQueuesCfnOutputs, ssmConfig, clusterConfig] = await Promise.all([
+  const [clusterCfnOutputs, argoDbCfnOutputs, ssmConfig, clusterConfig] = await Promise.all([
     getCfnOutputs(ClusterName),
     getCfnOutputs(ArgoDbInstanceName),
-    getCfnOutputs(SqsQueuesName),
     fetchSsmParameters({
       // Config for Cloudflared to access argo-server
       cloudflaredTunnelId: '/eks/cloudflared/argo/tunnelId',
@@ -55,7 +53,7 @@ async function main(): Promise<void> {
     }),
     describeCluster(ClusterName),
   ]);
-  const cfnOutputs = { ...clusterCfnOutputs, ...argoDbCfnOutputs, ...sqsQueuesCfnOutputs };
+  const cfnOutputs = { ...clusterCfnOutputs, ...argoDbCfnOutputs };
   validateKeys(cfnOutputs);
 
   new PriorityClasses(app, 'priority-classes');

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -9,8 +9,6 @@ export const ArgoDbInstanceName = `ArgoDb${environmentSuffix}`;
 export const ArgoDbName = 'argo';
 /** Argo Database user */
 export const ArgoDbUser = 'argo_user';
-/** SQS Queues CloudFormation Stack name */
-export const SqsQueuesName = `SqsQueues${environmentSuffix}`;
 /** AWS default region for our stack */
 export const DefaultRegion = 'ap-southeast-2';
 


### PR DESCRIPTION
### Motivation

SqsQueues stack dependencies haven't been removed while refactoring the SQS queue creation in https://github.com/linz/topo-workflows/pull/1142.
<!-- TODO: Say why you made your changes. -->

### Modifications

Remove SqsQeues stack dependencies in the codebase
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
