### PR TITLE
fix: reduce standardising grouping to 20

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -103,7 +103,7 @@ spec:
         value: '2193'
       - name: group
         description: 'How many output tiles to process in each standardise-validate task "pod". Change if you have resource or performance issues when standardising a dataset.'
-        value: '50'
+        value: '20'
       - name: concurrency
         description: 'Number of concurrent tiles to standardise. If not specified, defaults to 4, or 1 if compression is rgbnir_zstd.'
         value: ''


### PR DESCRIPTION
### Motivation & Modifications

Most of our standardising workflows now perform a retile, so our output tiles are larger and have many more input tiles. This PR is to reduce the standardising grouping to 20 output tiles per pod so that our workflows run faster and our spot instances are less likely to get reclaimed by AWS. 

In future we should look at automating this setting based on the geospatial type of the dataset and the retiling required.