### PR TITLE
feat: trigger national hillshade workflows using Argo Events TDE-1896

### DIFF
--- a/events/sensors/sensor-national-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-hillshades-coastal.yml
@@ -41,8 +41,6 @@ spec:
                     # Keep source_geospatial_categories first; sensor mapping targets index 0.
                     - name: source_geospatial_categories
                       value: ''
-                    - name: source_geospatial_categories
-                      value: '{{workflow.parameters.source_geospatial_categories}}'
                     - name: version_argo_tasks
                       value: 'v5'
                     - name: version_basemaps_cli
@@ -54,7 +52,7 @@ spec:
                     - name: bucket_name
                       value: 'nz-coastal'
                     - name: domain
-                      value: 'land'
+                      value: 'coastal'
                     - name: gsd
                       value: '1'
                     - name: hillshade_presets

--- a/events/sensors/sensor-national-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-hillshades-coastal.yml
@@ -32,7 +32,7 @@ spec:
                 labels:
                   linz.govt.nz/category: raster
                   linz.govt.nz/data-type: raster
-                  linz.govt.nz/ticket: 'TDE-1525'
+                  linz.govt.nz/ticket: 'TDE-1896'
               spec:
                 workflowTemplateRef:
                   name: hillshade-combinations
@@ -50,7 +50,7 @@ spec:
                     - name: version_topo_imagery
                       value: 'v7'
                     - name: ticket
-                      value: 'TDE-1479'
+                      value: 'TDE-1896'
                     - name: bucket_name
                       value: 'nz-coastal'
                     - name: domain

--- a/events/sensors/sensor-national-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-hillshades-coastal.yml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: 'national-hillshades'
+  name: 'national-hillshades-coastal'
 spec:
   template:
     serviceAccountName: 'operate-workflow-sa'
@@ -16,10 +16,10 @@ spec:
           - path: body.Message
             type: string
             value:
-              - nz-elevation.*\/(dem|dsm)_1m\/
+              - nz-coastal.*\/(dem|dsm)_1m\/
   triggers:
     - template:
-        name: 'trigger-wf-national-hillshades'
+        name: 'trigger-wf-national-hillshades-coastal'
         argoWorkflow:
           operation: 'submit'
           source:
@@ -32,7 +32,7 @@ spec:
                 labels:
                   linz.govt.nz/category: raster
                   linz.govt.nz/data-type: raster
-                  linz.govt.nz/ticket: 'TDE-1279'
+                  linz.govt.nz/ticket: 'TDE-1525'
               spec:
                 workflowTemplateRef:
                   name: hillshade-combinations
@@ -50,9 +50,9 @@ spec:
                     - name: version_topo_imagery
                       value: 'v7'
                     - name: ticket
-                      value: 'TDE-1279'
+                      value: 'TDE-1479'
                     - name: bucket_name
-                      value: 'nz-elevation'
+                      value: 'nz-coastal'
                     - name: domain
                       value: 'land'
                     - name: gsd
@@ -68,5 +68,5 @@ spec:
               dest: 'spec.arguments.parameters.0.value'
             - src:
                 dependencyName: 'bucket-events'
-                dataTemplate: '{{ "national-hillshades-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
+                dataTemplate: '{{ "national-hillshades-coastal-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
               dest: 'metadata.generateName'

--- a/events/sensors/sensor-national-hillshades.yml
+++ b/events/sensors/sensor-national-hillshades.yml
@@ -41,8 +41,6 @@ spec:
                     # Keep source_geospatial_categories first; sensor mapping targets index 0.
                     - name: source_geospatial_categories
                       value: ''
-                    - name: source_geospatial_categories
-                      value: '{{workflow.parameters.source_geospatial_categories}}'
                     - name: version_argo_tasks
                       value: 'v5'
                     - name: version_basemaps_cli

