### PR TITLE
chore: update Argo Events sensor argo-tasks version to v6 TDE-2022

### DIFF
--- a/events/sensors/sensor-national-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-hillshades-coastal.yml
@@ -42,7 +42,7 @@ spec:
                     - name: source_geospatial_categories
                       value: ''
                     - name: version_argo_tasks
-                      value: 'v5'
+                      value: 'v6'
                     - name: version_basemaps_cli
                       value: 'v8'
                     - name: version_topo_imagery

--- a/events/sensors/sensor-national-hillshades.yml
+++ b/events/sensors/sensor-national-hillshades.yml
@@ -42,7 +42,7 @@ spec:
                     - name: source_geospatial_categories
                       value: ''
                     - name: version_argo_tasks
-                      value: 'v5'
+                      value: 'v6'
                     - name: version_basemaps_cli
                       value: 'v8'
                     - name: version_topo_imagery

--- a/events/sensors/sensor-national-merged-hillshades-coastal.yml
+++ b/events/sensors/sensor-national-merged-hillshades-coastal.yml
@@ -48,7 +48,7 @@ spec:
                     - name: odr_url
                       value: 's3://nz-coastal/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
                     - name: version_argo_tasks
-                      value: 'v5'
+                      value: 'v6'
                     - name: version_basemaps_cli
                       value: 'v8'
                     - name: version_topo_imagery

--- a/events/sensors/sensor-national-merged-hillshades.yml
+++ b/events/sensors/sensor-national-merged-hillshades.yml
@@ -48,7 +48,7 @@ spec:
                     - name: odr_url
                       value: 's3://nz-elevation/new-zealand/new-zealand/{{workflow.parameters.geospatial_category}}/2193/'
                     - name: version_argo_tasks
-                      value: 'v5'
+                      value: 'v6'
                     - name: version_basemaps_cli
                       value: 'v8'
                     - name: version_topo_imagery


### PR DESCRIPTION
### Motivation & Modifications

Bump the version of `argo-tasks` used by the Argo Events sensors to `v6` to use the new GitHub App.