### PR TITLE
feat: upgrade to EKS v1.34 TDE-1963

### DIFF
--- a/cdk8s.yaml
+++ b/cdk8s.yaml
@@ -1,8 +1,8 @@
 app: npx tsx infra/cdk8s.ts
 language: typescript
 imports:
-  - https://raw.githubusercontent.com/aws/karpenter/main/pkg/apis/crds/karpenter.sh_provisioners.yaml
-  - https://raw.githubusercontent.com/aws/karpenter/main/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+  - https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.6.7/pkg/apis/crds/karpenter.sh_nodepools.yaml
+  - https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.6.7/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
   - https://raw.githubusercontent.com/argoproj/argo-events/refs/tags/v1.9.10/manifests/base/crds/argoproj.io_eventbus.yaml
   - https://raw.githubusercontent.com/argoproj/argo-events/refs/tags/v1.9.10/manifests/base/crds/argoproj.io_eventsources.yaml
   - https://raw.githubusercontent.com/argoproj/argo-events/refs/tags/v1.9.10/manifests/base/crds/argoproj.io_sensors.yaml

--- a/infra/charts/argo.events.ts
+++ b/infra/charts/argo.events.ts
@@ -1,6 +1,6 @@
 import { Chart, ChartProps, Helm } from 'cdk8s';
-import { Namespace, ServiceAccount } from 'cdk8s-plus-33';
-import { KubeClusterRole, KubeClusterRoleBinding } from 'cdk8s-plus-33/lib/imports/k8s.js';
+import { Namespace, ServiceAccount } from 'cdk8s-plus-34';
+import { KubeClusterRole, KubeClusterRoleBinding } from 'cdk8s-plus-34/lib/imports/k8s.js';
 import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.js';

--- a/infra/charts/argo.extras.ts
+++ b/infra/charts/argo.extras.ts
@@ -1,5 +1,5 @@
 import { Chart, ChartProps } from 'cdk8s';
-import * as kplus from 'cdk8s-plus-33';
+import * as kplus from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { ScratchBucketName } from '../constants.ts';

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -1,5 +1,5 @@
 import { Chart, ChartProps, Duration, Helm } from 'cdk8s';
-import { Secret } from 'cdk8s-plus-33';
+import { Secret } from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { ArgoDbName, ArgoDbUser, DefaultRegion } from '../constants.ts';

--- a/infra/charts/cloudflared.ts
+++ b/infra/charts/cloudflared.ts
@@ -1,5 +1,5 @@
 import { ApiObject, Chart, ChartProps, JsonPatch, Size } from 'cdk8s';
-import * as kplus from 'cdk8s-plus-33';
+import * as kplus from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.ts';

--- a/infra/charts/elastic.agent.ts
+++ b/infra/charts/elastic.agent.ts
@@ -1,5 +1,5 @@
 import { Chart, ChartProps } from 'cdk8s';
-import { Namespace } from 'cdk8s-plus-33';
+import { Namespace } from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.ts';

--- a/infra/charts/event.exporter.ts
+++ b/infra/charts/event.exporter.ts
@@ -1,5 +1,5 @@
 import { Chart, ChartProps } from 'cdk8s';
-import { ConfigMap, k8s, Namespace } from 'cdk8s-plus-33';
+import { ConfigMap, k8s, Namespace } from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { ClusterName } from '../constants.ts';

