### PR TITLE
feat: target epsg for tileindex-validate TDE-1990

### DIFF
--- a/templates/argo-tasks/tile-index-validate.yml
+++ b/templates/argo-tasks/tile-index-validate.yml
@@ -24,6 +24,10 @@ spec:
             description: Force source EPSG, "" will attempt to load EPSG from the source tiffs
             default: ''
 
+          - name: target_epsg
+            description: Force target EPSG, "" will default to source EPSG
+            default: ''
+
           - name: source
             description: Location to list
             default: ''
@@ -84,6 +88,7 @@ spec:
           - '--scale={{= inputs.parameters.scale }}'
           - '--preset={{= inputs.parameters.preset }}'
           - "{{= sprig.empty(inputs.parameters.source_epsg) ? '' : '--source-epsg=' + inputs.parameters.source_epsg }}"
+          - "{{= sprig.empty(inputs.parameters.target_epsg) ? '' : '--target-epsg=' + inputs.parameters.target_epsg }}"
           - "{{= sprig.empty(inputs.parameters.include) ? '' : '--include=' + inputs.parameters.include }}"
           - '--includeDerived={{= inputs.parameters.includeDerived }}'
           - '{{= sprig.trim(inputs.parameters.source) }}'

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -572,7 +572,7 @@ spec:
             depends: 'standardise-validate'
 
           - name: create-config
-            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857'"
+            when: "'{{workflow.parameters.target_epsg}}' =~ '2193|3857|3793'"
             arguments:
               parameters:
                 - name: location

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -376,6 +376,8 @@ spec:
                   value: '{{=sprig.trim(inputs.parameters.source)}}'
                 - name: source_epsg
                   value: '{{=sprig.trim(workflow.parameters.source_epsg)}}'
+                - name: target_epsg
+                  value: '{{=sprig.trim(workflow.parameters.target_epsg)}}'
                 - name: preset
                   value: '{{= workflow.parameters.compression}}'
                 - name: version


### PR DESCRIPTION
### Motivation & Modifications

Pass `target_epsg` to `tileindex-validate` to allow overriding the default 2193 NZTM2000 e.g. for processing Chatham Islands datasets.

### Verification

Workflow run.
