### PR TITLE
feat(topographic-system): Add new sea-polygon workflow for data preparation. BM-1812

### DIFF
--- a/workflows/topographic-system/coastline-polygon.yaml
+++ b/workflows/topographic-system/coastline-polygon.yaml
@@ -110,6 +110,7 @@ spec:
             memory: 7.8Gi
             cpu: 4000m
         args:
+          - 'data-prep'
           - 'coastline-polygon'
           - '--coastline={{ inputs.parameters.coastline }}'
           - '--island={{ inputs.parameters.island }}'

--- a/workflows/topographic-system/rock-line.yaml
+++ b/workflows/topographic-system/rock-line.yaml
@@ -124,6 +124,7 @@ spec:
             memory: 7.8Gi
             cpu: 4000m
         args:
+          - 'data-prep'
           - 'rock-line'
           - '--marine={{ inputs.parameters.marine }}'
           - '--coastline={{ inputs.parameters.coastline }}'

--- a/workflows/topographic-system/sea-polygon.yaml
+++ b/workflows/topographic-system/sea-polygon.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: topographic-ice-contour
+  name: topographic-sea-polygon
   labels:
     linz.govt.nz/category: topo-maps
     linz.govt.nz/data-type: vector
@@ -20,13 +20,9 @@ spec:
         description: Version of the kart CLI docker container to use
         value: 'latest'
 
-      - name: contour
-        description: S3 path of source parquet contour data stac collection.
-        value: 's3://linz-topography-nonprod/data/contour/latest/collection.json'
-
-      - name: landcover
-        description: S3 path of source parquet landcover data stac collection.
-        value: 's3://linz-topography-nonprod/data/landcover/latest/collection.json'
+      - name: coastline
+        description: S3 path of source parquet coastline data stac collection.
+        value: 's3://linz-topography-nonprod/data/nztopo50_coastline_island/latest/collection.json'
 
       - name: target
         description: Path or s3 of the target directory to write to.
@@ -61,23 +57,21 @@ spec:
               name: tpl-get-location
               template: main
 
-          - name: ice-contour
-            template: ice-contour
+          - name: sea-polygon
+            template: sea-polygon
             depends: get-location
             arguments:
               parameters:
                 - name: version_kart_cli
                   value: '{{ workflow.parameters.version_kart_cli }}'
-                - name: contour
-                  value: '{{ workflow.parameters.contour }}'
-                - name: landcover
-                  value: '{{ workflow.parameters.landcover }}'
+                - name: coastline
+                  value: '{{ workflow.parameters.coastline }}'
                 - name: output
                   value: '{{ tasks.get-location.outputs.parameters.location }}'
 
           - name: stac-push
             template: stac-push
-            depends: ice-contour
+            depends: sea-polygon
             arguments:
               parameters:
                 - name: version_kart_cli
@@ -91,12 +85,11 @@ spec:
                 - name: commit
                   value: '{{ workflow.parameters.commit }}'
 
-    - name: ice-contour
+    - name: sea-polygon
       inputs:
         parameters:
           - name: version_kart_cli
-          - name: contour
-          - name: landcover
+          - name: coastline
           - name: output
       container:
         image: ghcr.io/linz/topographic-system/kart:{{ inputs.parameters.version_kart_cli }}
@@ -107,13 +100,12 @@ spec:
             value: nonprod
         resources:
           requests:
-            memory: 12Gi
-            cpu: 8000m
+            memory: 7.8Gi
+            cpu: 4000m
         args:
           - 'data-prep'
-          - 'ice-contour'
-          - '--contour={{ inputs.parameters.contour }}'
-          - '--landcover={{ inputs.parameters.landcover }}'
+          - 'sea-polygon'
+          - '--coastline={{ inputs.parameters.coastline }}'
           - '--output={{ inputs.parameters.output }}'
 
     - name: stac-push


### PR DESCRIPTION
### Motivation

Add the new sea-polygon data prepare workflow and update all the data-prep subcommands.
This is ready after merging https://github.com/linz/topographic-system/pull/334

### Modifications

new sea-polygon workflow

### Verification

https://argo.linzaccess.com/workflows/argo/test-topographic-sea-polygon-pr-334-4kz7v?tab=workflow&uid=8886f69e-450c-400d-abc0-d95c8f220510