--- a/infra/charts/karpenter.ts
+++ b/infra/charts/karpenter.ts
@@ -54,7 +54,7 @@ export interface KarpenterProps {
  *
  * https://github.com/aws/karpenter/blob/7c989a2bfae43d4e73235aca0af50b8008c67b68/charts/karpenter/Chart.yaml#L5C10-L5C16
  */
-const version = '1.5.0';
+const version = '1.6.7';
 
 export class Karpenter extends Chart {
   constructor(scope: Construct, id: string, props: KarpenterProps & ChartProps) {

--- a/infra/charts/kube-system.coredns.ts
+++ b/infra/charts/kube-system.coredns.ts
@@ -1,5 +1,5 @@
 import { Chart, ChartProps } from 'cdk8s';
-import * as kplus from 'cdk8s-plus-33';
+import * as kplus from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.ts';

--- a/infra/charts/kube-system.node.local.dns.ts
+++ b/infra/charts/kube-system.node.local.dns.ts
@@ -1,5 +1,5 @@
 import { ApiObject, Chart, ChartProps, JsonPatch, Size } from 'cdk8s';
-import * as kplus from 'cdk8s-plus-33';
+import * as kplus from 'cdk8s-plus-34';
 import { Construct } from 'constructs';
 
 import { applyDefaultLabels } from '../util/labels.ts';

--- a/infra/eks/cluster.ts
+++ b/infra/eks/cluster.ts
@@ -1,4 +1,4 @@
-import { KubectlV33Layer } from '@aws-cdk/lambda-layer-kubectl-v33';
+import { KubectlV34Layer } from '@aws-cdk/lambda-layer-kubectl-v34';
 import { Aws, CfnOutput, Fn, Stack, StackProps } from 'aws-cdk-lib';
 import { InstanceType, IVpc, Port, SecurityGroup, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, ClusterLoggingTypes, IpFamily, KubernetesVersion, NodegroupAmiType } from 'aws-cdk-lib/aws-eks';
@@ -32,7 +32,7 @@ export class LinzEksCluster extends Stack {
   /* Cluster ID */
   id: string;
   /** Version of EKS to use, this must be aligned to the `kubectlLayer` */
-  version = KubernetesVersion.V1_33;
+  version = KubernetesVersion.V1_34;
   /** Argo needs a temporary bucket to store objects */
   tempBucket: IBucket;
   /* Bucket where read/write roles config files are stored */
@@ -63,7 +63,7 @@ export class LinzEksCluster extends Stack {
       defaultCapacity: 0,
       vpcSubnets: [{ subnetType: SubnetType.PRIVATE_WITH_EGRESS }],
       /** This must align to Cluster version: {@link version} */
-      kubectlLayer: new KubectlV33Layer(this, 'KubeCtlLayer'),
+      kubectlLayer: new KubectlV34Layer(this, 'KubeCtlLayer'),
       /** To prevent IP exhaustion when running huge workflows run using ipv6 */
       ipFamily: IpFamily.IP_V6,
       clusterLogging: [ClusterLoggingTypes.API, ClusterLoggingTypes.CONTROLLER_MANAGER, ClusterLoggingTypes.SCHEDULER],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
-        "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0",
+        "@aws-cdk/lambda-layer-kubectl-v34": "^2.2.2",
         "@aws-sdk/client-cloudformation": "^3.953.0",
         "@aws-sdk/client-eks": "^3.953.0",
         "@aws-sdk/client-ssm": "^3.953.0",
@@ -20,7 +20,7 @@
         "aws-cdk-lib": "^2.232.2",
         "cdk8s": "^2.70.34",
         "cdk8s-cli": "^2.203.7",
-        "cdk8s-plus-33": "^2.4.11",
+        "cdk8s-plus-34": "^2.0.36",
         "constructs": "^10.3.0",
         "tsx": "^4.6.2",
         "yaml": "^2.5.1"
@@ -90,14 +90,14 @@
         "node": ">=10"
       }
     },
-    "node_modules/@aws-cdk/lambda-layer-kubectl-v33": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v33/-/lambda-layer-kubectl-v33-2.0.0.tgz",
-      "integrity": "sha512-osA3wkwWK2OfpymTcCZKhgaKSca9PQSr+7xi+UevKFRHtMdxHgygC345hdDpCtZlMmX9pKjtFpRUxeRrbGHMEw==",
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v34": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v34/-/lambda-layer-kubectl-v34-2.2.2.tgz",
+      "integrity": "sha512-xfWArNU0MvErnJNKAT3SxDM5W/RqGQydd6cTCR3AEsR46e4zNnPImOIXYNpCGQEUEV1kNW7LBQIv2OXTEiKd1A==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "aws-cdk-lib": "^2.94.0",
+        "aws-cdk-lib": "^2.224.0",
         "constructs": "^10.0.5"
       }
     },
@@ -2213,7 +2213,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2406,7 +2405,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2678,7 +2676,6 @@
       ],
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -3143,7 +3140,6 @@
       ],
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "fast-json-patch": "^3.1.1",
         "follow-redirects": "^1.15.11",
