### PR TITLE
fix: do not create capture area for coastal merged datasets TDE-1931

### DIFF
--- a/events/sensors/sensor-national-merged-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-merged-hillshades-coastal.yml
@@ -60,7 +60,7 @@ spec:
                     - name: publish_to_odr
                       value: 'true'
                     - name: create_capture_area
-                      value: 'true'
+                      value: 'false'
                     - name: gsd
                       value: '1'
                     - name: scale_to_resolution


### PR DESCRIPTION
### Motivation & Modifications

The coastal merged hillshades should use the capture area from the 1m hillshades and not generate a new (large and complex) capture area. This was regressed due to a copy and paste error from the elevation hillshade sensor workflow.
