### PR TITLE
ci: trigger infrastructure deployment on GitHub Actions workflow change TDE-1812

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Find Changes in Infra
         id: get-infra-changes
         run: |
-          mapfile -d '' modified_infra_files < <(git diff --name-only -z ${{ github.event.before }} ${{ github.event.after }} -- "infra/*" ":(exclude)infra/*.md")
+          mapfile -d '' modified_infra_files < <(git diff --name-only -z ${{ github.event.before }} ${{ github.event.after }} -- "infra/*" ".github/workflows/main.yml" ":(exclude)infra/*.md")
           if [[ "${#modified_infra_files[@]}" -ge 1 ]]; then
             echo "run_infra=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
### Motivation

Previously, modifications to the infrastructure deployment commands (like `cdk deploy` or `cdk8s synth`) wouldn't trigger a deployment unless a file inside the `infra/` directory was also changed. By tracking the workflow file itself, any updates to the deployment commands or arguments will now correctly trigger an infrastructure deployment.
<!-- TODO: Say why you made your changes. -->

### Modifications

Updates the `get-infra-changes` step in the GitHub Actions workflow to include `.github/workflows/main.yml` in the Git diff check. 
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

On the next deployment commands change...
<!-- TODO: Say how you tested your changes. -->