@@ -3392,17 +3388,17 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/cdk8s-plus-33": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-33/-/cdk8s-plus-33-2.4.11.tgz",
-      "integrity": "sha512-aZ/6wgncI4TBSn+sKNDaWVEt7FXNwboHsTJYSWbg7Bgt5JEXux7y8uTk+6bsLgjqxcneLDYS2DTLSr8rSswshA==",
+    "node_modules/cdk8s-plus-34": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-34/-/cdk8s-plus-34-2.0.36.tgz",
+      "integrity": "sha512-V6IbWhDTbpDSzfImd27nlhv6BHWG+QAsVvk8qgVy/F7kiyI0K0z/RHlIw/znPlw44rjLW9rij9aTg1CPSN4rVA==",
       "bundleDependencies": [
         "minimatch"
       ],
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^9.0.5"
+        "minimatch": "^9.0.9"
       },
       "engines": {
         "node": ">= 16.20.0"
@@ -3412,14 +3408,14 @@
         "constructs": "^10.3.0"
       }
     },
-    "node_modules/cdk8s-plus-33/node_modules/balanced-match": {
+    "node_modules/cdk8s-plus-34/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/cdk8s-plus-33/node_modules/brace-expansion": {
-      "version": "2.0.2",
+    "node_modules/cdk8s-plus-34/node_modules/brace-expansion": {
+      "version": "2.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3427,13 +3423,13 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/cdk8s-plus-33/node_modules/minimatch": {
-      "version": "9.0.5",
+    "node_modules/cdk8s-plus-34/node_modules/minimatch": {
+      "version": "9.0.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3651,8 +3647,7 @@
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.4.tgz",
       "integrity": "sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4100,7 +4095,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4156,7 +4150,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5473,7 +5466,6 @@
       "integrity": "sha512-BMsFDilBLpSzIEdK38kYY4x0w4U5qZeLqOTiZUiyOwe9GsHZSfLCHWJ7TvTAAeBF36nnOzxSySL6+/Hp0N7pTQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jsii/check-node": "^1.121.0",
         "@jsii/spec": "^1.121.0",
@@ -6050,7 +6042,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6906,7 +6897,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node --test \"infra/**/*.test.ts\" \"templates/common/__test__/*.test.ts\""
   },
   "devDependencies": {
-    "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0",
+    "@aws-cdk/lambda-layer-kubectl-v34": "^2.2.2",
     "@aws-sdk/client-cloudformation": "^3.953.0",
     "@aws-sdk/client-eks": "^3.953.0",
     "@aws-sdk/client-ssm": "^3.953.0",
@@ -34,7 +34,7 @@
     "aws-cdk-lib": "^2.232.2",
     "cdk8s": "^2.70.34",
     "cdk8s-cli": "^2.203.7",
-    "cdk8s-plus-33": "^2.4.11",
+    "cdk8s-plus-34": "^2.0.36",
     "constructs": "^10.3.0",
     "tsx": "^4.6.2",
     "yaml": "^2.5.1"


### PR DESCRIPTION
### Motivation

In order to stay on a supported EKS version, we need to upgrade EKS to v1.34.

### Modifications

Update the following to 34 / v1.34:
`cdk8s+`
`@aws-cdk/lambda-layer-kubectl`
`KubernetesVersion`

Also update `karpenter` to 1.6.7, as EKS v1.34 requires karpenter >=1.6.

Deployment is through GitHub Actions CI.

### Verification

Applied to Dev and Nonprod environments, checked logs and ran workflows to spin up spot and on-demand instances.