### PR TITLE
feat: change and add ancillary aerial photos TDE-1924

### DIFF
--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -60,7 +60,8 @@ spec:
         description: 'Geospatial category of the dataset, e.g. "dem-hillshade"'
         value: 'dem-hillshade-igor'
         enum:
-          - 'aerial-photos'
+          - 'ancillary-aerial-photos'
+          - 'ancillary-near-infrared-aerial-photos'
           - 'near-infrared-aerial-photos'
           - 'urban-aerial-photos'
           - 'rural-aerial-photos'

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -141,7 +141,8 @@ spec:
         description: 'Geospatial category of the dataset'
         value: 'urban-aerial-photos'
         enum:
-          - 'aerial-photos'
+          - 'ancillary-aerial-photos'
+          - 'ancillary-near-infrared-aerial-photos'
           - 'near-infrared-aerial-photos'
           - 'urban-aerial-photos'
           - 'rural-aerial-photos'


### PR DESCRIPTION
### Motivation

Separately categorise opportunity imagery, project imagery and other random imagery
so that it can easily be split out from higher quality imagery.


### Modifications

Changed existing (but underutilised) aerial-photos geospatial category to ancillary-aerial-photos and added ancillary-near-infrared-aerial-photos.

