### PR TITLE
fix: disable event trigger TDE-1885

### DIFF
--- a/events/sensors/bucket-events.yml
+++ b/events/sensors/bucket-events.yml
@@ -8,9 +8,15 @@ spec:
   template:
     serviceAccountName: 'operate-workflow-sa'
   dependencies:
-    # - name: 'bucket-events'
-    #   eventSourceName: 'aws-sqs-bucket-events'
-    #   eventName: 'bucket-events'
+    - name: 'bucket-events'
+      eventSourceName: 'aws-sqs-bucket-events'
+      eventName: 'bucket-events'
+      filters:
+        data:
+          - path: body.Message
+            type: string
+            value:
+              - DO_NOT_MATCH
   triggers:
     - template:
         name: 'trigger-wf-bucket-events'


### PR DESCRIPTION
### Motivation & Modifications

Filter events on test sensor so that they will never match and trigger the test-print workflow which is triggering on ODR and Basemaps S3 events.

### Verification

Test cluster.
