### PR TITLE
chore: changed time of stac-validate-fast tde-1947

### DIFF
--- a/workflows/cron/cron-stac-validate-fast.yaml
+++ b/workflows/cron/cron-stac-validate-fast.yaml
@@ -7,7 +7,7 @@ metadata:
     linz.govt.nz/category: stac
 spec:
   schedules:
-    - '0 15 * * 1-5' # At 3:00 PM, Monday through Friday
+    - '0 04 * * 1-5' # At 4:00 AM, Monday through Friday
   timezone: 'NZ'
   startingDeadlineSeconds: 3600 # Allow 1 hour delay if the workflow-controller clashes during the starting time.
   concurrencyPolicy: 'Allow'


### PR DESCRIPTION
### Motivation
The https://argo.linzaccess.com/cron-workflows/argo/cron-stac-validate-fast cron workflow often fails as it runs at 3pm and sometimes datasets are in the middle of being published at the time. This particularly affects the DEM/DSM and hillshades, which may fail if they have not all been merged and their derived_from links are not yet updated.


### Modifications
Changed the scheduled time from 15:00 to 04:00.


