### PR TITLE
fix: retry on pod termination failure TDE-2017

### DIFF
--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -172,7 +172,12 @@ export class ArgoWorkflows extends Chart {
                 /** TODO: `nodeAntiAffinity` - to retry on different node - is not working yet (https://github.com/argoproj/argo-workflows/pull/12701)
                  * `affinity: { nodeAntiAffinity: {} }` seems to break `karpenter`, need more investigation
                  */
-                retryStrategy: { limit: 2, retryPolicy: 'OnError' },
+                retryStrategy: {
+                  limit: 2,
+                  retryPolicy: 'Always',
+                  expression:
+                    'lastRetry.status == "Error" || lastRetry.message matches "imminent node shutdown"',
+                },              
               },
             },
           },

--- a/infra/charts/argo.workflows.ts
+++ b/infra/charts/argo.workflows.ts
@@ -175,9 +175,8 @@ export class ArgoWorkflows extends Chart {
                 retryStrategy: {
                   limit: 2,
                   retryPolicy: 'Always',
-                  expression:
-                    'lastRetry.status == "Error" || lastRetry.message matches "imminent node shutdown"',
-                },              
+                  expression: 'lastRetry.status == "Error" || lastRetry.message matches "imminent node shutdown"',
+                },
               },
             },
           },


### PR DESCRIPTION
### Motivation

A change of behaviour (cause unknown but probably Karpenter or EKS upgrade) means that when a Spot Instance is interrupted, i.e. reclaimed by AWS, the pods are now aware of the grace period. Previously a pod would retry on on Error (the phase message was "pod deleted"). The new behaviour is to fail with Failure and a phase message of "Pod was terminated in response to imminent node shutdown."

### Modifications

Change the default `retryStrategy` to handle the new behaviour by matching the failure message string. We cannot just use `onFailure` as that will also match intentional application failures.

### Verification

Applied to NonProd environment and tested using AWS Fault Injection Service to simulate a Spot Instance interruption.