### PR TITLE
fix: standardising STAC validation step always triggered publish-odr TDE-2011

### DIFF
--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -601,7 +601,7 @@ spec:
                   value: '{{=sprig.trim(workflow.parameters.ticket)}}'
                 - name: odr_url
                   value: '{{=sprig.trim(workflow.parameters.odr_url)}}'
-            depends: '(stac-validate-all || stac-validate-only-updated) && create-config'
+            depends: '(stac-validate-all.Succeeded || stac-validate-only-updated.Succeeded) && create-config'
 
       outputs:
         parameters:


### PR DESCRIPTION
### Motivation & Modifications

The `publish-odr` step in the standardising workflow depended on the `stac-validate-all` or `stac-validate-only-updated` steps without specifying a status. This therefore defaulted to `.Succeeded` or `.Skipped` and since one of those tasks is always skipped, the condition is always met.

Modification is to specify `.Succeeded` in the depends condition.

