### PR TITLE
fix(unarchive): handle spaces correctly in S3 object filters TDE-1904

### DIFF
--- a/workflows/storage/unarchive.yaml
+++ b/workflows/storage/unarchive.yaml
@@ -87,7 +87,7 @@ spec:
                 - name: action_location
                   value: '{{=sprig.trimSuffix("/", tasks["get-location"].outputs.parameters.location)}}/actions/'
                 - name: include
-                  value: '{{= workflow.parameters.name_contains != "" ? ".*" + sprig.regexQuoteMeta(workflow.parameters.name_contains) + ".*" : ".*" }}'
+                  value: '{{= workflow.parameters.name_contains != "" ? ".*" + sprig.replace(" ", "(%20| )", sprig.regexQuoteMeta(workflow.parameters.name_contains)) + ".*" : ".*" }}'
                 - name: group
                   value: '{{workflow.parameters.group}}'
                 - name: group_size


### PR DESCRIPTION
### Motivation

When filtering files, those containing spaces were being silently skipped because `create-manifest` evaluates regexes against URL-encoded S3 keys (where spaces are %20), but our workflow passed literal spaces to the regex.
<!-- TODO: Say why you made your changes. -->

### Modifications

Updated the include regex using sprig.replace to convert spaces into (%20| ), allowing the regex to match both literal and URL-encoded spaces.
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Unarchive workflow ran and restore in progress
<!-- TODO: Say how you tested your changes. -->
