### PR TITLE
fix(topographic-system): Fix the stac push date strategy with the correct arugument

### DIFF
--- a/workflows/topographic-system/coastline-polygon.yaml
+++ b/workflows/topographic-system/coastline-polygon.yaml
@@ -139,7 +139,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
+          - '--strategy=date={{= sprig.dateInZone("2006-01-02T15:04:05.000Z", sprig.now(), "UTC") }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/coastline-polygon.yaml
+++ b/workflows/topographic-system/coastline-polygon.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: topographic-coastline-polygon
+  name: test-topographic-coastline-polygon
   labels:
     linz.govt.nz/category: topo-maps
     linz.govt.nz/data-type: vector
@@ -139,7 +139,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - --strategy=date
+          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/coastline-polygon.yaml
+++ b/workflows/topographic-system/coastline-polygon.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: test-topographic-coastline-polygon
+  name: topographic-coastline-polygon
   labels:
     linz.govt.nz/category: topo-maps
     linz.govt.nz/data-type: vector

--- a/workflows/topographic-system/ice-contour.yaml
+++ b/workflows/topographic-system/ice-contour.yaml
@@ -139,7 +139,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
+          - '--strategy=date={{= sprig.dateInZone("2006-01-02T15:04:05.000Z", sprig.now(), "UTC") }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/ice-contour.yaml
+++ b/workflows/topographic-system/ice-contour.yaml
@@ -139,7 +139,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - --strategy=date
+          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/map-produce.yaml
+++ b/workflows/topographic-system/map-produce.yaml
@@ -295,7 +295,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=product
-          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
+          - '--strategy=date={{= sprig.dateInZone("2006-01-02T15:04:05.000Z", sprig.now(), "UTC") }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/map-produce.yaml
+++ b/workflows/topographic-system/map-produce.yaml
@@ -295,7 +295,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=product
-          - --strategy=date
+          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/rock-line.yaml
+++ b/workflows/topographic-system/rock-line.yaml
@@ -155,7 +155,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - --strategy=date
+          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/rock-line.yaml
+++ b/workflows/topographic-system/rock-line.yaml
@@ -155,7 +155,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
+          - '--strategy=date={{= sprig.dateInZone("2006-01-02T15:04:05.000Z", sprig.now(), "UTC") }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/sea-polygon.yaml
+++ b/workflows/topographic-system/sea-polygon.yaml
@@ -131,7 +131,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
+          - '--strategy=date={{= sprig.dateInZone("2006-01-02T15:04:05.000Z", sprig.now(), "UTC") }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 

--- a/workflows/topographic-system/sea-polygon.yaml
+++ b/workflows/topographic-system/sea-polygon.yaml
@@ -131,7 +131,7 @@ spec:
           - --source={{= sprig.trimSuffix("/", inputs.parameters.source) }}/catalog.json
           - --target={{ inputs.parameters.target }}
           - --category=data
-          - --strategy=date
+          - '--strategy=date={{= sprig.date("2006-01-02T15:04:05.000Z", sprig.now()) }}'
           - '{{= inputs.parameters.latest == "true" ? "--strategy=latest" : "" }}'
           - --commit={{ inputs.parameters.commit }}
 


### PR DESCRIPTION
### Motivation

Some recent changes update the strategy parser for the date arguments need to include the ios string, for example `date=2006-01-02T15:04:05.000Z`

### Modifications

Format all the date parameter to include date now in UTC

### Verification

[Tested in argo](https://argo.linzaccess.com/workflows/argo/test-topographic-coastline-polygon-xdlj6?tab=workflow&nodeId=test-topographic-coastline-polygon-xdlj6-2415192934&nodePanelView=containers&sidePanel=logs:test-topographic-coastline-polygon-xdlj6-2415192934:&uid=3a30ffc1-0b67-4e5d-8d4a-7e7a93a98331)