--- a/events/sensors/sensor-national-hillshades.yml
+++ b/events/sensors/sensor-national-hillshades.yml
@@ -32,7 +32,7 @@ spec:
                 labels:
                   linz.govt.nz/category: raster
                   linz.govt.nz/data-type: raster
-                  linz.govt.nz/ticket: 'TDE-1279'
+                  linz.govt.nz/ticket: 'TDE-1896'
               spec:
                 workflowTemplateRef:
                   name: hillshade-combinations
@@ -50,7 +50,7 @@ spec:
                     - name: version_topo_imagery
                       value: 'v7'
                     - name: ticket
-                      value: 'TDE-1279'
+                      value: 'TDE-1896'
                     - name: bucket_name
                       value: 'nz-elevation'
                     - name: domain

--- a/events/sensors/sensor-national-hillshades.yml
+++ b/events/sensors/sensor-national-hillshades.yml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-events/v1.9.10/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: 'national-hillshades'
+spec:
+  template:
+    serviceAccountName: 'operate-workflow-sa'
+  dependencies:
+    - name: 'bucket-events'
+      eventSourceName: 'aws-sqs-bucket-events'
+      eventName: 'bucket-events'
+      filters:
+        data:
+          - path: body.Message
+            type: string
+            value:
+              - nz-elevation.*\/(dem|dsm)_1m\/
+  triggers:
+    - template:
+        name: 'trigger-wf-national-hillshades'
+        argoWorkflow:
+          operation: 'submit'
+          source:
+            resource:
+              apiVersion: 'argoproj.io/v1alpha1'
+              kind: 'Workflow'
+              metadata:
+                generateName: ''
+                namespace: 'argo'
+                labels:
+                  linz.govt.nz/category: raster
+                  linz.govt.nz/data-type: raster
+                  linz.govt.nz/ticket: 'TDE-1279'
+              spec:
+                entrypoint: main
+                onExit: exit-handler
+                podMetadata:
+                  labels:
+                    linz.govt.nz/category: raster
+                    linz.govt.nz/data-type: raster
+                    linz.govt.nz/region: 'new-zealand'
+                arguments:
+                  parameters:
+                    # Keep source_geospatial_categories first; sensor mapping targets index 0.
+                    - name: source_geospatial_categories
+                      value: '["dem"]'
+                    - name: version_argo_tasks
+                      value: 'v5'
+                    - name: version_basemaps_cli
+                      value: 'v8'
+                    - name: version_topo_imagery
+                      value: 'v7'
+                    - name: ticket
+                      value: 'TDE-1279'
+                    - name: bucket_name
+                      value: 'nz-elevation'
+                    - name: domain
+                      value: 'land'
+                    - name: gsd
+                      value: '1'
+                    - name: hillshade_presets
+                      value: '["hillshade", "hillshade-igor"]'
+                    - name: publish_to_odr
+                      value: 'true'
+                templates:
+                  - name: main
+                    retryStrategy:
+                      expression: 'false'
+                    steps:
+                      - - name: hillshade
+                          templateRef:
+                            name: hillshade-combinations
+                            template: main
+                          arguments:
+                            parameters:
+                              - name: source_geospatial_categories
+                                value: '{{workflow.parameters.source_geospatial_categories}}'
+                  - name: exit-handler
+                    retryStrategy:
+                      limit: '0' # tpl-log-notification retries itself
+                    steps:
+                      - - name: exit
+                          templateRef:
+                            name: tpl-log-notification
+                            template: main
+                          arguments:
+                            parameters:
+                              - name: workflow_status
+                                value: '{{workflow.status}}'
+                              - name: workflow_parameters
+                                value: '{{workflow.parameters}}'
+                volumes:
+                  - name: ephemeral
+                    emptyDir: {}
+          parameters:
+            - src:
+                dependencyName: 'bucket-events'
+                dataTemplate: '{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "[\"${1}\"]" }}'
+              dest: 'spec.arguments.parameters.0.value'
+            - src:
+                dependencyName: 'bucket-events'
+                dataTemplate: '{{ "national-hillshades-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
+              dest: 'metadata.generateName'

