### PR TITLE
feat: switch to using GitHub App for PR creation TDE-2022

### DIFF
--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -36,9 +36,6 @@ async function main(): Promise<void> {
       cloudflaredTunnelName: '/eks/cloudflared/argo/tunnelName',
       cloudflaredAccountId: '/eks/cloudflared/argo/accountId',
 
-      // Personal access token to gain access to linz-li-bot github user
-      githubPat: '/eks/github/linz-li-bot/pat',
-
       // Config for the GitHub App used to raise pull requests
       githubAppId: '/eks/github/argo-tasks/appId',
       githubAppPrivateKey: '/eks/github/argo-tasks/privateKey',
@@ -116,8 +113,6 @@ async function main(): Promise<void> {
   new ArgoExtras(app, 'argo-extras', {
     namespace: 'argo',
     secrets: [
-      /** Argo workflows interacts with github give it access to github bot user */
-      { name: 'github-linz-li-bot-pat', data: { pat: ssmConfig.githubPat } },
       /** Argo workflows interacts with github give it access to github app */
       {
         name: 'github-argo-tasks-app',

--- a/infra/cdk8s.ts
+++ b/infra/cdk8s.ts
@@ -39,6 +39,11 @@ async function main(): Promise<void> {
       // Personal access token to gain access to linz-li-bot github user
       githubPat: '/eks/github/linz-li-bot/pat',
 
+      // Config for the GitHub App used to raise pull requests
+      githubAppId: '/eks/github/argo-tasks/appId',
+      githubAppPrivateKey: '/eks/github/argo-tasks/privateKey',
+      githubAppInstallationId: '/eks/github/argo-tasks/installationId',
+
       // Argo Database connection password
       argoDbPassword: '/eks/argo/postgres/password',
 
@@ -113,6 +118,15 @@ async function main(): Promise<void> {
     secrets: [
       /** Argo workflows interacts with github give it access to github bot user */
       { name: 'github-linz-li-bot-pat', data: { pat: ssmConfig.githubPat } },
+      /** Argo workflows interacts with github give it access to github app */
+      {
+        name: 'github-argo-tasks-app',
+        data: {
+          GITHUB_APP_ID: ssmConfig.githubAppId,
+          GITHUB_APP_PRIVATE_KEY: ssmConfig.githubAppPrivateKey,
+          GITHUB_APP_INSTALLATION_ID: ssmConfig.githubAppInstallationId,
+        },
+      },
       {
         name: 's3-batch-restore-secrets',
         data: {

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -40,8 +40,13 @@ export const CfnOutputKeys = {
 
 /** The list of possible keys */
 export type ICfnOutputKeys = keyof typeof CfnOutputKeys;
-/** A map containing a key value pair for every possible CfnOutputKey */
-export type CfnOutputMap = Record<ICfnOutputKeys, string>;
+/**
+ * A map containing a key value pair for every possible CfnOutputKey
+ *
+ * Keyed by the CloudFormation output names — the *values* of {@link CfnOutputKeys}, which carry
+ * the environment suffix — not by the property names used to look them up.
+ */
+export type CfnOutputMap = Record<(typeof CfnOutputKeys)[ICfnOutputKeys], string>;
 
 /**
  *  Assert that all the keys in this Record contains all the expected CfnOutputKeys

--- a/templates/argo-tasks/copy.yml
+++ b/templates/argo-tasks/copy.yml
@@ -21,7 +21,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
 
           - name: copy_option
             description: --no-clobber Skip overwriting existing files. --force Overwrite all files. --force-no-clobber Overwrite only changed files, skip unchanged files.

--- a/templates/argo-tasks/create-manifest.yml
+++ b/templates/argo-tasks/create-manifest.yml
@@ -27,7 +27,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
 
           - name: include
             description: A regular expression to match object path(s) or name(s) from within the source path to include in the copy

--- a/templates/argo-tasks/list.yaml
+++ b/templates/argo-tasks/list.yaml
@@ -17,7 +17,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
 
           - name: include
             description: A regular expression to match object path(s) or name(s) to include in the list

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -39,11 +39,21 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.json
-          - name: GITHUB_API_TOKEN
+          - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:
-                name: github-linz-li-bot-pat
-                key: pat
+                name: github-argo-tasks-app
+                key: GITHUB_APP_ID
+          - name: GITHUB_APP_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: github-argo-tasks-app
+                key: GITHUB_APP_PRIVATE_KEY
+          - name: GITHUB_APP_INSTALLATION_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-argo-tasks-app
+                key: GITHUB_APP_INSTALLATION_ID
         args:
           [
             'stac',

--- a/templates/argo-tasks/push-to-github.yml
+++ b/templates/argo-tasks/push-to-github.yml
@@ -23,7 +23,7 @@ spec:
 
           - name: version_argo_tasks
             description: version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
 
           - name: repository
             description: Repository Name

--- a/templates/argo-tasks/verify-restore.yaml
+++ b/templates/argo-tasks/verify-restore.yaml
@@ -14,7 +14,7 @@ spec:
         parameters:
           - name: version_argo_tasks
             description: Version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
           - name: restore_manifest
             description: S3 path to the restore manifest file
             default: ''

--- a/templates/basemaps/cogify.yml
+++ b/templates/basemaps/cogify.yml
@@ -19,7 +19,7 @@ spec:
 
       - name: version_argo_tasks
         description: Version of the argo-tasks CLI docker container to use
-        value: v4
+        value: v6
 
       - name: preset
         description: Import preset configuration, WebP for 4 band RGBA, LERC for 1 band DEM/DSM and ZSTD for everything else

--- a/templates/basemaps/create-pull-request.yml
+++ b/templates/basemaps/create-pull-request.yml
@@ -14,7 +14,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: Version of the argo-tasks CLI docker container to use
-        value: v4
+        value: v6
 
   templates:
     # Main entrypoint into the workflow

--- a/templates/basemaps/create-pull-request.yml
+++ b/templates/basemaps/create-pull-request.yml
@@ -54,11 +54,21 @@ spec:
         env:
           - name: AWS_ROLE_CONFIG_PATH
             value: s3://linz-bucket-config/config.basemaps.json
-          - name: GITHUB_API_TOKEN
+          - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:
-                name: github-linz-li-bot-pat
-                key: pat
+                name: github-argo-tasks-app
+                key: GITHUB_APP_ID
+          - name: GITHUB_APP_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: github-argo-tasks-app
+                key: GITHUB_APP_PRIVATE_KEY
+          - name: GITHUB_APP_INSTALLATION_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-argo-tasks-app
+                key: GITHUB_APP_INSTALLATION_ID
         args:
           - 'bmc'
           - 'create-pr'

--- a/templates/common/get.location.yml
+++ b/templates/common/get.location.yml
@@ -17,7 +17,7 @@ spec:
         parameters:
           - name: version_argo_tasks
             description: Version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
           - name: artifact_key
             description: Key of the artifact in S3. Must match the `keyFormat` (without pod name) used in Argo Workflows artifact repository configuration.
             default: '{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}-{{workflow.name}}'

--- a/templates/common/log.notification.yml
+++ b/templates/common/log.notification.yml
@@ -24,7 +24,7 @@ spec:
             description: Parameters of the workflow or custom parameters
           - name: version_argo_tasks
             description: Version of argo-tasks to use
-            default: 'v5'
+            default: 'v6'
       script:
         image: '019359803926.dkr.ecr.ap-southeast-2.amazonaws.com/argo-tasks:{{=sprig.trim(inputs.parameters.version_argo_tasks)}}'
         command: [node]

--- a/workflows/basemaps/charts-import-cogify.yml
+++ b/workflows/basemaps/charts-import-cogify.yml
@@ -40,7 +40,7 @@ spec:
 
       - name: version_argo_tasks
         description: Version of the argo-tasks CLI docker container to use
-        value: v4
+        value: v6
 
       - name: user_group
         description: Group of users running the workflow

--- a/workflows/basemaps/imagery-import-cogify.yml
+++ b/workflows/basemaps/imagery-import-cogify.yml
@@ -43,7 +43,7 @@ spec:
 
       - name: version_argo_tasks
         description: Version of the argo-tasks CLI docker container to use
-        value: v4
+        value: v6
 
       - name: user_group
         description: Group of users running the workflow

--- a/workflows/basemaps/mapsheet-json.yaml
+++ b/workflows/basemaps/mapsheet-json.yaml
@@ -18,7 +18,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v5'
+        value: 'v6'
       - name: layer
         value: '104687'
       - name: config

--- a/workflows/basemaps/topo-maps-standardising.yml
+++ b/workflows/basemaps/topo-maps-standardising.yml
@@ -27,7 +27,7 @@ spec:
 
       - name: version_argo_tasks
         description: Version of the argo tasks CLI docker container to use
-        value: v4
+        value: v6
 
       - name: source
         description: s3 directory of the NZ Topo Raster Map Series imagery to process

--- a/workflows/basemaps/vector-etl-shortbread.yaml
+++ b/workflows/basemaps/vector-etl-shortbread.yaml
@@ -23,7 +23,7 @@ spec:
 
       - name: version_argo_tasks
         description: Version of the Argo Tasks CLI docker container to use
-        value: 'v5'
+        value: 'v6'
 
       - name: target
         description: S3 Bucket to use for storing the output

--- a/workflows/basemaps/vector-etl.yaml
+++ b/workflows/basemaps/vector-etl.yaml
@@ -18,7 +18,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: Version of the Argo Tasks CLI docker container to use
-        value: 'v5'
+        value: 'v6'
 
       - name: version_basemaps_etl
         description: Version of the Basemaps ETL eks container to use

--- a/workflows/cron/cron-copy-restore.yaml
+++ b/workflows/cron/cron-copy-restore.yaml
@@ -23,7 +23,7 @@ spec:
     arguments:
       parameters:
         - name: version_argo_tasks
-          value: 'v5'
+          value: 'v6'
         - name: reports_location
           value: 's3://linz-workflows-scratch/restore/requests/'
     templates:

--- a/workflows/cron/cron-stac-validate-full.yaml
+++ b/workflows/cron/cron-stac-validate-full.yaml
@@ -23,7 +23,7 @@ spec:
     arguments:
       parameters:
         - name: version_argo_tasks
-          value: 'v5'
+          value: 'v6'
         - name: 'include'
           value: 'collection.json$'
         - name: checksum_assets

--- a/workflows/pointcloud/fix_laz_header.yaml
+++ b/workflows/pointcloud/fix_laz_header.yaml
@@ -32,7 +32,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_topo_imagery
         description: 'Specify a version of the topo-imagery image to use, e.g. "v4.8" or "latest". Note: This image needs to contain PDAL.'
         value: 'v7'

--- a/workflows/raster/hillshade-combinations.yaml
+++ b/workflows/raster/hillshade-combinations.yaml
@@ -28,7 +28,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_basemaps_cli
         description: 'Specify a version of the basemaps-cli image to use, e.g. "v8" or "latest"'
         value: 'v8'

--- a/workflows/raster/hillshade.yaml
+++ b/workflows/raster/hillshade.yaml
@@ -28,7 +28,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_basemaps_cli
         description: 'Specify a version of the basemaps-cli image to use, e.g. "v8" or "latest"'
         value: 'v8'

--- a/workflows/raster/merge-layers.yaml
+++ b/workflows/raster/merge-layers.yaml
@@ -28,7 +28,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_basemaps_cli
         description: 'Specify a version of the basemaps-cli image to use, e.g. "v8" or "latest"'
         value: 'v8'

--- a/workflows/raster/national-elevation.yaml
+++ b/workflows/raster/national-elevation.yaml
@@ -28,7 +28,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_basemaps_cli
         description: 'Specify a version of the basemaps-cli image to use, e.g. "v8" or "latest"'
         value: 'v8'

--- a/workflows/raster/publish-odr.yaml
+++ b/workflows/raster/publish-odr.yaml
@@ -34,7 +34,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: ticket
         description: 'Ticket ID, e.g. "LI-1570"'
         value: ''

--- a/workflows/raster/standardising.yaml
+++ b/workflows/raster/standardising.yaml
@@ -37,7 +37,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_basemaps_cli
         description: 'Specify a version of the basemaps-cli image to use, e.g. "v8" or "latest"'
         value: 'v8'

--- a/workflows/stac/stac-validate-parallel.yaml
+++ b/workflows/stac/stac-validate-parallel.yaml
@@ -17,7 +17,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v5'
+        value: 'v6'
       - name: uri
         description: 'Path(s) to the STAC file(s).'
         value: 's3://linz-imagery-staging/test/stac-validate/'

--- a/workflows/storage/archive.yaml
+++ b/workflows/storage/archive.yaml
@@ -24,7 +24,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v5'
+        value: 'v6'
       - name: user_group
         description: Group of users running the workflow
         value: 'none'
@@ -71,7 +71,7 @@ spec:
             default: '100Gi'
           - name: version_argo_tasks
             value: '{{workflow.parameters.version_argo_tasks}}'
-            default: 'v5'
+            default: 'v6'
       dag:
         tasks:
           - name: archive-setup

--- a/workflows/storage/check-restore-copy.yaml
+++ b/workflows/storage/check-restore-copy.yaml
@@ -17,7 +17,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: reports_location
         description: 'Location of the archive restore report manifest files'
         value: 's3://linz-workflows-scratch/restore/requests/'
@@ -30,7 +30,7 @@ spec:
         parameters:
           - name: version_argo_tasks
             value: '{{workflow.parameters.version_argo_tasks}}'
-            default: 'v5'
+            default: 'v6'
           - name: reports_location
             value: '{{workflow.parameters.reports_location}}'
             default: 's3://linz-workflows-scratch/restore/requests/'

--- a/workflows/storage/copy.yaml
+++ b/workflows/storage/copy.yaml
@@ -32,7 +32,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: user_group
         description: Group of users running the workflow
         value: 'none'
@@ -143,7 +143,7 @@ spec:
             default: '100Gi'
           - name: version_argo_tasks
             value: '{{workflow.parameters.version_argo_tasks}}'
-            default: 'v5'
+            default: 'v6'
           - name: compress # This should not be exposed to the user (as a workflow parameter)
             default: 'false'
           - name: decompress # This should not be exposed to the user (as a workflow parameter)

--- a/workflows/storage/temp-archive-custom-target.yaml
+++ b/workflows/storage/temp-archive-custom-target.yaml
@@ -25,7 +25,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: user_group
         description: Group of users running the workflow
         value: 'none'
@@ -77,7 +77,7 @@ spec:
             default: '100Gi'
           - name: version_argo_tasks
             value: '{{workflow.parameters.version_argo_tasks}}'
-            default: 'v5'
+            default: 'v6'
           - name: check_source_path
             value: '{{workflow.parameters.check_source_path}}'
             default: 'true'

--- a/workflows/storage/unarchive.yaml
+++ b/workflows/storage/unarchive.yaml
@@ -23,7 +23,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: user_group
         description: Group of users running the workflow
         value: 'none'

--- a/workflows/test/generate-path.yaml
+++ b/workflows/test/generate-path.yaml
@@ -16,7 +16,7 @@ spec:
   arguments:
     parameters:
       - name: version_argo_tasks
-        value: 'v5'
+        value: 'v6'
       - name: source
         value: 's3://linz-imagery-staging/test/sample/'
       - name: target_bucket_name

--- a/workflows/topographic-system/map-produce.yaml
+++ b/workflows/topographic-system/map-produce.yaml
@@ -22,7 +22,7 @@ spec:
 
       - name: version_argo_tasks
         description: Version of the Argo Tasks CLI docker container to use
-        value: 'v5'
+        value: 'v6'
 
       - name: project
         description: Path or s3 of QGIS Project to use for generate map sheets.

--- a/workflows/util/create-thumbnails.yaml
+++ b/workflows/util/create-thumbnails.yaml
@@ -17,7 +17,7 @@ spec:
     parameters:
       - name: version_argo_tasks
         description: 'Specify a version of the argo-tasks image to use, e.g. "v5.1" or "latest"'
-        value: 'v5'
+        value: 'v6'
       - name: version_topo_imagery
         description: 'Specify a version of the topo-imagery image to use, e.g. "v7.0" or "latest"'
         value: 'v7'


### PR DESCRIPTION
:mega: This PR must be merged **after** https://github.com/linz/argo-tasks/pull/1347 has been merged and released as Argo Tasks `v6` :mega:

### Motivation

To meet security requirements we need to retire our use of a classic PAT and use a GitHub App.

### Modifications

- Creation of the new EKS secrets for the GitHub App (from AWS Parameter Store).
- Removal of the retired `linz-li-bot` PAT.
- Add the new secrets to the `push-to-github` and `create-pull-request` WorkflowTemplates, removing the reference to the old secret.
- Bumped Argo Tasks container version to `v6`.
- Fixed a bug related to NonProd naming suffix.

### Verification

Applied to NonProd environment.
Tested Argo Tasks using local code to raise a GitHub PR https://github.com/linz/test-elevation/pull/64