--- a/events/sensors/sensor-national-merged-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-merged-hillshades-coastal.yml
@@ -1,0 +1,125 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-events/v1.9.10/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: 'national-merged-hillshades-coastal'
+spec:
+  template:
+    serviceAccountName: 'operate-workflow-sa'
+  dependencies:
+    - name: 'bucket-events'
+      eventSourceName: 'aws-sqs-bucket-events'
+      eventName: 'bucket-events'
+      filters:
+        data:
+          - path: body.Message
+            type: string
+            value:
+              - nz-coastal.*\/[^\"]*hillshade[^\"]*_1m
+  triggers:
+    - template:
+        name: 'trigger-wf-national-merged-hillshades-coastal'
+        argoWorkflow:
+          operation: 'submit'
+          source:
+            resource:
+              apiVersion: 'argoproj.io/v1alpha1'
+              kind: 'Workflow'
+              metadata:
+                generateName: ''
+                namespace: 'argo'
+                labels:
+                  linz.govt.nz/category: raster
+                  linz.govt.nz/data-type: raster
+                  linz.govt.nz/ticket: 'TDE-1479'
+              spec:
+                entrypoint: main
+                onExit: exit-handler
+                podMetadata:
+                  labels:
+                    linz.govt.nz/category: raster
+                    linz.govt.nz/data-type: raster
+                    linz.govt.nz/region: 'new-zealand'
+                arguments:
+                  parameters:
+                    # Keep geospatial_category first; sensor mapping targets index 0.
+                    - name: geospatial_category
+                      value: ''
+                    - name: version_argo_tasks
+                      value: 'v5'
+                    - name: version_basemaps_cli
+                      value: 'v8'
+                    - name: version_topo_imagery
+                      value: 'v7'
+                    - name: ticket
+                      value: 'TDE-1479'
+                    - name: group
+                      value: '4'
+                    - name: publish_to_odr
+                      value: 'true'
+                    - name: create_capture_area
+                      value: 'true'
+                    - name: gsd
+                      value: '1'
+                    - name: scale_to_resolution
+                      value: '1,1'
+                    - name: source_epsg
+                      value: '2193'
+                    - name: target_epsg
+                      value: '2193'
+                    - name: include
+                      value: '.tiff?$'
+                    - name: scale
+                      value: '50000'
+                    - name: target_bucket_name
+                      value: 'nz-coastal'
+                    - name: region
+                      value: 'new-zealand'
+                    - name: gdal_compression_preset
+                      value: 'dem_zstd'
+                templates:
+                  - name: main
+                    retryStrategy:
+                      expression: 'false'
+                    steps:
+                      - - name: hillshade
+                          templateRef:
+                            name: merge-layers
+                            template: main
+                          arguments:
+                            parameters:
+                              - name: top_layer_source
+                                value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
+                              - name: base_layer_source
+                                value: '' # No base layer for Coastal hillshades
+                              - name: odr_url
+                                value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
+                              - name: geospatial_category
+                                value: '{{workflow.parameters.geospatial_category}}'
+                  - name: exit-handler
+                    retryStrategy:
+                      limit: '0' # tpl-log-notification retries itself
+                    steps:
+                      - - name: exit
+                          templateRef:
+                            name: tpl-log-notification
+                            template: main
+                          arguments:
+                            parameters:
+                              - name: workflow_status
+                                value: '{{workflow.status}}'
+                              - name: workflow_parameters
+                                value: '{{workflow.parameters}}'
+                volumes:
+                  - name: ephemeral
+                    emptyDir: {}
+          parameters:
+            - src:
+                dependencyName: 'bucket-events'
+                dataTemplate: '{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}'
+              dest: 'spec.arguments.parameters.0.value'
+            - src:
+                dependencyName: 'bucket-events'
+                dataTemplate: '{{ "national-merged-coastal-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
+              dest: 'metadata.generateName'

--- a/events/sensors/sensor-national-merged-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-merged-hillshades-coastal.yml
@@ -34,18 +34,21 @@ spec:
                   linz.govt.nz/data-type: raster
                   linz.govt.nz/ticket: 'TDE-1479'
               spec:
-                entrypoint: main
-                onExit: exit-handler
-                podMetadata:
-                  labels:
-                    linz.govt.nz/category: raster
-                    linz.govt.nz/data-type: raster
-                    linz.govt.nz/region: 'new-zealand'
+                workflowTemplateRef:
+                  name: merge-layers
                 arguments:
                   parameters:
                     # Keep geospatial_category first; sensor mapping targets index 0.
                     - name: geospatial_category
                       value: ''
+                    - name: top_layer_source
+                      value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
+                    - name: base_layer_source
+                      value: '' # No base layer for Coastal hillshades
+                    - name: odr_url
+                      value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
+                    - name: geospatial_category
+                      value: '{{workflow.parameters.geospatial_category}}'
                     - name: version_argo_tasks
                       value: 'v5'
                     - name: version_basemaps_cli
@@ -78,42 +81,6 @@ spec:
                       value: 'new-zealand'
                     - name: gdal_compression_preset
                       value: 'dem_zstd'
-                templates:
-                  - name: main
-                    retryStrategy:
-                      expression: 'false'
-                    steps:
-                      - - name: hillshade
-                          templateRef:
-                            name: merge-layers
-                            template: main
-                          arguments:
-                            parameters:
-                              - name: top_layer_source
-                                value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
-                              - name: base_layer_source
-                                value: '' # No base layer for Coastal hillshades
-                              - name: odr_url
-                                value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
-                              - name: geospatial_category
-                                value: '{{workflow.parameters.geospatial_category}}'
-                  - name: exit-handler
-                    retryStrategy:
-                      limit: '0' # tpl-log-notification retries itself
-                    steps:
-                      - - name: exit
-                          templateRef:
-                            name: tpl-log-notification
-                            template: main
-                          arguments:
-                            parameters:
-                              - name: workflow_status
-                                value: '{{workflow.status}}'
-                              - name: workflow_parameters
-                                value: '{{workflow.parameters}}'
-                volumes:
-                  - name: ephemeral
-                    emptyDir: {}
           parameters:
             - src:
                 dependencyName: 'bucket-events'

--- a/events/sensors/sensor-national-merged-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-merged-hillshades-coastal.yml
@@ -47,8 +47,6 @@ spec:
                       value: '' # No base layer for Coastal hillshades
                     - name: odr_url
                       value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
-                    - name: geospatial_category
-                      value: '{{workflow.parameters.geospatial_category}}'
                     - name: version_argo_tasks
                       value: 'v5'
                     - name: version_basemaps_cli

--- a/events/sensors/sensor-national-merged-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-merged-hillshades-coastal.yml
@@ -32,7 +32,7 @@ spec:
                 labels:
                   linz.govt.nz/category: raster
                   linz.govt.nz/data-type: raster
-                  linz.govt.nz/ticket: 'TDE-1479'
+                  linz.govt.nz/ticket: 'TDE-1896'
               spec:
                 workflowTemplateRef:
                   name: merge-layers
@@ -56,7 +56,7 @@ spec:
                     - name: version_topo_imagery
                       value: 'v7'
                     - name: ticket
-                      value: 'TDE-1479'
+                      value: 'TDE-1896'
                     - name: group
                       value: '4'
                     - name: publish_to_odr

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -92,7 +92,7 @@ spec:
                               - name: top_layer_source
                                 value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
                               - name: base_layer_source
-                                value: '{{ if contains .Parameters.geospatial_category "dsm" }}{{ else }}s3://nz-elevation/new-zealand/new-zealand-contour/{{.Parameters.geospatial_category}}_8m/2193/{{ end }}'
+                                value: '{{= workflow.parameters.geospatial_category matches ".*dem-hillshade.*" ? "s3://nz-elevation/new-zealand/new-zealand-contour/" + workflow.parameters.geospatial_category + "_8m/2193/" : "" }}'
                               - name: odr_url
                                 value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
                               - name: geospatial_category

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -32,7 +32,7 @@ spec:
                 labels:
                   linz.govt.nz/category: raster
                   linz.govt.nz/data-type: raster
-                  linz.govt.nz/ticket: 'TDE-1428'
+                  linz.govt.nz/ticket: 'TDE-1896'
               spec:
                 workflowTemplateRef:
                   name: merge-layers
@@ -54,7 +54,7 @@ spec:
                     - name: version_topo_imagery
                       value: 'v7'
                     - name: ticket
-                      value: 'TDE-1428'
+                      value: 'TDE-1896'
                     - name: group
                       value: '4'
                     - name: publish_to_odr

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: 'national-merged-dem-hillshades'
+  name: 'national-merged-hillshades'
 spec:
   template:
     serviceAccountName: 'operate-workflow-sa'
@@ -16,10 +16,10 @@ spec:
           - path: body.Message
             type: string
             value:
-              - linz-workflowsaf-scratch.*\/[^"]*dem-hillshade[^"]*_1m
+              - linz-workflowsaf-scratch.*\/[^"]*hillshade[^"]*_1m
   triggers:
     - template:
-        name: 'trigger-wf-national-merged-dem-hillshades'
+        name: 'trigger-wf-national-merged-hillshades'
         argoWorkflow:
           operation: 'submit'
           source:
@@ -27,7 +27,7 @@ spec:
               apiVersion: 'argoproj.io/v1alpha1'
               kind: 'Workflow'
               metadata:
-                generateName: 'national-merged-dem-hillshades-'
+                generateName: ''
                 namespace: 'argo'
                 labels:
                   linz.govt.nz/category: raster
@@ -92,7 +92,7 @@ spec:
                               - name: top_layer_source
                                 value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
                               - name: base_layer_source
-                                value: 's3://nz-elevation/new-zealand/new-zealand-contour/{{workflow.parameters.geospatial_category}}_8m/2193/'
+                                value: '{{ if contains .Parameters.geospatial_category "dsm" }}{{ else }}s3://nz-elevation/new-zealand/new-zealand-contour/{{.Parameters.geospatial_category}}_8m/2193/{{ end }}'
                               - name: odr_url
                                 value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
                               - name: geospatial_category
@@ -121,5 +121,5 @@ spec:
               dest: 'spec.arguments.parameters.0.value'
             - src:
                 dependencyName: 'bucket-events-af'
-                dataTemplate: '{{ "national-merged-dem-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
+                dataTemplate: '{{ "national-merged-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
               dest: 'metadata.generateName'

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -1,0 +1,125 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-events/v1.9.10/api/jsonschema/schema.json
+
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: 'national-merged-dem-hillshades'
+spec:
+  template:
+    serviceAccountName: 'operate-workflow-sa'
+  dependencies:
+    - name: 'bucket-events'
+      eventSourceName: 'aws-sqs-bucket-events'
+      eventName: 'bucket-events'
+      filters:
+        data:
+          - path: body.Message
+            type: string
+            value:
+              - linz-workflowsaf-scratch.*\/[^"]*dem-hillshade[^"]*_1m
+  triggers:
+    - template:
+        name: 'trigger-wf-national-merged-dem-hillshades'
+        argoWorkflow:
+          operation: 'submit'
+          source:
+            resource:
+              apiVersion: 'argoproj.io/v1alpha1'
+              kind: 'Workflow'
+              metadata:
+                generateName: 'national-merged-dem-hillshades-'
+                namespace: 'argo'
+                labels:
+                  linz.govt.nz/category: raster
+                  linz.govt.nz/data-type: raster
+                  linz.govt.nz/ticket: 'TDE-1428'
+              spec:
+                entrypoint: main
+                onExit: exit-handler
+                podMetadata:
+                  labels:
+                    linz.govt.nz/category: raster
+                    linz.govt.nz/data-type: raster
+                    linz.govt.nz/region: 'new-zealand'
+                arguments:
+                  parameters:
+                    # Keep geospatial_category first; sensor mapping targets index 0.
+                    - name: geospatial_category
+                      value: ''
+                    - name: version_argo_tasks
+                      value: 'v5'
+                    - name: version_basemaps_cli
+                      value: 'v8'
+                    - name: version_topo_imagery
+                      value: 'v7'
+                    - name: ticket
+                      value: 'TDE-1428'
+                    - name: group
+                      value: '4'
+                    - name: publish_to_odr
+                      value: 'true'
+                    - name: create_capture_area
+                      value: 'true'
+                    - name: gsd
+                      value: '1'
+                    - name: scale_to_resolution
+                      value: '1,1'
+                    - name: source_epsg
+                      value: '2193'
+                    - name: target_epsg
+                      value: '2193'
+                    - name: include
+                      value: '.tiff?$'
+                    - name: scale
+                      value: '50000'
+                    - name: target_bucket_name
+                      value: 'nz-elevation'
+                    - name: region
+                      value: 'new-zealand'
+                    - name: gdal_compression_preset
+                      value: 'dem_zstd'
+                templates:
+                  - name: main
+                    retryStrategy:
+                      expression: 'false'
+                    steps:
+                      - - name: hillshade
+                          templateRef:
+                            name: merge-layers
+                            template: main
+                          arguments:
+                            parameters:
+                              - name: top_layer_source
+                                value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
+                              - name: base_layer_source
+                                value: 's3://nz-elevation/new-zealand/new-zealand-contour/{{workflow.parameters.geospatial_category}}_8m/2193/'
+                              - name: odr_url
+                                value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
+                              - name: geospatial_category
+                                value: '{{workflow.parameters.geospatial_category}}'
+                  - name: exit-handler
+                    retryStrategy:
+                      limit: '0' # tpl-log-notification retries itself
+                    steps:
+                      - - name: exit
+                          templateRef:
+                            name: tpl-log-notification
+                            template: main
+                          arguments:
+                            parameters:
+                              - name: workflow_status
+                                value: '{{workflow.status}}'
+                              - name: workflow_parameters
+                                value: '{{workflow.parameters}}'
+                volumes:
+                  - name: ephemeral
+                    emptyDir: {}
+          parameters:
+            - src:
+                dependencyName: 'bucket-events-af'
+                dataTemplate: '{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}'
+              dest: 'spec.arguments.parameters.0.value'
+            - src:
+                dependencyName: 'bucket-events-af'
+                dataTemplate: '{{ "national-merged-dem-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
+              dest: 'metadata.generateName'

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -16,7 +16,7 @@ spec:
           - path: body.Message
             type: string
             value:
-              - linz-workflowsaf-scratch.*\/[^"]*hillshade[^"]*_1m
+              - nz-elevation.*\/[^"]*hillshade[^"]*_1m
   triggers:
     - template:
         name: 'trigger-wf-national-merged-hillshades'
@@ -116,10 +116,10 @@ spec:
                     emptyDir: {}
           parameters:
             - src:
-                dependencyName: 'bucket-events-af'
+                dependencyName: 'bucket-events'
                 dataTemplate: '{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}'
               dest: 'spec.arguments.parameters.0.value'
             - src:
-                dependencyName: 'bucket-events-af'
+                dependencyName: 'bucket-events'
                 dataTemplate: '{{ "national-merged-" }}{{ regexReplaceAll "^.*new-zealand/new-zealand/(.*?)(?:_1m)?/2193(?:/.*)?$" (index (fromJson (index (index .Input "body") "Message")) "Records" 0 "s3" "object" "key") "${1}" }}{{ "-" }}'
               dest: 'metadata.generateName'

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -16,7 +16,7 @@ spec:
           - path: body.Message
             type: string
             value:
-              - nz-elevation.*\/[^"]*hillshade[^"]*_1m
+              - nz-elevation.*\/[^\"]*hillshade[^\"]*_1m
   triggers:
     - template:
         name: 'trigger-wf-national-merged-hillshades'

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -34,18 +34,19 @@ spec:
                   linz.govt.nz/data-type: raster
                   linz.govt.nz/ticket: 'TDE-1428'
               spec:
-                entrypoint: main
-                onExit: exit-handler
-                podMetadata:
-                  labels:
-                    linz.govt.nz/category: raster
-                    linz.govt.nz/data-type: raster
-                    linz.govt.nz/region: 'new-zealand'
+                workflowTemplateRef:
+                  name: merge-layers
                 arguments:
                   parameters:
                     # Keep geospatial_category first; sensor mapping targets index 0.
                     - name: geospatial_category
                       value: ''
+                    - name: top_layer_source
+                      value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
+                    - name: base_layer_source
+                      value: '{{= workflow.parameters.geospatial_category matches ".*dem-hillshade.*" ? "s3://nz-elevation/new-zealand/new-zealand-contour/" + workflow.parameters.geospatial_category + "_8m/2193/" : "" }}'
+                    - name: odr_url
+                      value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
                     - name: version_argo_tasks
                       value: 'v5'
                     - name: version_basemaps_cli
@@ -78,42 +79,6 @@ spec:
                       value: 'new-zealand'
                     - name: gdal_compression_preset
                       value: 'dem_zstd'
-                templates:
-                  - name: main
-                    retryStrategy:
-                      expression: 'false'
-                    steps:
-                      - - name: hillshade
-                          templateRef:
-                            name: merge-layers
-                            template: main
-                          arguments:
-                            parameters:
-                              - name: top_layer_source
-                                value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}_1m/2193/'
-                              - name: base_layer_source
-                                value: '{{= workflow.parameters.geospatial_category matches ".*dem-hillshade.*" ? "s3://nz-elevation/new-zealand/new-zealand-contour/" + workflow.parameters.geospatial_category + "_8m/2193/" : "" }}'
-                              - name: odr_url
-                                value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
-                              - name: geospatial_category
-                                value: '{{workflow.parameters.geospatial_category}}'
-                  - name: exit-handler
-                    retryStrategy:
-                      limit: '0' # tpl-log-notification retries itself
-                    steps:
-                      - - name: exit
-                          templateRef:
-                            name: tpl-log-notification
-                            template: main
-                          arguments:
-                            parameters:
-                              - name: workflow_status
-                                value: '{{workflow.status}}'
-                              - name: workflow_parameters
-                                value: '{{workflow.parameters}}'
-                volumes:
-                  - name: ephemeral
-                    emptyDir: {}
           parameters:
             - src:
                 dependencyName: 'bucket-events'

--- a/workflows/cron/cron-national-dem-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-dem-hillshades-coastal.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1525'

--- a/workflows/cron/cron-national-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-dem-hillshades.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1279'

--- a/workflows/cron/cron-national-dsm-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades-coastal.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1571'

--- a/workflows/cron/cron-national-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-dsm-hillshades.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1455'

--- a/workflows/cron/cron-national-merged-dem-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades-coastal.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1479'

--- a/workflows/cron/cron-national-merged-dem-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dem-hillshades.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1428'

--- a/workflows/cron/cron-national-merged-dsm-hillshades-coastal.yaml
+++ b/workflows/cron/cron-national-merged-dsm-hillshades-coastal.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1571'

--- a/workflows/cron/cron-national-merged-dsm-hillshades.yaml
+++ b/workflows/cron/cron-national-merged-dsm-hillshades.yaml
@@ -13,6 +13,7 @@ spec:
   concurrencyPolicy: 'Allow'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  suspend: true
   workflowMetadata:
     labels:
       linz.govt.nz/ticket: 'TDE-1428'


### PR DESCRIPTION
### Motivation

To generate the hillshades in a timely manner after the national DEM/DSM products are published to the ODR.
To reduce the noise of many daily cron workflows running when there is no data to publish.

### Modifications

Sensors created to trigger when the National DEM and DSM and 1m hillshade dataset collections are updated.
Suspend hillshade cron workflows (before deleting in future PR once deployed and run in prod).

### Verification

Ran on test cluster.

<img width="998" height="394" alt="image" src="https://github.com/user-attachments/assets/3a3d03a5-e63c-4c82-bbe0-60abc7721151" />

<img width="990" height="636" alt="image" src="https://github.com/user-attachments/assets/ee3eec33-185a-4dc5-8b80-d01439cffba5" />

Example Argo Event sensor log:

```
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=NATS auth strategy: Basic
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Connected to NATS Jetstream server.
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Successfully located K/V store for sensor national-hillshades-coastal
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=starting eventbus connection daemon for client JetstreamTriggerConn{Sensor:national-hillshades-coastal,Trigger:trigger-wf-national-hillshades-coastal}...
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=started subscribing to events for trigger trigger-wf-national-hillshades-coastal with client connection JetstreamTriggerConn{Sensor:national-hillshades-coastal,Trigger:trigger-wf-national-hillshades-coastal}
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Subscribing to subject default.aws-sqs-bucket-events-af.bucket-events-af with durable name group-3147653848
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Triggering actions after receiving dependency bucket-events-af
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Triggering actions after receiving dependency bucket-events-af
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Name:                national-hillshades-coastal-dem-nlb4z
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Namespace:           argo
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=ServiceAccount:      unset
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Status:              Pending
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Created:             Thu Apr 23 02:40:21 +0000 (now)
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Progress:            
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Parameters:          
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  source_geospatial_categories: ["dem"]
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  version_argo_tasks: v5
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  version_basemaps_cli: v8
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  version_topo_imagery: v7
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  ticket:            TDE-1896
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  bucket_name:       nz-coastal
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  domain:            coastal
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  gsd:               1
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  hillshade_presets: ["hillshade", "hillshade-igor"]
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  publish_to_odr:    false
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Successfully processed trigger 'trigger-wf-national-hillshades-coastal'
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Name:                national-hillshades-coastal-dsm-v8zcb
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Namespace:           argo
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=ServiceAccount:      unset
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Status:              Pending
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Created:             Thu Apr 23 02:40:23 +0000 (now)
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Progress:            
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Parameters:          
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  source_geospatial_categories: ["dsm"]
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  version_argo_tasks: v5
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  version_basemaps_cli: v8
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  version_topo_imagery: v7
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  ticket:            TDE-1896
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  bucket_name:       nz-coastal
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  domain:            coastal
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  gsd:               1
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  hillshade_presets: ["hillshade", "hillshade-igor"]
namespace=argo-events, sensorName=national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=  publish_to_odr:    false
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=Successfully processed trigger 'trigger-wf-national-hillshades-coastal'
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=not interested in dependency bucket-events-af (didn't pass filter)
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=not interested in dependency bucket-events-af (didn't pass filter)
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=not interested in dependency bucket-events-af (didn't pass filter)
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=not interested in dependency bucket-events-af (didn't pass filter)
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=not interested in dependency bucket-events-af (didn't pass filter)
namespace=argo-events, sensorName=national-hillshades-coastal, triggerName=trigger-wf-national-hillshades-coastal, level=info, time=2026-04-23T02:56:22Z, msg=not interested in dependency bucket-events-af (didn't pass filter)
```